### PR TITLE
emit an endpoint event

### DIFF
--- a/index.js
+++ b/index.js
@@ -625,7 +625,7 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
             cb(err, null, null);
         };
 
-        self.channel.emit('missingEndpoint', {
+        self.channel.emit('endpoint.missing', {
             name: name
         });
 

--- a/index.js
+++ b/index.js
@@ -613,6 +613,10 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
 
     var handler = self.localEndpoints[name] || self.channel.endpoints[name];
 
+    self.channel.emit('endpoint', {
+        name: name
+    });
+
     if (typeof handler !== 'function') {
         // TODO: test this behavior, in fact the prior early return subtlety
         // broke tests in an unknown way after deferring the inOps mutation

--- a/index.js
+++ b/index.js
@@ -613,10 +613,6 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
 
     var handler = self.localEndpoints[name] || self.channel.endpoints[name];
 
-    self.channel.emit('endpoint', {
-        name: name
-    });
-
     if (typeof handler !== 'function') {
         // TODO: test this behavior, in fact the prior early return subtlety
         // broke tests in an unknown way after deferring the inOps mutation
@@ -628,7 +624,16 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
             err.op = name;
             cb(err, null, null);
         };
+
+        self.channel.emit('missingEndpoint', {
+            name: name
+        });
+
         return;
+    } else if (self.channel.endpoints[name]) {
+        self.channel.emit('endpoint', {
+            name: name
+        });
     }
 
     self.inPending++;

--- a/test/emits-endpoint.js
+++ b/test/emits-endpoint.js
@@ -32,9 +32,6 @@ allocCluster.test('emits endpoint event', 2, {
     one.register('/hello', function hello(arg1, arg2, hi, cb) {
         assert.deepEqual(endpoints, [
             {
-                name: 'TChannel identify'
-            },
-            {
                 name: '/hello'
             }
         ]);
@@ -56,9 +53,6 @@ allocCluster.test('emits endpoint event', 2, {
         assert.equal(String(res2), 'hello');
 
         assert.deepEqual(endpoints, [
-            {
-                name: 'TChannel identify'
-            },
             {
                 name: '/hello'
             }


### PR DESCRIPTION
This closes #52

Emitting an endpoint event allows us to write a tchannel
access logger.

reviewers: @jcorbin @jwolski

cc: @jsu1212