### PR TITLE
Enable clean destroy of tchannel

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,9 @@ TChannel.prototype.send = function (options, arg1, arg2, arg3, callback) {
 	}
 
 	var dest = options.host;
+	if (!dest || dest.indexOf(':') === -1) {
+		throw new Error('cannot send() without options.host');
+	}
 
 	var peer = this.getPeer(dest);
 	if (!peer) {


### PR DESCRIPTION
- this removes a tcp leak if we open concurrent
  tcp sockets
- Also adds more debug logging around destroy()

I verified the memory leak is gone by running

`while true; do node test/index.js; done` in
    ringpop. The tests no longer hang.

reviewers: @mranney @jwolski

cc @sh1mmer
