### PR TITLE
Decoupled tchannel config and creation and added unit tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function TChannel(options) {
 	this.serverSocket = new net.createServer();
 
 	if (this.listening) {
-		this.createTchannel();
+		this.listen();
 	}
 
 	this.serverSocket.on('listening', function () {
@@ -97,7 +97,7 @@ require('util').inherits(TChannel, require('events').EventEmitter);
 // Decoulping config and creation from the constructor.
 // This also allows us to better unit test the code as the test process
 // is not blocked by the listening connections
-TChannel.prototype.createTchannel = function () {
+TChannel.prototype.listen = function () {
 	if (!this.serverSocket) {
 		throw new Error('Missing server Socket.');
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -25,3 +25,4 @@ require('./timeouts.js');
 require('./send.js');
 require('./register.js');
 require('./identify.js');
+require('./tchannel.js');

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -1,12 +1,12 @@
 var test = require('tape');
 var TChannel = require('../index.js');
 
-var serverOptions = {host: '127.0.0.1', port: 4040, listening: false},
-  clientOptions = {host: '127.0.0.1', port: 4041, listening: false},
-  client1Options = {host: '127.0.0.1', port: 4042, listening: false},
-  serverName = serverOptions.host + ':' + serverOptions.port,
-  clientName = clientOptions.host + ':' + clientOptions.port,
-  client1Name = client1Options.host + ':' + client1Options.port;
+var serverOptions = {host: '127.0.0.1', port: 4040, listening: false};
+var clientOptions = {host: '127.0.0.1', port: 4041, listening: false};
+var client1Options = {host: '127.0.0.1', port: 4042, listening: false};
+var serverName = serverOptions.host + ':' + serverOptions.port;
+var clientName = clientOptions.host + ':' + clientOptions.port;
+var client1Name = client1Options.host + ':' + client1Options.port;
 
 
 test('add peer: refuse to add self', function t(assert) {
@@ -32,8 +32,8 @@ test('add peer: should successfully add peer', function t(assert) {
 
 
 test('add peer: get connection', function t(assert) {
-  var server = new TChannel(serverOptions),
-    connection = server.addPeer(clientName);
+  var server = new TChannel(serverOptions);
+  var connection = server.addPeer(clientName);
 
   assert.ok(connection, 'A connection object should be returned');
   assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
@@ -53,8 +53,8 @@ test('set peer: refuse to set self', function t(assert) {
 
 
 test('set peer: should successfully set peer', function t(assert) {
-  var server = new TChannel(serverOptions),
-    conn = server.makeOutConnection(clientName);
+  var server = new TChannel(serverOptions);
+  var conn = server.makeOutConnection(clientName);
 
   assert.doesNotThrow(function () {
     server.setPeer(clientName, conn);
@@ -65,9 +65,9 @@ test('set peer: should successfully set peer', function t(assert) {
 
 
 test('set peer: get connection', function t(assert) {
-  var server = new TChannel(serverOptions),
-    conn = server.makeOutConnection(clientName),
-    connection = server.setPeer(clientName, conn);
+  var server = new TChannel(serverOptions);
+  var conn = server.makeOutConnection(clientName);
+  var connection = server.setPeer(clientName, conn);
 
   assert.ok(connection, 'A connection object should be returned');
   assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
@@ -165,5 +165,3 @@ test('make socket: should throw for invalid destination', function t(assert) {
 //    'Should reject invalid destination');
 //  assert.end();
 //});
-
-

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -1,0 +1,169 @@
+var test = require('tape');
+var TChannel = require('../index.js');
+
+var serverOptions = {host: '127.0.0.1', port: 4040, listening: false},
+  clientOptions = {host: '127.0.0.1', port: 4041, listening: false},
+  client1Options = {host: '127.0.0.1', port: 4042, listening: false},
+  serverName = serverOptions.host + ':' + serverOptions.port,
+  clientName = clientOptions.host + ':' + clientOptions.port,
+  client1Name = client1Options.host + ':' + client1Options.port;
+
+
+test('add peer: refuse to add self', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  assert.throws(function () {
+    server.addPeer(serverName);
+  }, new Error('refusing to add self peer'),
+    'Should refuse to add self as a peer');
+  assert.end();
+});
+
+
+test('add peer: should successfully add peer', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  assert.doesNotThrow(function () {
+    server.addPeer(clientName);
+  }, new Error('refusing to add self peer'),
+    'Should successfully add peer');
+  assert.end();
+});
+
+
+test('add peer: get connection', function t(assert) {
+  var server = new TChannel(serverOptions),
+    connection = server.addPeer(clientName);
+
+  assert.ok(connection, 'A connection object should be returned');
+  assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+  assert.end();
+});
+
+
+test('set peer: refuse to set self', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  assert.throws(function () {
+    server.setPeer(serverName);
+  }, new Error('refusing to set self peer'),
+    'Should refuse to set self as a peer');
+  assert.end();
+});
+
+
+test('set peer: should successfully set peer', function t(assert) {
+  var server = new TChannel(serverOptions),
+    conn = server.makeOutConnection(clientName);
+
+  assert.doesNotThrow(function () {
+    server.setPeer(clientName, conn);
+  }, new Error('refusing to set self peer'),
+    'Should successfully set peer');
+  assert.end();
+});
+
+
+test('set peer: get connection', function t(assert) {
+  var server = new TChannel(serverOptions),
+    conn = server.makeOutConnection(clientName),
+    connection = server.setPeer(clientName, conn);
+
+  assert.ok(connection, 'A connection object should be returned');
+  assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+  assert.end();
+});
+
+
+test('get peer: should fail to get non existent peer', function t(assert) {
+  var server = new TChannel(serverOptions),
+    peer = server.getPeer("idontexist");
+
+  assert.notOk(peer, 'Non existent peer should not be retuned');
+  assert.end();
+});
+
+
+test('get peer: should return requested peer', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  server.addPeer(clientName);
+  assert.equals(clientName, server.getPeer(clientName).remoteAddr,
+    'The added peer should be returned');
+  assert.end();
+});
+
+
+test('get peers: should get all peers', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  server.addPeer(clientName);
+  server.addPeer(client1Name);
+  assert.equals(server.getPeers().length, 2);
+  assert.equals(clientName, server.getPeers()[0].remoteAddr,
+    'Peer added first should be returned');
+  assert.equals(client1Name, server.getPeers()[1].remoteAddr,
+    'Peer added second should be returned');
+  assert.end();
+});
+
+
+test('remove peer: should remove requested peer', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  server.removePeer(clientName, server.addPeer(clientName));
+  assert.notOk(server.getPeer(clientName),
+    'Added peer should have been deleted. Nothing should be returned');
+  assert.end();
+});
+
+
+test('getOut connection: get for existing peer', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  server.addPeer(clientName);
+
+  assert.ok(server.getOutConnection(clientName),
+    'Added connection should be returned');
+  assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
+    'Remote address should match the client');
+  assert.end();
+});
+
+
+test('getOut connection: add and get for provided peer', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  assert.ok(server.getOutConnection(clientName),
+    'Added connection should be returned');
+  assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
+    'Remote address should match the client');
+  assert.end();
+});
+
+
+test('make socket: should throw for invalid destination', function t(assert) {
+  var server = new TChannel(serverOptions);
+
+  assert.throws(function () {
+    server.makeSocket('localhost');
+  }, new Error('invalid destination'),
+    'Should reject invalid destination');
+  assert.end();
+});
+
+
+//makeSocket creates net.createConnection. Can't test it as of now.
+// also cant test makeOutConnection for same reason.
+//test('make socket: should create for valid destination', function t(assert) {
+//  
+//  var server = new TChannel(serverOptions);
+//  
+//  assert.doesNotThrow(function() {
+//    server.makeSocket(clientName);
+//  }, new Error('invalid destination'),
+//    'Should reject invalid destination');
+//  assert.end();
+//});
+
+


### PR DESCRIPTION
What:

1. Moved serverSocket.listen out of the constructor to decouple configuration from connection.
2. Added this.listening option TChannel which would be true by default so existing tests would work. Decoupling config and connection creation can be achieved by setting this to false.
3. Added unit tests for methods on TChannel testing both positive as well as throwing scenarios.

Why:

1. While trying to understand the code flow, I usually try adding unit tests. I realized that as we were creating a connection (which would persist), unit testing was unnecessarily  hard.
2. From a design point of view, I think it makes sense to move establishing the connection out of the constructor.
3. Improved code coverage: 

Master:
![screen shot 2015-02-07 at 4 46 43 pm](https://cloud.githubusercontent.com/assets/5800520/6094672/3f81a0a2-aee9-11e4-8122-fd7355669cf9.png)

This branch:
![screen shot 2015-02-07 at 4 46 16 pm](https://cloud.githubusercontent.com/assets/5800520/6094673/4fefb14a-aee9-11e4-9f13-f1d234e96057.png)

 