### PR TITLE
Superficial cleanup ahead of v2 efforts

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,64 +34,64 @@ var net = require('net');
 var inspect = require('util').inspect;
 
 function TChannel(options) {
-	if (!(this instanceof TChannel)) {
-		return new TChannel(options);
-	}
+    if (!(this instanceof TChannel)) {
+        return new TChannel(options);
+    }
 
-	var self = this;
+    var self = this;
 
-	this.options = options || {};
-	this.logger = this.options.logger || nullLogger;
-	// TODO do not default the host.
-	this.host = this.options.host || '127.0.0.1';
-	// TODO do not default the port.
-	this.port = this.options.port || 4040;
-	this.name = this.host + ':' + this.port;
-	this.random = this.options.random ?
-		this.options.random : globalRandom;
-	this.setTimeout = this.options.timers ?
-		this.options.timers.setTimeout : globalSetTimeout;
-	this.clearTimeout = this.options.timers ?
-		this.options.timers.clearTimeout : globalClearTimeout;
-	this.now = this.options.timers ?
-		this.options.timers.now : globalNow;
+    this.options = options || {};
+    this.logger = this.options.logger || nullLogger;
+    // TODO do not default the host.
+    this.host = this.options.host || '127.0.0.1';
+    // TODO do not default the port.
+    this.port = this.options.port || 4040;
+    this.name = this.host + ':' + this.port;
+    this.random = this.options.random ?
+        this.options.random : globalRandom;
+    this.setTimeout = this.options.timers ?
+        this.options.timers.setTimeout : globalSetTimeout;
+    this.clearTimeout = this.options.timers ?
+        this.options.timers.clearTimeout : globalClearTimeout;
+    this.now = this.options.timers ?
+        this.options.timers.now : globalNow;
 
-	this.reqTimeoutDefault = this.options.reqTimeoutDefault || 5000;
-	this.serverTimeoutDefault = this.options.serverTimeoutDefault || 5000;
-	this.timeoutCheckInterval = this.options.timeoutCheckInterval || 1000;
-	this.timeoutFuzz = this.options.timeoutFuzz || 100;
+    this.reqTimeoutDefault = this.options.reqTimeoutDefault || 5000;
+    this.serverTimeoutDefault = this.options.serverTimeoutDefault || 5000;
+    this.timeoutCheckInterval = this.options.timeoutCheckInterval || 1000;
+    this.timeoutFuzz = this.options.timeoutFuzz || 100;
 
-	this.peers = Object.create(null);
+    this.peers = Object.create(null);
 
-	this.endpoints = Object.create(null);
-	this.destroyed = false;
-	// to provide backward compatibility. 
-	this.listening = this.options.listening === false ?
-	  false : true;
-	this.serverSocket = new net.createServer();
+    this.endpoints = Object.create(null);
+    this.destroyed = false;
+    // to provide backward compatibility.
+    this.listening = this.options.listening === false ?
+      false : true;
+    this.serverSocket = new net.createServer();
 
-	if (this.listening) {
-		this.listen();
-	}
+    if (this.listening) {
+        this.listen();
+    }
 
-	this.serverSocket.on('listening', function () {
-		self.logger.info(self.name + ' listening');
-		if (!self.destroyed) {
-			self.emit('listening');
-		}
-	});
-	this.serverSocket.on('error', function (err) {
-		self.logger.error(self.name + ' server socket error: ' + inspect(err));
-	});
-	this.serverSocket.on('close', function () {
-		self.logger.warn('server socket close');
-	});
-	this.serverSocket.on('connection', function (sock) {
-		if (!self.destroyed) {
-			var remoteAddr = sock.remoteAddress + ':' + sock.remotePort;
-			return new TChannelConnection(self, sock, 'in', remoteAddr);
-		}
-	});
+    this.serverSocket.on('listening', function () {
+        self.logger.info(self.name + ' listening');
+        if (!self.destroyed) {
+            self.emit('listening');
+        }
+    });
+    this.serverSocket.on('error', function (err) {
+        self.logger.error(self.name + ' server socket error: ' + inspect(err));
+    });
+    this.serverSocket.on('close', function () {
+        self.logger.warn('server socket close');
+    });
+    this.serverSocket.on('connection', function (sock) {
+        if (!self.destroyed) {
+            var remoteAddr = sock.remoteAddress + ':' + sock.remotePort;
+            return new TChannelConnection(self, sock, 'in', remoteAddr);
+        }
+    });
 }
 require('util').inherits(TChannel, require('events').EventEmitter);
 
