### PR TITLE
Clarify frame arguments in protocol.md

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -41,11 +41,11 @@ All 4-byte integers are unsigned and in big-endian.
  - The next 4 bytes is the length of argument 3
  - The next 4 bytes is the checksum of the first 3 args
  - The next N bytes is arg 1, N is based on the length of arg 1 and must be
-   greater than 0 for request frames
+   greater than 0 for messages of type `req_complete_message`
  - The next M bytes is arg 2, M is based on the length of arg 2 and can be 0
-   bytes on all frames
+   on all frames
  - The next P bytes is arg 3, P is based on the length of arg 3 and can be 0
-   bytes on all frames
+   on all frames
 
 The checksum is computed as follows using [FarmHash](https://code.google.com/p/farmhash/source/browse/trunk/src/farmhash.h#86)
 


### PR DESCRIPTION
My editor also cleaned up some trailing whitespace -- not sure if that's kosher.

@Raynos @mranney 
