### PR TITLE
V2 support

### DIFF
--- a/docs.jsig
+++ b/docs.jsig
@@ -48,10 +48,10 @@ type TChannel : {
     ) => void,
     quit: (Callback<Error>) => void,
 
-    getPeer: (name: HostInfo) => TChannelConnection,
+    getPeer: (hostPort: HostInfo) => TChannelConnection,
     getPeers: () => Array<TChannelConnection>,
 
-    name: HostInfo
+    hostPort: HostInfo
 }
 
 tchannel : (options: {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function TChannel(options) {
     self.host = self.options.host || '127.0.0.1';
     // TODO do not default the port.
     self.port = self.options.port || 4040;
-    self.name = self.host + ':' + self.port;
+    self.hostPort = self.host + ':' + self.port;
     self.random = self.options.random ?
         self.options.random : globalRandom;
     self.setTimeout = self.options.timers ?
@@ -77,12 +77,12 @@ function TChannel(options) {
 
     self.serverSocket.on('listening', function onServerSocketListening() {
         if (!self.destroyed) {
-            self.logger.info(self.name + ' listening');
+            self.logger.info(self.hostPort + ' listening');
             self.emit('listening');
         }
     });
     self.serverSocket.on('error', function onServerSocketError(err) {
-        self.logger.error(self.name + ' server socket error: ' + inspect(err));
+        self.logger.error(self.hostPort + ' server socket error: ' + inspect(err));
     });
     self.serverSocket.on('close', function onServerSocketClose() {
         self.logger.warn('server socket close');
@@ -118,15 +118,15 @@ TChannel.prototype.register = function register(op, callback) {
     self.endpoints[op] = callback;
 };
 
-TChannel.prototype.setPeer = function setPeer(name, conn) {
+TChannel.prototype.setPeer = function setPeer(hostPort, conn) {
     var self = this;
-    if (name === self.name) {
+    if (hostPort === self.hostPort) {
         throw new Error('refusing to set self peer');
     }
 
-    var list = self.peers[name];
+    var list = self.peers[hostPort];
     if (!list) {
-        list = self.peers[name] = [];
+        list = self.peers[hostPort] = [];
     }
 
     if (conn.direction === 'out') {
@@ -136,15 +136,16 @@ TChannel.prototype.setPeer = function setPeer(name, conn) {
     }
     return conn;
 };
-TChannel.prototype.getPeer = function getPeer(name) {
+
+TChannel.prototype.getPeer = function getPeer(hostPort) {
     var self = this;
-    var list = self.peers[name];
+    var list = self.peers[hostPort];
     return list && list[0] ? list[0] : null;
 };
 
-TChannel.prototype.removePeer = function removePeer(name, conn) {
+TChannel.prototype.removePeer = function removePeer(hostPort, conn) {
     var self = this;
-    var list = self.peers[name];
+    var list = self.peers[hostPort];
     var index = list ? list.indexOf(conn) : -1;
 
     if (index === -1) {
@@ -173,39 +174,39 @@ TChannel.prototype.getPeers = function getPeers() {
     return peers;
 };
 
-TChannel.prototype.addPeer = function addPeer(name, connection) {
+TChannel.prototype.addPeer = function addPeer(hostPort, connection) {
     var self = this;
-    if (name === self.name) {
+    if (hostPort === self.hostPort) {
         throw new Error('refusing to add self peer');
     }
 
     if (!connection) {
-        connection = self.makeOutConnection(name);
+        connection = self.makeOutConnection(hostPort);
     }
 
-    var existingPeer = self.getPeer(name);
+    var existingPeer = self.getPeer(hostPort);
     if (existingPeer !== null && existingPeer !== connection) { // TODO: how about === undefined?
         self.logger.warn('allocated a connection twice', {
-            name: name,
+            hostPort: hostPort,
             direction: connection.direction
             // TODO: more log context
         });
     }
 
     self.logger.debug('alloc peer', {
-        source: self.name,
-        destination: name,
+        source: self.hostPort,
+        destination: hostPort,
         direction: connection.direction
         // TODO: more log context
     });
     connection.once('reset', function onConnectionReset(/* err */) {
         // TODO: log?
-        self.removePeer(name, connection);
+        self.removePeer(hostPort, connection);
     });
     connection.once('socketClose', function onConnectionSocketClose(conn, err) {
         self.emit('socketClose', conn, err);
     });
-    return self.setPeer(name, connection);
+    return self.setPeer(hostPort, connection);
 };
 
 /* jshint maxparams:5 */
@@ -267,7 +268,7 @@ TChannel.prototype.quit = function quit(callback) {
     var counter = peers.length + 1;
 
     self.logger.debug('quitting tchannel', {
-        name: self.name
+        hostPort: self.hostPort
     });
 
     peers.forEach(function eachPeer(conn) {
@@ -315,7 +316,7 @@ TChannel.prototype.quit = function quit(callback) {
 
 function TChannelConnection(channel, socket, direction, remoteAddr) {
     var self = this;
-    if (remoteAddr === channel.name) {
+    if (remoteAddr === channel.hostPort) {
         throw new Error('refusing to create self connection');
     }
 
@@ -368,7 +369,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     });
 
     self.localEndpoints['TChannel identify'] = function identifyEndpoint(arg1, arg2, hostInfo, cb) {
-        cb(null, self.channel.name, null);
+        cb(null, self.channel.hostPort, null);
     };
 
     if (direction === 'out') {
@@ -398,7 +399,7 @@ TChannelConnection.prototype.onParserError = function onParserError(err) {
     var self = this;
     self.channel.logger.error('tchannel parse error', {
         remoteName: self.remoteName,
-        localName: self.channel.name,
+        localName: self.channel.hostPort,
         error: err
     });
     // TODO should we close the connection?
@@ -444,7 +445,7 @@ TChannelConnection.prototype.onTimeoutCheck = function onTimeoutCheck() {
     }
 
     if (self.lastTimeoutTime) {
-        self.logger.warn(self.channel.name + ' destroying socket from timeouts');
+        self.logger.warn(self.channel.hostPort + ' destroying socket from timeouts');
         self.socket.destroy();
         return;
     }
@@ -585,6 +586,7 @@ TChannelConnection.prototype.onIdentify = function onIdentify(frame) {
     return false;
 };
 
+
 TChannelConnection.prototype.onFrame = function onFrame(frame) {
     var self = this;
 
@@ -634,7 +636,7 @@ TChannelConnection.prototype.handleReqFrame = function handleReqFrame(reqFrame) 
     function sendFrame(resFrame) {
         if (self.inOps[id] !== op) {
             self.logger.warn('attempt to send frame for mismatched operation', {
-                hostPort: self.channel.name,
+                hostPort: self.channel.hostPort,
                 opId: id
             });
             return;
@@ -676,7 +678,7 @@ TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg
 TChannelConnection.prototype.sendInitRequest = function sendInitRequest(callback) {
     var self = this;
     var reqFrame = new v1.Frame();
-    reqFrame.set('TChannel identify', self.channel.name, null);
+    reqFrame.set('TChannel identify', self.channel.hostPort, null);
     reqFrame.header.type = v1.Types.reqCompleteMessage;
     self.send({}, reqFrame, callback);
 };
@@ -687,6 +689,7 @@ TChannelConnection.prototype.handleInitResponse = function handleInitResponse(re
     self.remoteName = remote;
     self.channel.emit('identified', remote);
 };
+
 
 // send a req frame
 /* jshint maxparams:5 */

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var globalSetTimeout = require('timers').setTimeout;
 var globalNow = Date.now;
 var globalRandom = Math.random;
 var net = require('net');
+var format = require('util').format;
 var inspect = require('util').inspect;
 
 function TChannel(options) {
@@ -43,6 +44,9 @@ function TChannel(options) {
     // TODO do not default the port.
     self.port = self.options.port || 4040;
     self.hostPort = self.host + ':' + self.port;
+    // TODO: maybe we should always add pid to user-supplied?
+    self.processName = self.options.processName ||
+        format('%s[%s]', process.title, process.pid);
     self.random = self.options.random ?
         self.options.random : globalRandom;
     self.setTimeout = self.options.timers ?


### PR DESCRIPTION
In v2, what we used to call a "name" is now very solidly the "hostPort" and we've added a new "processName".

I still don't have a great story on the processName yet, but this can work.

Plus having a field called name alongside "processName", let alone forbid "serviceName" if we ever have it at the channel layer is heavily confusing.