@@ -99,633 +99,633 @@ require('util').inherits(TChannel, require('events').EventEmitter);
 // This also allows us to better unit test the code as the test process
 // is not blocked by the listening connections
 TChannel.prototype.listen = function () {
-	if (!this.serverSocket) {
-		throw new Error('Missing server Socket.');
-	}
-	if (!this.host) {
-		throw new Error('Missing server host.');
-	}
-	if (!this.port) {
-		throw new Error('Missing server port.');
-	}
+    if (!this.serverSocket) {
+        throw new Error('Missing server Socket.');
+    }
+    if (!this.host) {
+        throw new Error('Missing server host.');
+    }
+    if (!this.port) {
+        throw new Error('Missing server port.');
+    }
 
-	this.serverSocket.listen(this.port, this.host);
+    this.serverSocket.listen(this.port, this.host);
 };
 
 
 TChannel.prototype.register = function (op, callback) {
-	this.endpoints[op] = callback;
+    this.endpoints[op] = callback;
 };
 
 TChannel.prototype.setPeer = function (name, conn) {
-	if (name === this.name) {
-		throw new Error('refusing to set self peer');
-	}
+    if (name === this.name) {
+        throw new Error('refusing to set self peer');
+    }
 
-	var list = this.peers[name];
-	if (!list) {
-		list = this.peers[name] = [];
-	}
+    var list = this.peers[name];
+    if (!list) {
+        list = this.peers[name] = [];
+    }
 
-	if (conn.direction === 'out') {
-		list.unshift(conn);
-	} else {
-		list.push(conn);
-	}
-	return conn;
+    if (conn.direction === 'out') {
+        list.unshift(conn);
+    } else {
+        list.push(conn);
+    }
+    return conn;
 };
 TChannel.prototype.getPeer = function (name) {
-	var list = this.peers[name];
-	return list && list[0] ? list[0] : null;
+    var list = this.peers[name];
+    return list && list[0] ? list[0] : null;
 };
 
 TChannel.prototype.removePeer = function (name, conn) {
-	var list = this.peers[name];
-	var index = list ? list.indexOf(conn) : -1;
+    var list = this.peers[name];
+    var index = list ? list.indexOf(conn) : -1;
 
-	if (index === -1) {
-		return;
-	}
+    if (index === -1) {
+        return;
+    }
 
-	// TODO: run (don't walk) away from "arrays" as peers, get to actual peer
-	// objects... note how these current semantics can implicitly convert
-	// an in socket to an out socket
-	list.splice(index, 1);
+    // TODO: run (don't walk) away from "arrays" as peers, get to actual peer
+    // objects... note how these current semantics can implicitly convert
+    // an in socket to an out socket
+    list.splice(index, 1);
 };
 
 TChannel.prototype.getPeers = function () {
-	var keys = Object.keys(this.peers);
+    var keys = Object.keys(this.peers);
 
-	var peers = [];
-	for (var i = 0; i < keys.length; i++) {
-		var list = this.peers[keys[i]];
+    var peers = [];
+    for (var i = 0; i < keys.length; i++) {
+        var list = this.peers[keys[i]];
 
-		for (var j = 0; j < list.length; j++) {
-			peers.push(list[j]);
-		}
-	}
+        for (var j = 0; j < list.length; j++) {
+            peers.push(list[j]);
+        }
+    }
 
-	return peers;
+    return peers;
 };
 
 TChannel.prototype.addPeer = function (name, connection) {
-	if (name === this.name) {
-		throw new Error('refusing to add self peer');
-	}
+    if (name === this.name) {
+        throw new Error('refusing to add self peer');
+    }
 
-	if (!connection) {
-		connection = this.makeOutConnection(name);
-	}
+    if (!connection) {
+        connection = this.makeOutConnection(name);
+    }
 
-	var existingPeer = this.getPeer(name);
-	if (existingPeer !== null && existingPeer !== connection) { // TODO: how about === undefined?
-		this.logger.warn('allocated a connection twice', {
-			name: name,
-			direction: connection.direction
-			// TODO: more log context
-		});
-	}
+    var existingPeer = this.getPeer(name);
+    if (existingPeer !== null && existingPeer !== connection) { // TODO: how about === undefined?
+        this.logger.warn('allocated a connection twice', {
+            name: name,
+            direction: connection.direction
+            // TODO: more log context
+        });
+    }
 
-	this.logger.debug('alloc peer', {
-		source: this.name,
-		destination: name,
-		direction: connection.direction
-		// TODO: more log context
-	});
-	var self = this;
-	connection.on('reset', function (/* err */) {
-		// TODO: log?
-		self.removePeer(name, connection);
-	});
-	connection.on('socketClose', function (conn, err) {
-		self.emit('socketClose', conn, err);
-	});
-	return this.setPeer(name, connection);
+    this.logger.debug('alloc peer', {
+        source: this.name,
+        destination: name,
+        direction: connection.direction
+        // TODO: more log context
+    });
+    var self = this;
+    connection.on('reset', function (/* err */) {
+        // TODO: log?
+        self.removePeer(name, connection);
+    });
+    connection.on('socketClose', function (conn, err) {
+        self.emit('socketClose', conn, err);
+    });
+    return this.setPeer(name, connection);
 };
 
 /* jshint maxparams:5 */
 TChannel.prototype.send = function (options, arg1, arg2, arg3, callback) {
-	if (this.destroyed) {
-		throw new Error('cannot send() to destroyed tchannel');
-	}
+    if (this.destroyed) {
+        throw new Error('cannot send() to destroyed tchannel');
+    }
 
-	var dest = options.host;
-	if (!dest) {
-		throw new Error('cannot send() without options.host');
-	}
+    var dest = options.host;
+    if (!dest) {
+        throw new Error('cannot send() without options.host');
+    }
 
-	var peer = this.getOutConnection(dest);
-	peer.send(options, arg1, arg2, arg3, callback);
+    var peer = this.getOutConnection(dest);
+    peer.send(options, arg1, arg2, arg3, callback);
 };
 /* jshint maxparams:4 */
 
 TChannel.prototype.getOutConnection = function (dest) {
-	var peer = this.getPeer(dest);
-	if (!peer) {
-		peer = this.addPeer(dest);
-	}
-	return peer;
+    var peer = this.getPeer(dest);
+    if (!peer) {
+        peer = this.addPeer(dest);
+    }
+    return peer;
 };
 
 TChannel.prototype.makeSocket = function (dest) {
-	var parts = dest.split(':');
-	if (parts.length !== 2) {
-		throw new Error('invalid destination');
-	}
-	var host = parts[0];
-	var port = parts[1];
-	var socket = net.createConnection({host: host, port: port});
-	return socket;
+    var parts = dest.split(':');
+    if (parts.length !== 2) {
+        throw new Error('invalid destination');
+    }
+    var host = parts[0];
+    var port = parts[1];
+    var socket = net.createConnection({host: host, port: port});
+    return socket;
 };
 
 TChannel.prototype.makeOutConnection = function (dest) {
-	var socket = this.makeSocket(dest);
-	var connection = new TChannelConnection(this, socket, 'out', dest);
-	return connection;
+    var socket = this.makeSocket(dest);
+    var connection = new TChannelConnection(this, socket, 'out', dest);
+    return connection;
 };
 
 TChannel.prototype.quit = function (callback) {
-	var self = this;
-	this.destroyed = true;
-	var peers = this.getPeers();
-	var counter = peers.length + 1;
+    var self = this;
+    this.destroyed = true;
+    var peers = this.getPeers();
+    var counter = peers.length + 1;
 
-	this.logger.debug('quitting tchannel', {
-		name: this.name
-	});
+    this.logger.debug('quitting tchannel', {
+        name: this.name
+    });
 
-	peers.forEach(function (conn) {
-		var sock = conn.socket;
-		sock.once('close', onClose);
+    peers.forEach(function (conn) {
+        var sock = conn.socket;
+        sock.once('close', onClose);
 
-		conn.clearTimeoutTimer();
+        conn.clearTimeoutTimer();
 
-		self.logger.debug('destroy channel for', {
-			direction: conn.direction,
-			peerRemoteAddr: conn.remoteAddr,
-			peerRemoteName: conn.remoteName,
-			fromAddress: sock.address()
-		});
-		conn.closing = true;
-		conn.resetAll(new Error('shutdown from quit'));
-		sock.end();
-	});
+        self.logger.debug('destroy channel for', {
+            direction: conn.direction,
+            peerRemoteAddr: conn.remoteAddr,
+            peerRemoteName: conn.remoteName,
+            fromAddress: sock.address()
+        });
+        conn.closing = true;
+        conn.resetAll(new Error('shutdown from quit'));
+        sock.end();
+    });
 
-	var serverSocket = this.serverSocket;
-	if (serverSocket.address()) {
-		closeServerSocket();
-	} else {
-		serverSocket.once('listening', closeServerSocket);
-	}
+    var serverSocket = this.serverSocket;
+    if (serverSocket.address()) {
+        closeServerSocket();
+    } else {
+        serverSocket.once('listening', closeServerSocket);
+    }
 
-	function closeServerSocket() {
-		serverSocket.once('close', onClose);
-		serverSocket.close();
-	}
+    function closeServerSocket() {
+        serverSocket.once('close', onClose);
+        serverSocket.close();
+    }
 
-	function onClose() {
-		if (--counter <= 0) {
-			if (counter < 0) {
-				self.logger.error('closed more sockets than expected', {
-					counter: counter
-				});
-			}
-			if (typeof callback === 'function') {
-				callback();
-			}
-		}
-	}
+    function onClose() {
+        if (--counter <= 0) {
+            if (counter < 0) {
+                self.logger.error('closed more sockets than expected', {
+                    counter: counter
+                });
+            }
+            if (typeof callback === 'function') {
+                callback();
+            }
+        }
+    }
 };
 
 function TChannelConnection(channel, socket, direction, remoteAddr) {
-	var self = this;
-	if (remoteAddr === channel.name) {
-		throw new Error('refusing to create self connection');
-	}
+    var self = this;
+    if (remoteAddr === channel.name) {
+        throw new Error('refusing to create self connection');
+    }
 
-	this.channel = channel;
-	this.logger = this.channel.logger;
-	this.socket = socket;
-	this.direction = direction;
-	this.remoteAddr = remoteAddr;
-	this.timer = null;
+    this.channel = channel;
+    this.logger = this.channel.logger;
+    this.socket = socket;
+    this.direction = direction;
+    this.remoteAddr = remoteAddr;
+    this.timer = null;
 
-	this.remoteName = null; // filled in by identify message
+    this.remoteName = null; // filled in by identify message
 
-	// TODO: factor out an operation collection abstraction
-	this.inOps = Object.create(null);
-	this.inPending = 0;
-	this.outOps = Object.create(null);
-	this.outPending = 0;
+    // TODO: factor out an operation collection abstraction
+    this.inOps = Object.create(null);
+    this.inPending = 0;
+    this.outOps = Object.create(null);
+    this.outPending = 0;
 
-	this.localEndpoints = Object.create(null);
+    this.localEndpoints = Object.create(null);
 
-	this.lastSentMessage = 0;
-	this.lastTimeoutTime = 0;
-	this.closing = false;
+    this.lastSentMessage = 0;
+    this.lastTimeoutTime = 0;
+    this.closing = false;
 
-	this.parser = new TChannelParser(this);
+    this.parser = new TChannelParser(this);
 
-	this.socket.setNoDelay(true);
+    this.socket.setNoDelay(true);
 
-	this.socket.on('data', function (chunk) {
-		if (!self.closing) {
-			self.parser.execute(chunk);
-		}
-	});
-	this.socket.on('error', function (err) {
-		self.onSocketErr(err);
-	});
-	this.socket.on('close', function () {
-		self.onSocketErr(new Error('socket closed'));
-	});
+    this.socket.on('data', function (chunk) {
+        if (!self.closing) {
+            self.parser.execute(chunk);
+        }
+    });
+    this.socket.on('error', function (err) {
+        self.onSocketErr(err);
+    });
+    this.socket.on('close', function () {
+        self.onSocketErr(new Error('socket closed'));
+    });
 
-	this.parser.on('frame', function (frame) {
-		if (!self.closing) {
-			self.onFrame(frame);
-		}
-	});
-	this.parser.on('error', function (err) {
-		if (!self.closing) {
-			// TODO this method is not implemented.
-			// We should close the connection.
-			self.onParserErr(err);
-		}
-	});
+    this.parser.on('frame', function (frame) {
+        if (!self.closing) {
+            self.onFrame(frame);
+        }
+    });
+    this.parser.on('error', function (err) {
+        if (!self.closing) {
+            // TODO this method is not implemented.
+            // We should close the connection.
+            self.onParserErr(err);
+        }
+    });
 
-	this.localEndpoints['TChannel identify'] = function (arg1, arg2, hostInfo, cb) {
-		cb(null, self.channel.name, null);
-	};
+    this.localEndpoints['TChannel identify'] = function (arg1, arg2, hostInfo, cb) {
+        cb(null, self.channel.name, null);
+    };
 
-	if (direction === 'out') {
-		this.send({}, 'TChannel identify', this.channel.name, null, function onOutIdentify(err, res1/*, res2 */) {
-			if (err) {
-				self.channel.logger.error('identification error', {
-					remoteAddr: remoteAddr,
-					error: err
-				});
-				return;
-			}
-			var remote = res1.toString();
-			self.remoteName = remote;
-			self.channel.emit('identified', remote);
-		});
-	}
+    if (direction === 'out') {
+        this.send({}, 'TChannel identify', this.channel.name, null, function onOutIdentify(err, res1/*, res2 */) {
+            if (err) {
+                self.channel.logger.error('identification error', {
+                    remoteAddr: remoteAddr,
+                    error: err
+                });
+                return;
+            }
+            var remote = res1.toString();
+            self.remoteName = remote;
+            self.channel.emit('identified', remote);
+        });
+    }
 
-	this.startTimeoutTimer();
+    this.startTimeoutTimer();
 
-	socket.once('close', clearTimer);
+    socket.once('close', clearTimer);
 
-	function clearTimer() {
-		self.channel.clearTimeout(self.timer);
-	}
+    function clearTimer() {
+        self.channel.clearTimeout(self.timer);
+    }
 }
 require('util').inherits(TChannelConnection, require('events').EventEmitter);
 
 // timeout check runs every timeoutCheckInterval +/- some random fuzz. Range is from
 //   base - fuzz/2 to base + fuzz/2
 TChannelConnection.prototype.getTimeoutDelay = function () {
-	var base = this.channel.timeoutCheckInterval;
-	var fuzz = this.channel.timeoutFuzz;
-	return base + Math.round(Math.floor(this.channel.random() * fuzz) - (fuzz / 2));
+    var base = this.channel.timeoutCheckInterval;
+    var fuzz = this.channel.timeoutFuzz;
+    return base + Math.round(Math.floor(this.channel.random() * fuzz) - (fuzz / 2));
 };
 
 TChannelConnection.prototype.startTimeoutTimer = function () {
-	var self = this;
+    var self = this;
 
-	this.timer = this.channel.setTimeout(function () {
-		// TODO: worth it to clear the fired self.timer objcet?
-		self.onTimeoutCheck();
-	}, this.getTimeoutDelay());
+    this.timer = this.channel.setTimeout(function () {
+        // TODO: worth it to clear the fired self.timer objcet?
+        self.onTimeoutCheck();
+    }, this.getTimeoutDelay());
 };
 
 TChannelConnection.prototype.clearTimeoutTimer = function () {
-	if (this.timer) {
-		this.channel.clearTimeout(this.timer);
-		this.timer = null;
-	}
+    if (this.timer) {
+        this.channel.clearTimeout(this.timer);
+        this.timer = null;
+    }
 };
 
 // If the connection has some success and some timeouts, we should probably leave it up,
 // but if everything is timing out, then we should kill the connection.
 TChannelConnection.prototype.onTimeoutCheck = function () {
-	if (this.closing) {
-		return;
-	}
+    if (this.closing) {
+        return;
+    }
 
-	if (this.lastTimeoutTime) {
-		this.logger.warn(this.channel.name + ' destroying socket from timeouts');
-		this.socket.destroy();
-		return;
-	}
+    if (this.lastTimeoutTime) {
+        this.logger.warn(this.channel.name + ' destroying socket from timeouts');
+        this.socket.destroy();
+        return;
+    }
 
-	this.checkOutOpsForTimeout(this.outOps);
-	this.checkInOpsForTimeout(this.inOps);
+    this.checkOutOpsForTimeout(this.outOps);
+    this.checkInOpsForTimeout(this.inOps);
 
-	this.startTimeoutTimer();
+    this.startTimeoutTimer();
 };
 
 TChannelConnection.prototype.checkInOpsForTimeout = function checkInOpsForTimeout(ops) {
-	var self = this;
-	var opKeys = Object.keys(ops);
-	var now = self.channel.now();
+    var self = this;
+    var opKeys = Object.keys(ops);
+    var now = self.channel.now();
 
-	for (var i = 0; i < opKeys.length; i++) {
-		var opKey = opKeys[i];
-		var op = ops[opKey];
+    for (var i = 0; i < opKeys.length; i++) {
+        var opKey = opKeys[i];
+        var op = ops[opKey];
 
-		if (op === undefined) {
-			continue;
-		}
+        if (op === undefined) {
+            continue;
+        }
 
-		var timeout = self.channel.serverTimeoutDefault;
-		var duration = now - op.start;
-		if (duration > timeout) {
-			delete ops[opKey];
-			self.inPending--;
-		}
-	}
+        var timeout = self.channel.serverTimeoutDefault;
+        var duration = now - op.start;
+        if (duration > timeout) {
+            delete ops[opKey];
+            self.inPending--;
+        }
+    }
 };
 
 TChannelConnection.prototype.checkOutOpsForTimeout = function checkOutOpsForTimeout(ops) {
-	var self = this;
-	var opKeys = Object.keys(ops);
-	var now = self.channel.now();
-	for (var i = 0; i < opKeys.length ; i++) {
-		var opKey = opKeys[i];
-		var op = ops[opKey];
-		if (op.timedOut) {
-			delete ops[opKey];
-			self.outPending--;
-			self.logger.warn('lingering timed-out outgoing operation');
-			continue;
-		}
-		if (op === undefined) {
-			// TODO: why not null and empty string too? I mean I guess false
-			// and 0 might be a thing, but really why not just !op?
-			self.channel.logger
-				.warn('unexpected undefined operation', {
-					key: opKey,
-					op: op
-				});
-			continue;
-		}
-		var timeout = op.options.timeout || self.channel.reqTimeoutDefault;
-		var duration = now - op.start;
-		if (duration > timeout) {
-			delete ops[opKey];
-			self.outPending--;
-			self.onReqTimeout(op);
-		}
-	}
+    var self = this;
+    var opKeys = Object.keys(ops);
+    var now = self.channel.now();
+    for (var i = 0; i < opKeys.length ; i++) {
+        var opKey = opKeys[i];
+        var op = ops[opKey];
+        if (op.timedOut) {
+            delete ops[opKey];
+            self.outPending--;
+            self.logger.warn('lingering timed-out outgoing operation');
+            continue;
+        }
+        if (op === undefined) {
+            // TODO: why not null and empty string too? I mean I guess false
+            // and 0 might be a thing, but really why not just !op?
+            self.channel.logger
+                .warn('unexpected undefined operation', {
+                    key: opKey,
+                    op: op
+                });
+            continue;
+        }
+        var timeout = op.options.timeout || self.channel.reqTimeoutDefault;
+        var duration = now - op.start;
+        if (duration > timeout) {
+            delete ops[opKey];
+            self.outPending--;
+            self.onReqTimeout(op);
+        }
+    }
 };
 
 TChannelConnection.prototype.onReqTimeout = function (op) {
-	op.timedOut = true;
-	op.callback(new Error('timed out'), null, null);
-	this.lastTimeoutTime = this.channel.now();
+    op.timedOut = true;
+    op.callback(new Error('timed out'), null, null);
+    this.lastTimeoutTime = this.channel.now();
 };
 
 // this socket is completely broken, and is going away
 // In addition to erroring out all of the pending work, we reset the state in case anybody
 // stumbles across this object in a core dump.
 TChannelConnection.prototype.resetAll = function (err) {
-	this.closing = true;
-	this.clearTimeoutTimer();
+    this.closing = true;
+    this.clearTimeoutTimer();
 
-	this.emit('reset');
-	var self = this;
+    this.emit('reset');
+    var self = this;
 
-	// requests that we've received we can delete, but these reqs may have started their
-	//   own outgoing work, which is hard to cancel. By setting this.closing, we make sure
-	//   that once they do finish that their callback will swallow the response.
-	Object.keys(this.inOps).forEach(function (id) {
-		// TODO: we could support an op.cancel opt-in callback
-		delete self.inOps[id];
-	});
+    // requests that we've received we can delete, but these reqs may have started their
+    //   own outgoing work, which is hard to cancel. By setting this.closing, we make sure
+    //   that once they do finish that their callback will swallow the response.
+    Object.keys(this.inOps).forEach(function (id) {
+        // TODO: we could support an op.cancel opt-in callback
+        delete self.inOps[id];
+    });
 
-	// for all outgoing requests, forward the triggering error to the user callback
-	Object.keys(this.outOps).forEach(function (id) {
-		var op = self.outOps[id];
-		delete self.outOps[id];
-		// TODO: shared mutable object... use Object.create(err)?
-		op.callback(err, null, null);
-	});
+    // for all outgoing requests, forward the triggering error to the user callback
+    Object.keys(this.outOps).forEach(function (id) {
+        var op = self.outOps[id];
+        delete self.outOps[id];
+        // TODO: shared mutable object... use Object.create(err)?
+        op.callback(err, null, null);
+    });
 
-	this.inPending = 0;
-	this.outPending = 0;
+    this.inPending = 0;
+    this.outPending = 0;
 
-	this.emit('socketClose', this, err);
+    this.emit('socketClose', this, err);
 };
 
 TChannelConnection.prototype.onSocketErr = function (err) {
-	if (!this.closing) {
-		this.resetAll(err);
-	}
+    if (!this.closing) {
+        this.resetAll(err);
+    }
 };
 
 TChannelConnection.prototype.validateChecksum = function (frame) {
-	var actual = frame.checksum();
-	var expected = frame.header.csum;
-	if (expected !== actual) {
-		this.logger.warn('server checksum validation failed ' + expected + ' vs ' + actual);
-		this.logger.warn(inspect(frame));
-		return false;
-	} else {
-		return true;
-	}
+    var actual = frame.checksum();
+    var expected = frame.header.csum;
+    if (expected !== actual) {
+        this.logger.warn('server checksum validation failed ' + expected + ' vs ' + actual);
+        this.logger.warn(inspect(frame));
+        return false;
+    } else {
+        return true;
+    }
 };
 
 // when we receive a new connection, we expect the first message to be identify
 TChannelConnection.prototype.onIdentify = function (frame) {
-	var str1 = frame.arg1.toString();
-	var str2 = frame.arg2.toString();
-	if (str1 === 'TChannel identify') {
-		this.remoteName = str2;
-		this.channel.addPeer(str2, this);
-		this.channel.emit('identified', str2);
-		return true;
-	}
+    var str1 = frame.arg1.toString();
+    var str2 = frame.arg2.toString();
+    if (str1 === 'TChannel identify') {
+        this.remoteName = str2;
+        this.channel.addPeer(str2, this);
+        this.channel.emit('identified', str2);
+        return true;
+    }
 
-	this.logger.error('first req on socket must be identify');
-	return false;
+    this.logger.error('first req on socket must be identify');
+    return false;
 };
 
 TChannelConnection.prototype.onFrame = function (frame) {
-//	this.logger.info(this.channel.name + ' got frame ' + frame.arg1 + ' ' + frame.arg2);
+//  this.logger.info(this.channel.name + ' got frame ' + frame.arg1 + ' ' + frame.arg2);
 
-	if (this.validateChecksum(frame) === false) {
-		// TODO: reduce the log spam: validateChecksum emits 2x warn logs, then
-		// we have a less than informative error log here... use a structured
-		// error out of validation and log it here instead
-		this.logger.error("bad checksum");
-	}
+    if (this.validateChecksum(frame) === false) {
+        // TODO: reduce the log spam: validateChecksum emits 2x warn logs, then
+        // we have a less than informative error log here... use a structured
+        // error out of validation and log it here instead
+        this.logger.error("bad checksum");
+    }
 
-	this.lastTimeoutTime = 0;
+    this.lastTimeoutTime = 0;
 
-	if (frame.header.type === types.reqCompleteMessage) {
-		if (this.remoteName === null && this.onIdentify(frame) === false) {
-			return;
-		}
-		this.handleReqFrame(frame);
-	} else if (frame.header.type === types.resCompleteMessage) {
-		this.handleResCompleteMessage(frame);
-	} else if (frame.header.type === types.resError) {
-		this.handleResError(frame);
-	} else {
-		this.logger.error('unknown frame type', {
-			type: frame.header.type
-		});
-	}
+    if (frame.header.type === types.reqCompleteMessage) {
+        if (this.remoteName === null && this.onIdentify(frame) === false) {
+            return;
+        }
+        this.handleReqFrame(frame);
+    } else if (frame.header.type === types.resCompleteMessage) {
+        this.handleResCompleteMessage(frame);
+    } else if (frame.header.type === types.resError) {
+        this.handleResError(frame);
+    } else {
+        this.logger.error('unknown frame type', {
+            type: frame.header.type
+        });
+    }
 };
 
 TChannelConnection.prototype.handleReqFrame = function (reqFrame) {
-	var self = this;
-	var id = reqFrame.header.id;
-	var name = reqFrame.arg1.toString();
+    var self = this;
+    var id = reqFrame.header.id;
+    var name = reqFrame.arg1.toString();
 
-	var handler = this.localEndpoints[name] || this.channel.endpoints[name];
+    var handler = this.localEndpoints[name] || this.channel.endpoints[name];
 
-	if (typeof handler !== 'function') {
-		// TODO: test this behavior, in fact the prior early return subtlety
-		// broke tests in an unknown way after deferring the inOps mutation
-		// until after old handler verification without this... arguably it's
-		// what we want anyhow, but that weird test failure should be
-		// understood
-		handler = function(arg2, arg3, remoteAddr, cb) {
-			var err = new Error('no such operation');
-			err.op = name;
-			cb(err, null, null);
-		};
-		return;
-	}
+    if (typeof handler !== 'function') {
+        // TODO: test this behavior, in fact the prior early return subtlety
+        // broke tests in an unknown way after deferring the inOps mutation
+        // until after old handler verification without this... arguably it's
+        // what we want anyhow, but that weird test failure should be
+        // understood
+        handler = function(arg2, arg3, remoteAddr, cb) {
+            var err = new Error('no such operation');
+            err.op = name;
+            cb(err, null, null);
+        };
+        return;
+    }
 
-	this.inPending++;
-	var opCallback = responseFrameBuilder(reqFrame, sendResponse);
-	var op = this.inOps[id] = new TChannelServerOp(this,
-		handler, reqFrame, this.channel.now(), {}, opCallback);
+    this.inPending++;
+    var opCallback = responseFrameBuilder(reqFrame, sendResponse);
+    var op = this.inOps[id] = new TChannelServerOp(this,
+        handler, reqFrame, this.channel.now(), {}, opCallback);
 
-	function sendResponse(err, handlerErr, resFrame) {
-		if (err) {
-			// TODO: add more log context
-			self.logger.error(err);
-			return;
-		}
-		if (self.closing) {
-			return;
-		}
-		if (self.inOps[id] !== op) {
-			// TODO log...
-			return;
-		}
-		// TODO: observability hook for handler errors
-		var buf = resFrame.toBuffer();
-		delete self.inOps[id];
-		self.inPending--;
-		self.socket.write(buf);
-	}
+    function sendResponse(err, handlerErr, resFrame) {
+        if (err) {
+            // TODO: add more log context
+            self.logger.error(err);
+            return;
+        }
+        if (self.closing) {
+            return;
+        }
+        if (self.inOps[id] !== op) {
+            // TODO log...
+            return;
+        }
+        // TODO: observability hook for handler errors
+        var buf = resFrame.toBuffer();
+        delete self.inOps[id];
+        self.inPending--;
+        self.socket.write(buf);
+    }
 };
 
 TChannelConnection.prototype.handleResCompleteMessage = function (frame) {
-	this.completeOutOp(frame.header.id, null, frame.arg2, frame.arg3);
+    this.completeOutOp(frame.header.id, null, frame.arg2, frame.arg3);
 };
 
 TChannelConnection.prototype.handleResError = function (frame) {
-	var err = new Error(frame.arg1);
-	this.completeOutOp(frame.header.id, err, null, null);
+    var err = new Error(frame.arg1);
+    this.completeOutOp(frame.header.id, err, null, null);
 };
 
 TChannelConnection.prototype.completeOutOp = function (id, err, arg1, arg2) {
-	var op = this.outOps[id];
-	if (op) {
-		delete this.outOps[id];
-		this.outPending--;
-		op.callback(err, arg1, arg2);
-	// } else { // TODO log...
-	}
-	// TODO else case. We should warn about an incoming response
-	// for an operation we did not send out.
-	// This could be because of a timeout or could be because
-	// of a confused / corrupted server.
+    var op = this.outOps[id];
+    if (op) {
+        delete this.outOps[id];
+        this.outPending--;
+        op.callback(err, arg1, arg2);
+    // } else { // TODO log...
+    }
+    // TODO else case. We should warn about an incoming response
+    // for an operation we did not send out.
+    // This could be because of a timeout or could be because
+    // of a confused / corrupted server.
 };
 
 // send a req frame
 /* jshint maxparams:5 */
 TChannelConnection.prototype.send = function(options, arg1, arg2, arg3, callback) {
-	var frame = new TChannelFrame();
+    var frame = new TChannelFrame();
 
-	frame.set(arg1, arg2, arg3);
-	frame.header.type = types.reqCompleteMessage;
-	// TODO This id will overflow at the 4 million messages mark
-	// This can create a very strange race condition where we
-	// call an very old operation with a long timeout if we
-	// send more then 4 million messages in a certain timeframe
-	frame.header.id = ++this.lastSentMessage;
-	frame.header.seq = 0;
+    frame.set(arg1, arg2, arg3);
+    frame.header.type = types.reqCompleteMessage;
+    // TODO This id will overflow at the 4 million messages mark
+    // This can create a very strange race condition where we
+    // call an very old operation with a long timeout if we
+    // send more then 4 million messages in a certain timeframe
+    frame.header.id = ++this.lastSentMessage;
+    frame.header.seq = 0;
 
-	// TODO check whether this outOps already exists in case
-	// we send more then 4 million messages in a time frame.
-	this.outOps[frame.header.id] = new TChannelClientOp(
-		options, frame, this.channel.now(), callback);
-	this.pendingCount++;
-	return this.socket.write(frame.toBuffer());
+    // TODO check whether this outOps already exists in case
+    // we send more then 4 million messages in a time frame.
+    this.outOps[frame.header.id] = new TChannelClientOp(
+        options, frame, this.channel.now(), callback);
+    this.pendingCount++;
+    return this.socket.write(frame.toBuffer());
 };
 /* jshint maxparams:4 */
 
 /* jshint maxparams:6 */
 function TChannelServerOp(connection, handler, reqFrame, start, options, callback) {
-	this.connection = connection;
-	this.handler = handler;
-	this.reqFrame = reqFrame;
-	this.timedOut = false;
-	this.start = start;
-	this.options = options;
-	handler(reqFrame.arg2, reqFrame.arg3, connection.remoteName, callback);
+    this.connection = connection;
+    this.handler = handler;
+    this.reqFrame = reqFrame;
+    this.timedOut = false;
+    this.start = start;
+    this.options = options;
+    handler(reqFrame.arg2, reqFrame.arg3, connection.remoteName, callback);
 }
 /* jshint maxparams:4 */
 
 function responseFrameBuilder(reqFrame, callback) {
-	var id = reqFrame.header.id;
-	var arg1 = reqFrame.arg1;
-	var sent = false;
-	var resFrame = new TChannelFrame();
-	resFrame.header.id = id;
-	resFrame.header.seq = 0;
-	return function (handlerErr, res1, res2) {
-		if (sent) {
-			return callback(new Error('response already sent', {
-				handlerErr: handlerErr,
-				res1: res1,
-				res2: res2
-			}));
-		}
-		sent = true;
-		if (handlerErr) {
-			// TODO should the error response contain a head ?
-			// Is there any value in sending meta data along with
-			// the error.
-			resFrame.set(isError(handlerErr) ? handlerErr.message : handlerErr, null, null);
-			resFrame.header.type = types.resError;
-		} else {
-			resFrame.set(arg1, res1, res2);
-			resFrame.header.type = types.resCompleteMessage;
-		}
-		callback(null, handlerErr, resFrame);
-	};
+    var id = reqFrame.header.id;
+    var arg1 = reqFrame.arg1;
+    var sent = false;
+    var resFrame = new TChannelFrame();
+    resFrame.header.id = id;
+    resFrame.header.seq = 0;
+    return function (handlerErr, res1, res2) {
+        if (sent) {
+            return callback(new Error('response already sent', {
+                handlerErr: handlerErr,
+                res1: res1,
+                res2: res2
+            }));
+        }
+        sent = true;
+        if (handlerErr) {
+            // TODO should the error response contain a head ?
+            // Is there any value in sending meta data along with
+            // the error.
+            resFrame.set(isError(handlerErr) ? handlerErr.message : handlerErr, null, null);
+            resFrame.header.type = types.resError;
+        } else {
+            resFrame.set(arg1, res1, res2);
+            resFrame.header.type = types.resCompleteMessage;
+        }
+        callback(null, handlerErr, resFrame);
+    };
 }
 
 function isError(obj) {
-	return typeof obj === 'object' && (
-		Object.prototype.toString.call(obj) === '[object Error]' ||
-		obj instanceof Error);
+    return typeof obj === 'object' && (
+        Object.prototype.toString.call(obj) === '[object Error]' ||
+        obj instanceof Error);
 }
 
 function TChannelClientOp(options, frame, start, callback) {
-	this.options = options;
-	this.frame = frame;
-	this.callback = callback;
-	this.start = start;
-	this.timedOut = false;
+    this.options = options;
+    this.frame = frame;
+    this.callback = callback;
+    this.start = start;
+    this.timedOut = false;
 }
 
 module.exports = TChannel;

