### PR TITLE
Add missing run-parallel package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "pre-commit": "0.0.9",
     "tape": "^3.0.3",
     "time-mock": "^0.1.2",
-    "uber-licence": "^1.1.0"
+    "uber-licence": "^1.1.0",
+    "run-parallel": "^1.0.0"
   },
   "pre-commit": [
     "test",


### PR DESCRIPTION
What:
Adds run-parallel to package.json.

Why:
Package is missing and is needed by test/send.js