### PR TITLE
Improve tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@ function TChannel(options) {
     });
 
     self.serverSocket.on('listening', function onServerSocketListening() {
-        self.logger.info(self.name + ' listening');
         if (!self.destroyed) {
+            self.logger.info(self.name + ' listening');
             self.emit('listening');
         }
     });

--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ function TChannel(options) {
     self.serverSocket = new net.createServer(function onServerSocketConnection(sock) {
         if (!self.destroyed) {
             var remoteAddr = sock.remoteAddress + ':' + sock.remotePort;
-            return new TChannelConnection(self, sock, 'in', remoteAddr);
+            var conn = new TChannelConnection(self, sock, 'in', remoteAddr);
+            self.logger.debug('incoming server connection', {
+                hostPort: self.hostPort,
+                remoteAddr: conn.remoteAddr
+            });
         }
     });
 

--- a/test/identify.js
+++ b/test/identify.js
@@ -34,8 +34,8 @@ test('identify', function t(assert) {
     var hostOne = cluster.hosts[0];
     var hostTwo = cluster.hosts[1];
 
-    assert.equal(one.getPeer(hostTwo), null);
-    assert.equal(two.getPeer(hostOne), null);
+    assert.equal(one.getPeer(hostTwo), null, 'one has no peer two');
+    assert.equal(two.getPeer(hostOne), null, 'two has no peer one');
 
     var idBar = barrier.keyed(2, function(idents, done) {
         var outPeer = one.getPeer(hostTwo);

--- a/test/lib/alloc-cluster.js
+++ b/test/lib/alloc-cluster.js
@@ -24,6 +24,7 @@ var extend = require('xtend');
 var util = require('util');
 var TChannel = require('../../index.js');
 var parallel = require('run-parallel');
+var echoLogger = require('./logger');
 
 module.exports = allocCluster;
 
@@ -40,6 +41,7 @@ function allocCluster(n, opts) {
     for (var i=0; i<n; i++) {
         var port = randomPort();
         ret.channels[i] = TChannel(extend({
+            logger: opts.debugLog ? echoLogger(process.stdout) : null,
             host: host,
             port: port
         }, opts));


### PR DESCRIPTION
Some log tweaks, but most concerningly, some ordering changes; while developing towards v2, I kept hitting non-determinism in the tests:
- sometimes but not always the first connection coming into a newly listening server would be lost
- these changes _seemed_ to help, but the problem never fully went away
- I only got the problem to reliably go away by deferring run of primary test logic for 1ms after alloc cluster returned

I don't feel confident yet that the non-determinism wasn't a bug introduced in v2 since I've not got it past the full suite yet.

So while I'm certainly not going to propose adding magic delays, these changes seem sensible.