--- a/null-logger.js
+++ b/null-logger.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+'use strict';
+
 function noop() {}
 
 module.exports = {

--- a/parser.js
+++ b/parser.js
@@ -50,288 +50,288 @@ states.error = states.error = 255;
 var emptyBuffer = new Buffer(0);
 
 function TChannelHeader() {
-	this.type = null;
-	this.id = null;
-	this.seq = null;
-	this.arg1len = null;
-	this.arg2len = null;
-	this.arg3len = null;
-	this.csum = null;
+    this.type = null;
+    this.id = null;
+    this.seq = null;
+    this.arg1len = null;
+    this.arg2len = null;
+    this.arg3len = null;
+    this.csum = null;
 }
 
 function TChannelFrame() {
-	this.header = new TChannelHeader();
-	// TODO this field is unused. It should be removed.
-	this.options = null;
-	this.arg1 = null;
-	this.arg2 = null;
-	this.arg3 = null;
+    this.header = new TChannelHeader();
+    // TODO this field is unused. It should be removed.
+    this.options = null;
+    this.arg1 = null;
+    this.arg2 = null;
+    this.arg3 = null;
 }
 
 TChannelFrame.prototype.set = function (arg1, arg2, arg3) {
-	if (arg1 === undefined || arg1 === null) {
-		arg1 = '';
-	}
-	if (arg2 === undefined || arg2 === null) {
-		arg2 = '';
-	}
-	if (arg3 === undefined || arg3 === null) {
-		arg3 = '';
-	}
+    if (arg1 === undefined || arg1 === null) {
+        arg1 = '';
+    }
+    if (arg2 === undefined || arg2 === null) {
+        arg2 = '';
+    }
+    if (arg3 === undefined || arg3 === null) {
+        arg3 = '';
+    }
 
-	var type;
+    var type;
 
-	if (Buffer.isBuffer(arg1)) {
-		this.arg1 = arg1;
-	} else {
-		this.arg1 = new Buffer(arg1.toString());
-	}
-	this.header.arg1len = this.arg1.length;
+    if (Buffer.isBuffer(arg1)) {
+        this.arg1 = arg1;
+    } else {
+        this.arg1 = new Buffer(arg1.toString());
+    }
+    this.header.arg1len = this.arg1.length;
 
-	if (Buffer.isBuffer(arg2)) {
-		this.arg2 = arg2;
-	} else {
-		// 	TODO remove special case for JSON.stringify
-		// 	This creates a situation where objects are
-		// 	JSON serialized but `null`, `true` and strings are
-		//	not.
-		// 	
-		//	The convenience of object serialization is not worth
-		// 	The confusion it introduces.
-		if (typeof arg2 === 'object') {
-			this.arg2 = new Buffer(JSON.stringify(arg2));
-		} else if (typeof arg2 === 'string') {
-			this.arg2 = new Buffer(arg2);
-		} else {
-			this.arg2 = new Buffer(arg2.toString());
-		}
-	}
-	this.header.arg2len = this.arg2.length;
+    if (Buffer.isBuffer(arg2)) {
+        this.arg2 = arg2;
+    } else {
+        //  TODO remove special case for JSON.stringify
+        //  This creates a situation where objects are
+        //  JSON serialized but `null`, `true` and strings are
+        //  not.
+        //  
+        //  The convenience of object serialization is not worth
+        //  The confusion it introduces.
+        if (typeof arg2 === 'object') {
+            this.arg2 = new Buffer(JSON.stringify(arg2));
+        } else if (typeof arg2 === 'string') {
+            this.arg2 = new Buffer(arg2);
+        } else {
+            this.arg2 = new Buffer(arg2.toString());
+        }
+    }
+    this.header.arg2len = this.arg2.length;
 
-	if (Buffer.isBuffer(arg3)) {
-		this.arg3 = arg3;
-	} else {
-		if (typeof arg3 === 'object') {
-			this.arg3 = new Buffer(JSON.stringify(arg3));
-		} else if (typeof arg3 === 'string') {
-			this.arg3 = new Buffer(arg3);
-		} else {
-			this.arg3 = new Buffer(arg3.toString());
-		}
-	}
-	this.header.arg3len = this.arg3.length;
-	this.header.csum = this.checksum();
+    if (Buffer.isBuffer(arg3)) {
+        this.arg3 = arg3;
+    } else {
+        if (typeof arg3 === 'object') {
+            this.arg3 = new Buffer(JSON.stringify(arg3));
+        } else if (typeof arg3 === 'string') {
+            this.arg3 = new Buffer(arg3);
+        } else {
+            this.arg3 = new Buffer(arg3.toString());
+        }
+    }
+    this.header.arg3len = this.arg3.length;
+    this.header.csum = this.checksum();
 };
 
 TChannelFrame.prototype.checksum = function () {
-	var csum = farmhash.hash32(this.arg1);
-	if (this.arg2.length > 0) {
-		csum = farmhash.hash32WithSeed(this.arg2, csum);
-	}
-	if (this.arg3.length > 0) {
-		csum = farmhash.hash32WithSeed(this.arg3, csum);
-	}
-	return csum;
+    var csum = farmhash.hash32(this.arg1);
+    if (this.arg2.length > 0) {
+        csum = farmhash.hash32WithSeed(this.arg2, csum);
+    }
+    if (this.arg3.length > 0) {
+        csum = farmhash.hash32WithSeed(this.arg3, csum);
+    }
+    return csum;
 };
 
 TChannelFrame.prototype.toBuffer = function () {
-	var header = this.header;
-	var buf = new Buffer(25 + header.arg1len + header.arg2len + header.arg3len);
-	var offset = 0;
+    var header = this.header;
+    var buf = new Buffer(25 + header.arg1len + header.arg2len + header.arg3len);
+    var offset = 0;
 
-	buf.writeUInt8(header.type, offset, true);
-	offset += 1;
-	buf.writeUInt32BE(header.id, offset, true);
-	offset += 4;
-	buf.writeUInt32BE(header.seq, offset, true);
-	offset += 4;
-	buf.writeUInt32BE(header.arg1len, offset, true);
-	offset += 4;
-	buf.writeUInt32BE(header.arg2len, offset, true);
-	offset += 4;
-	buf.writeUInt32BE(header.arg3len, offset, true);
-	offset += 4;
-	buf.writeUInt32BE(header.csum, offset, true);
-	offset += 4;
+    buf.writeUInt8(header.type, offset, true);
+    offset += 1;
+    buf.writeUInt32BE(header.id, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.seq, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg1len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg2len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg3len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.csum, offset, true);
+    offset += 4;
 
-	this.arg1.copy(buf, offset);
-	offset += this.arg1.length;
-	this.arg2.copy(buf, offset);
-	offset += this.arg2.length;
-	this.arg3.copy(buf, offset);
-	offset += this.arg3.length;
+    this.arg1.copy(buf, offset);
+    offset += this.arg1.length;
+    this.arg2.copy(buf, offset);
+    offset += this.arg2.length;
+    this.arg3.copy(buf, offset);
+    offset += this.arg3.length;
 
-	return buf;
+    return buf;
 };
 
 
 function TChannelParser(connection) {
-	this.newFrame = new TChannelFrame();
+    this.newFrame = new TChannelFrame();
 
-	this.logger = connection.logger;
-	this.state = states.read_type;
+    this.logger = connection.logger;
+    this.state = states.read_type;
 
-	this.tmpInt = null;
-	this.tmpIntBuf = new Buffer(4);
-	this.tmpIntPos = 0;
-	this.tmpStr = null;
-	this.tmpStrPos = 0;
+    this.tmpInt = null;
+    this.tmpIntBuf = new Buffer(4);
+    this.tmpIntPos = 0;
+    this.tmpStr = null;
+    this.tmpStrPos = 0;
 
-	this.pos = null;
-	this.chunk = null;
+    this.pos = null;
+    this.chunk = null;
 }
 
 require('util').inherits(TChannelParser, require('events').EventEmitter);
 
 TChannelParser.prototype.parseError = function(msg) {
-	this.emit('error', new Error(msg));
-	this.logger.error('parse error: ' + msg);
-	this.pos = this.chunk.length;
-	this.state = states.error;
+    this.emit('error', new Error(msg));
+    this.logger.error('parse error: ' + msg);
+    this.pos = this.chunk.length;
+    this.state = states.error;
 };
 
 TChannelParser.prototype.readType = function () {
-	var newType = this.chunk[this.pos++];
-	this.state = states.read_id;
-	this.newFrame.header.type = newType;
+    var newType = this.chunk[this.pos++];
+    this.state = states.read_id;
+    this.newFrame.header.type = newType;
 };
 
 TChannelParser.prototype.readInt = function () {
-	if (this.tmpIntPos === 0 && this.chunk.length >= this.pos + 4) {
-		this.tmpInt = this.chunk.readUInt32BE(this.pos, true);
-		this.pos += 4;
-		return;
-	}
-	while (this.tmpIntPos < 4 && this.pos < this.chunk.length) {
-		this.tmpIntBuf[this.tmpIntPos++] = this.chunk[this.pos++];
-	}
-	if (this.tmpIntPos === 4) {
-		this.tmpInt = this.tmpIntBuf.readUInt32BE(0, true);
-		this.tmpIntPos = 0;
-	}
+    if (this.tmpIntPos === 0 && this.chunk.length >= this.pos + 4) {
+        this.tmpInt = this.chunk.readUInt32BE(this.pos, true);
+        this.pos += 4;
+        return;
+    }
+    while (this.tmpIntPos < 4 && this.pos < this.chunk.length) {
+        this.tmpIntBuf[this.tmpIntPos++] = this.chunk[this.pos++];
+    }
+    if (this.tmpIntPos === 4) {
+        this.tmpInt = this.tmpIntBuf.readUInt32BE(0, true);
+        this.tmpIntPos = 0;
+    }
 };
 
 TChannelParser.prototype.readStr = function (len) {
-	if (this.tmpStr === null) {
-		if ((this.chunk.length - this.pos) >= len) {
-			this.tmpStr = this.chunk.slice(this.pos, this.pos + len);
-			this.pos += len;
-			this.tmpStrPos = len;
-		} else {
-			this.tmpStr = new Buffer(len);
-			this.chunk.copy(this.tmpStr, 0, this.pos, this.chunk.length);
-			this.tmpStrPos = this.chunk.length - this.pos;
-			this.pos += (this.chunk.length - this.pos);
-		}
-	} else {
-		var bytesToCopy = Math.min(this.chunk.length, (len - this.tmpStrPos));
-		this.chunk.copy(this.tmpStr, this.tmpStrPos, this.pos, this.pos + bytesToCopy);
-		this.tmpStrPos += bytesToCopy;
-		this.pos += bytesToCopy;
-	}
+    if (this.tmpStr === null) {
+        if ((this.chunk.length - this.pos) >= len) {
+            this.tmpStr = this.chunk.slice(this.pos, this.pos + len);
+            this.pos += len;
+            this.tmpStrPos = len;
+        } else {
+            this.tmpStr = new Buffer(len);
+            this.chunk.copy(this.tmpStr, 0, this.pos, this.chunk.length);
+            this.tmpStrPos = this.chunk.length - this.pos;
+            this.pos += (this.chunk.length - this.pos);
+        }
+    } else {
+        var bytesToCopy = Math.min(this.chunk.length, (len - this.tmpStrPos));
+        this.chunk.copy(this.tmpStr, this.tmpStrPos, this.pos, this.pos + bytesToCopy);
+        this.tmpStrPos += bytesToCopy;
+        this.pos += bytesToCopy;
+    }
 };
 
 TChannelParser.prototype.execute = function (chunk) {
-	this.pos = 0;
-	this.chunk = chunk;
-	var header = this.newFrame.header;
+    this.pos = 0;
+    this.chunk = chunk;
+    var header = this.newFrame.header;
 
-	while (this.pos < chunk.length) {
-		if (this.state === states.read_type) {
-			this.readType();
-		} else if (this.state === states.read_id) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.id = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_seq;
-			}
-		} else if (this.state === states.read_seq) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.seq = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_arg1len;
-			}
-		} else if (this.state === states.read_arg1len) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.arg1len = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_arg2len;
-			}
-		} else if (this.state === states.read_arg2len) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.arg2len = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_arg3len;
-			}
-		} else if (this.state === states.read_arg3len) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.arg3len = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_csum;
-			}
-		} else if (this.state === states.read_csum) {
-			this.readInt();
-			if (typeof this.tmpInt === 'number') {
-				header.csum = this.tmpInt;
-				this.tmpInt = null;
-				this.state = states.read_arg1;
-			}
-		} else if (this.state === states.read_arg1) {
-			this.readStr(header.arg1len);
-			if (this.tmpStrPos === header.arg1len) {
-				this.newFrame.arg1 = this.tmpStr;
-				this.tmpStr = null;
-				this.tmpStrPos = 0;
-				if (header.arg2len === 0 && header.arg3len === 0) {
-					this.emitAndReset();
-					header = this.newFrame.header;
-				} else {
-					this.state = states.read_arg2;
-				}
-			}
-		} else if (this.state === states.read_arg2) {
-			this.readStr(header.arg2len);
-			if (this.tmpStrPos === header.arg2len) {
-				this.newFrame.arg2 = this.tmpStr;
-				this.tmpStr = null;
-				this.tmpStrPos = 0;
-				if (header.arg3len === 0) {
-					this.emitAndReset();
-					header = this.newFrame.header;
-				} else {
-					this.state = states.read_arg3;
-				}
-			}
-		} else if (this.state === states.read_arg3) {
-			this.readStr(header.arg3len);
-			if (this.tmpStrPos === header.arg3len) {
-				this.newFrame.arg3 = this.tmpStr;
-				this.emitAndReset();
-				header = this.newFrame.header;
-			}
-		} else if (this.state !== states.error) {
-			throw new Error('unknown state ' + this.state);
-		}
-	}
+    while (this.pos < chunk.length) {
+        if (this.state === states.read_type) {
+            this.readType();
+        } else if (this.state === states.read_id) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.id = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_seq;
+            }
+        } else if (this.state === states.read_seq) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.seq = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_arg1len;
+            }
+        } else if (this.state === states.read_arg1len) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.arg1len = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_arg2len;
+            }
+        } else if (this.state === states.read_arg2len) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.arg2len = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_arg3len;
+            }
+        } else if (this.state === states.read_arg3len) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.arg3len = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_csum;
+            }
+        } else if (this.state === states.read_csum) {
+            this.readInt();
+            if (typeof this.tmpInt === 'number') {
+                header.csum = this.tmpInt;
+                this.tmpInt = null;
+                this.state = states.read_arg1;
+            }
+        } else if (this.state === states.read_arg1) {
+            this.readStr(header.arg1len);
+            if (this.tmpStrPos === header.arg1len) {
+                this.newFrame.arg1 = this.tmpStr;
+                this.tmpStr = null;
+                this.tmpStrPos = 0;
+                if (header.arg2len === 0 && header.arg3len === 0) {
+                    this.emitAndReset();
+                    header = this.newFrame.header;
+                } else {
+                    this.state = states.read_arg2;
+                }
+            }
+        } else if (this.state === states.read_arg2) {
+            this.readStr(header.arg2len);
+            if (this.tmpStrPos === header.arg2len) {
+                this.newFrame.arg2 = this.tmpStr;
+                this.tmpStr = null;
+                this.tmpStrPos = 0;
+                if (header.arg3len === 0) {
+                    this.emitAndReset();
+                    header = this.newFrame.header;
+                } else {
+                    this.state = states.read_arg3;
+                }
+            }
+        } else if (this.state === states.read_arg3) {
+            this.readStr(header.arg3len);
+            if (this.tmpStrPos === header.arg3len) {
+                this.newFrame.arg3 = this.tmpStr;
+                this.emitAndReset();
+                header = this.newFrame.header;
+            }
+        } else if (this.state !== states.error) {
+            throw new Error('unknown state ' + this.state);
+        }
+    }
 };
 
 TChannelParser.prototype.emitAndReset = function () {
-	this.tmpStr = null;
-	this.tmpStrPos = 0;
-	if (this.newFrame.header.arg2len === 0) {
-		this.newFrame.arg2 = emptyBuffer;
-	}
-	if (this.newFrame.header.arg3len === 0) {
-		this.newFrame.arg3 = emptyBuffer;
-	}
-	this.emit('frame', this.newFrame);
-	this.newFrame = new TChannelFrame();
-	this.state = states.read_type;
+    this.tmpStr = null;
+    this.tmpStrPos = 0;
+    if (this.newFrame.header.arg2len === 0) {
+        this.newFrame.arg2 = emptyBuffer;
+    }
+    if (this.newFrame.header.arg3len === 0) {
+        this.newFrame.arg3 = emptyBuffer;
+    }
+    this.emit('frame', this.newFrame);
+    this.newFrame = new TChannelFrame();
+    this.state = states.read_type;
 };
 
 exports.TChannelParser = TChannelParser;

