### PR TITLE
Fix and better test subtle inOps edge case

### DIFF
--- a/index.js
+++ b/index.js
@@ -720,7 +720,9 @@ function TChannelServerOp(connection, handler, reqFrame, start, options, sendFra
     self.options = options;
     self.sendFrame = sendFrame;
     self.responseSent = false;
-    self.handler(reqFrame.arg2, reqFrame.arg3, connection.remoteName, sendResponse);
+    process.nextTick(function runHandler() {
+        self.handler(reqFrame.arg2, reqFrame.arg3, connection.remoteName, sendResponse);
+    });
     function sendResponse(err, res1, res2) {
         self.sendResponse(err, res1, res2);
     }

--- a/index.js
+++ b/index.js
@@ -632,17 +632,16 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
         handler, reqFrame, self.channel.now(), {}, sendFrame);
 
     function sendFrame(resFrame) {
-        if (self.closing) {
-            return;
-        }
         if (self.inOps[id] !== op) {
             // TODO log...
             return;
         }
-        var buf = resFrame.toBuffer();
         delete self.inOps[id];
         self.inPending--;
-        self.socket.write(buf);
+        if (!self.closing) {
+            var buf = resFrame.toBuffer();
+            self.socket.write(buf);
+        }
     }
 };
 

--- a/index.js
+++ b/index.js
@@ -633,7 +633,10 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
 
     function sendFrame(resFrame) {
         if (self.inOps[id] !== op) {
-            // TODO log...
+            self.logger.warn('attempt to send frame for mismatched operation', {
+                hostPort: self.channel.name,
+                opId: id
+            });
             return;
         }
         delete self.inOps[id];

--- a/test/identify.js
+++ b/test/identify.js
@@ -33,14 +33,21 @@ allocCluster.test('identify', 2, function t(cluster, assert) {
     assert.equal(two.getPeer(hostOne), null, 'two has no peer one');
 
     var idBar = barrier.keyed(2, function(idents, done) {
-        var outPeer = one.getPeer(hostTwo);
-        var inPeer = two.getPeer(hostOne);
         assert.equal(idents.one, hostTwo, 'one identified two');
         assert.equal(idents.two, hostOne, 'two identified one');
-        assert.equal(outPeer.direction, 'out', 'outPeer is out');
-        assert.equal(inPeer.direction, 'in', 'inPeer is in');
-        assert.equal(outPeer && outPeer.remoteName, hostTwo, 'outgoing connection name filled in');
-        assert.equal(inPeer && inPeer.remoteName, hostOne, 'incoming connection name filled in');
+
+        var outPeer = one.getPeer(hostTwo);
+        if (outPeer) {
+            assert.equal(outPeer.direction, 'out', 'outPeer is out');
+            assert.equal(outPeer.remoteName, hostTwo, 'outgoing connection name filled in');
+        }
+
+        var inPeer = two.getPeer(hostOne);
+        if (inPeer) {
+            assert.equal(inPeer.direction, 'in', 'inPeer is in');
+            assert.equal(inPeer.remoteName, hostOne, 'incoming connection name filled in');
+        }
+
         done();
     }, assert.end);
 

--- a/test/identify.js
+++ b/test/identify.js
@@ -36,6 +36,12 @@ allocCluster.test('identify', 2, function t(cluster, assert) {
         assert.equal(idents.one, hostTwo, 'one identified two');
         assert.equal(idents.two, hostOne, 'two identified one');
 
+        var peersOne = one.getPeers();
+        var peersTwo = two.getPeers();
+
+        assert.equal(peersOne.length, 1, 'one should have 1 peer');
+        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
+
         var outPeer = one.getPeer(hostTwo);
         if (outPeer) {
             assert.equal(outPeer.direction, 'out', 'outPeer is out');

--- a/test/regression-inOps-leak.js
+++ b/test/regression-inOps-leak.js
@@ -38,29 +38,28 @@ allocCluster.test('does not leak inOps', 2, {
 
     function onTimeout(err) {
         two.timeoutCheckInterval = 99999;
-        assert.ok(err);
-
-        assert.equal(err.message, 'timed out');
+        assert.equal(err && err.message, 'timed out', 'should have a timeout error');
 
         var peersOne = one.getPeers();
         var peersTwo = two.getPeers();
 
-        assert.equal(peersOne.length, 1);
-        assert.equal(peersTwo.length, 1);
+        assert.equal(peersOne.length, 1, 'one should have 1 peer');
+        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
 
         var inPeer = peersOne[0];
+        if (inPeer) {
+            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
+            inPeer.onTimeoutCheck();
+            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
+            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
+        }
+
         var outPeer = peersTwo[0];
-
-        assert.equal(inPeer.direction, 'in');
-        assert.equal(outPeer.direction, 'out');
-
-        inPeer.onTimeoutCheck();
-
-        assert.equal(Object.keys(inPeer.outOps).length, 0);
-        assert.equal(Object.keys(outPeer.inOps).length, 0);
-
-        assert.equal(Object.keys(inPeer.inOps).length, 0);
-        assert.equal(Object.keys(outPeer.outOps).length, 0);
+        if (outPeer) {
+            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
+            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
+            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
+        }
 
         assert.end();
     }

--- a/test/send.js
+++ b/test/send.js
@@ -75,6 +75,26 @@ allocCluster.test('send() to a server', 2, function t(cluster, assert) {
     }, function onResults(err, results) {
         assert.ifError(err);
 
+        var peersOne = one.getPeers();
+        var peersTwo = two.getPeers();
+
+        assert.equal(peersOne.length, 1, 'one should have 1 peer');
+        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
+
+        var inPeer = peersOne[0];
+        if (inPeer) {
+            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
+            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
+            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
+        }
+
+        var outPeer = peersTwo[0];
+        if (outPeer) {
+            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
+            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
+            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
+        }
+
         var stringOp = results.stringOp;
         assert.ok(Buffer.isBuffer(stringOp.head));
         assert.equal(stringOp.head.length, 0);

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -53,6 +53,27 @@ allocCluster.test('requests will timeout', 2, {
     function onTimeout(err) {
         assert.equal(err && err.message, 'timed out', 'expected timeout error');
 
+        var peersOne = one.getPeers();
+        var peersTwo = two.getPeers();
+
+        assert.equal(peersOne.length, 1, 'one should have 1 peer');
+        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
+
+        var inPeer = peersOne[0];
+        if (inPeer) {
+            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
+            inPeer.onTimeoutCheck();
+            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
+            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
+        }
+
+        var outPeer = peersTwo[0];
+        if (outPeer) {
+            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
+            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
+            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
+        }
+
         assert.end();
     }
 

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -51,8 +51,8 @@ allocCluster.test('requests will timeout', 2, {
     });
 
     function onTimeout(err) {
-        assert.ok(err);
-        assert.equal(err.message, 'timed out');
+        assert.equal(err && err.message, 'timed out', 'expected timeout error');
+
         assert.end();
     }
 


### PR DESCRIPTION
- fix inOps leak when handler calls its callback synchronously (as part of RHS of inOps assign)
- test against assumed behavior underscored by the recent regression-inops-leak test by @Raynos 
- always mutate inOps and inPending, even in closing case
- add a marked TODO warn log