--- a/parser.js
+++ b/parser.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+'use strict';
+
 var farmhash = require('farmhash');
 
 /* jshint camelcase:false */

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+'use strict';
+
 var test = require('tape');
 var TChannel = require('../index.js');
 

--- a/v1/frame.js
+++ b/v1/frame.js
@@ -1,0 +1,129 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var farmhash = require('farmhash');
+var Header = require('./header');
+
+module.exports = TChannelFrame;
+
+function TChannelFrame() {
+    this.header = new Header();
+    // TODO this field is unused. It should be removed.
+    this.options = null;
+    this.arg1 = null;
+    this.arg2 = null;
+    this.arg3 = null;
+}
+
+TChannelFrame.prototype.set = function (arg1, arg2, arg3) {
+    if (arg1 === undefined || arg1 === null) {
+        arg1 = '';
+    }
+    if (arg2 === undefined || arg2 === null) {
+        arg2 = '';
+    }
+    if (arg3 === undefined || arg3 === null) {
+        arg3 = '';
+    }
+
+    if (Buffer.isBuffer(arg1)) {
+        this.arg1 = arg1;
+    } else {
+        this.arg1 = new Buffer(arg1.toString());
+    }
+    this.header.arg1len = this.arg1.length;
+
+    if (Buffer.isBuffer(arg2)) {
+        this.arg2 = arg2;
+    } else {
+        //  TODO remove special case for JSON.stringify
+        //  This creates a situation where objects are
+        //  JSON serialized but `null`, `true` and strings are
+        //  not.
+        //  
+        //  The convenience of object serialization is not worth
+        //  The confusion it introduces.
+        if (typeof arg2 === 'object') {
+            this.arg2 = new Buffer(JSON.stringify(arg2));
+        } else if (typeof arg2 === 'string') {
+            this.arg2 = new Buffer(arg2);
+        } else {
+            this.arg2 = new Buffer(arg2.toString());
+        }
+    }
+    this.header.arg2len = this.arg2.length;
+
+    if (Buffer.isBuffer(arg3)) {
+        this.arg3 = arg3;
+    } else {
+        if (typeof arg3 === 'object') {
+            this.arg3 = new Buffer(JSON.stringify(arg3));
+        } else if (typeof arg3 === 'string') {
+            this.arg3 = new Buffer(arg3);
+        } else {
+            this.arg3 = new Buffer(arg3.toString());
+        }
+    }
+    this.header.arg3len = this.arg3.length;
+    this.header.csum = this.checksum();
+};
+
+TChannelFrame.prototype.checksum = function () {
+    var csum = farmhash.hash32(this.arg1);
+    if (this.arg2.length > 0) {
+        csum = farmhash.hash32WithSeed(this.arg2, csum);
+    }
+    if (this.arg3.length > 0) {
+        csum = farmhash.hash32WithSeed(this.arg3, csum);
+    }
+    return csum;
+};
+
+TChannelFrame.prototype.toBuffer = function () {
+    var header = this.header;
+    var buf = new Buffer(25 + header.arg1len + header.arg2len + header.arg3len);
+    var offset = 0;
+
+    buf.writeUInt8(header.type, offset, true);
+    offset += 1;
+    buf.writeUInt32BE(header.id, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.seq, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg1len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg2len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.arg3len, offset, true);
+    offset += 4;
+    buf.writeUInt32BE(header.csum, offset, true);
+    offset += 4;
+
+    this.arg1.copy(buf, offset);
+    offset += this.arg1.length;
+    this.arg2.copy(buf, offset);
+    offset += this.arg2.length;
+    this.arg3.copy(buf, offset);
+    offset += this.arg3.length;
+
+    return buf;
+};

--- a/v1/header.js
+++ b/v1/header.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = TChannelHeader;
+
+function TChannelHeader() {
+    this.type = null;
+    this.id = null;
+    this.seq = null;
+    this.arg1len = null;
+    this.arg2len = null;
+    this.arg3len = null;
+    this.csum = null;
+}

--- a/v1/index.js
+++ b/v1/index.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports.VERSION = 1;
+
+module.exports.Frame = require('./frame');
+module.exports.Header = require('./header');
+module.exports.Parser = require('./parser');
+
+/* jshint camelcase:false */
+
+var types = module.exports.Types = {};
+types.reqCompleteMessage = types.req_complete_message = 0x01;
+types.reqMessageFragment = types.req_message_fragment = 0x02;
+types.reqLastFragment = types.req_last_fragment = 0x03;
+types.resCompleteMessage = types.res_complete_message = 0x80;
+types.resMessageFragment = types.res_message_fragment = 0x81;
+types.resLastFragment = types.res_last_fragment = 0x82;
+types.resError = types.res_error = 0xC0;
+
+/* jshint camelcase:true */


### PR DESCRIPTION
- tabs => spaces in `parser` and `index`, leaving benchmark for another day/diff
- added a few missing `"use strict";`s
- name all functions `TChannel` and `TChannelConnection`
- break up the old `parser` module into `v1/{index,parser,frame,header}` to align with an eventual `v2/...` structure