### PR TITLE
Allow listening on port 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,34 @@ network multiplexing and framing protocol for RPC
 
 ```js
 var TChannel = require('tchannel');
+var after = require('after');
 
-var server = new TChannel({host: '127.0.0.1', port: 4040});
-var client = new TChannel({host: '127.0.0.1', port: 4041});
+var server = new TChannel();
+var client = new TChannel();
 
-// normal response
-server.register('func 1', function (arg1, arg2, peerInfo, cb) {
-    console.log('func 1 responding immediately 1:' + arg1.toString() + ' 2:' + arg2.toString());
-    cb(null, 'result', 'indeed it did');
+var listening = after(2, function (err) {
+    // ...forward or handle err
+
+    // normal response
+    server.register('func 1', function (arg1, arg2, peerInfo, cb) {
+        console.log('func 1 responding immediately 1:' + arg1.toString() + ' 2:' + arg2.toString());
+        cb(null, 'result', 'indeed it did');
+    });
+    // err response
+    server.register('func 2', function (arg1, arg2, peerInfo, cb) {
+        cb(new Error('it failed'));
+    });
+    client.send({host: '127.0.0.1:4040'}, 'func 1', "arg 1", "arg 2", function (err, res1, res2) {
+        console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
+    });
+    client.send({host: '127.0.0.1:4040'}, 'func 2', "arg 1", "arg 2", function (err, res1, res2) {
+        console.log('err res: ' + err.message);
+    });
+
 });
-// err response
-server.register('func 2', function (arg1, arg2, peerInfo, cb) {
-    cb(new Error('it failed'));
-});
-client.send({host: '127.0.0.1:4040'}, 'func 1', "arg 1", "arg 2", function (err, res1, res2) {
-    console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
-});
-client.send({host: '127.0.0.1:4040'}, 'func 2', "arg 1", "arg 2", function (err, res1, res2) {
-    console.log('err res: ' + err.message);
-});
+
+server.listen(4040, '127.0.0.1', listening);
+client.listen(4041, '127.0.0.1', listening);
 ```
 
 This example registers two functions on the "server". "func 1" always works and "func 2" always 
@@ -124,6 +133,7 @@ The host name and port must be a unique identifier for your
 #### `options.port`
 
 The port for which `TChannel` will open a TCP server on.
+If the port is 0, the operating system will select an available port for you.
 
 #### `options.logger`
 

--- a/README.md
+++ b/README.md
@@ -121,20 +121,6 @@ var channel = TChannel({
 });
 ```
 
-#### `options.host`
-
-You must specify a local host name. This local host name will
-    be used the remote server to identify you.
-
-The host name and port must be a unique identifier for your
-    TChannel server and its strongly recommended that this host
-    is the publicly addressable IP address.
-
-#### `options.port`
-
-The port for which `TChannel` will open a TCP server on.
-If the port is 0, the operating system will select an available port for you.
-
 #### `options.logger`
 
 ```ocaml
@@ -204,6 +190,19 @@ The client interval does not run every N milliseconds, it has
 > every `timeoutCheckInterval` +/ `fuzz/2`
 
 This is used to avoid race conditions in the network.
+
+#### `channel.listen(port, host, callback?)
+
+Starts listening on the given port and host.
+
+Both port and host are mandatory.
+
+The port may be 0, indicating that the operating system must grant an available
+    ephemeral port.
+
+The eventual host and port combination must uniquely identify the TChannel
+    server and it is strongly recommended that the host be the public IP
+    address.
 
 ### `channel.register(op, fn)`
 

--- a/benchmarks/bench_server.js
+++ b/benchmarks/bench_server.js
@@ -19,7 +19,8 @@
 // THE SOFTWARE.
 
 var TChannel = require('../index');
-var server = new TChannel({listen: '127.0.0.1', port: 4040});
+var server = new TChannel();
+server.listen(4040, '127.0.0.1');
 
 var keys = {};
 

--- a/benchmarks/multi_bench.js
+++ b/benchmarks/multi_bench.js
@@ -76,22 +76,23 @@ Test.prototype.new_client = function (id) {
     var self = this, new_client;
     
     var port = 4041 + id;
-    new_client = new TChannel({host: "127.0.0.1", port: port});
+    new_client = new TChannel();
     new_client.create_time = Date.now();
+    new_client.listen(port, "127.0.0.1", function (err) {
+        // sending a ping to pre-connect the socket
+        new_client.send({host: '127.0.0.1:4040'}, 'ping', null, null, function () {});
 
-    // sending a ping to pre-connect the socket
-    new_client.send({host: '127.0.0.1:4040'}, 'ping', null, null, function () {});
+        new_client.on("identified", function (peer) {
+            self.connect_latency.update(Date.now() - new_client.create_time);
+            self.ready_latency.update(Date.now() - new_client.create_time);
+            self.clients_ready++;
+            if (self.clients_ready === self.clients.length) {
+                self.on_clients_ready();
+            }
+        });
 
-    new_client.on("identified", function (peer) {
-        self.connect_latency.update(Date.now() - new_client.create_time);
-        self.ready_latency.update(Date.now() - new_client.create_time);
-        self.clients_ready++;
-        if (self.clients_ready === self.clients.length) {
-            self.on_clients_ready();
-        }
+        self.clients[id] = new_client;
     });
-
-    self.clients[id] = new_client;
 };
 
 Test.prototype.on_clients_ready = function () {

--- a/docs.jsig
+++ b/docs.jsig
@@ -46,7 +46,8 @@ type TChannel : {
             res2: Buffer | null
         ) => void
     ) => void,
-    quit: (Callback<Error>) => void,
+    listen: (port:Number, hostname:String, Callback<Error>?) => void,
+    close: (Callback<Error>) => void,
 
     getPeer: (hostPort: HostInfo) => TChannelConnection,
     getPeers: () => Array<TChannelConnection>,

--- a/examples/example1.js
+++ b/examples/example1.js
@@ -19,22 +19,34 @@
 // THE SOFTWARE.
 
 var TChannel = require('../index.js');
+var after = require('after');
 
-var server = new TChannel({host: '127.0.0.1', port: 4040});
-var client = new TChannel({host: '127.0.0.1', port: 4041});
+var server = new TChannel();
+var client = new TChannel();
 
 // normal response
 server.register('func 1', function (arg1, arg2, peerInfo, cb) {
-	console.log('func 1 responding immediately 1:' + arg1.toString() + ' 2:' + arg2.toString());
-	cb(null, 'result', 'indeed it did');
+    console.log('func 1 responding immediately 1:' + arg1.toString() + ' 2:' + arg2.toString());
+    cb(null, 'result', 'indeed it did');
 });
 // err response
 server.register('func 2', function (arg1, arg2, peerInfo, cb) {
-	cb(new Error('it failed'));
+    cb(new Error('it failed'));
 });
-client.send({host: '127.0.0.1:4040'}, 'func 1', "arg 1", "arg 2", function (err, res1, res2) {
-	console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
+
+var listening = after(2, function (err) {
+    if (err) {
+        throw err;
+    }
+
+    client.send({host: '127.0.0.1:4040'}, 'func 1', "arg 1", "arg 2", function (err, res1, res2) {
+        console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
+    });
+    client.send({host: '127.0.0.1:4040'}, 'func 2', "arg 1", "arg 2", function (err, res1, res2) {
+        console.log('err res: ' + err.message);
+    });
+
 });
-client.send({host: '127.0.0.1:4040'}, 'func 2', "arg 1", "arg 2", function (err, res1, res2) {
-	console.log('err res: ' + err.message);
-});
+
+server.listen(4040, '127.0.0.1', listening);
+client.listen(4041, '127.0.0.1', listening);

--- a/examples/example2.js
+++ b/examples/example2.js
@@ -20,21 +20,32 @@
 
 var TChannel = require('../index.js');
 
-var server = new TChannel({host: '127.0.0.1', port: 4040});
-var client = new TChannel({host: '127.0.0.1', port: 4041});
+var server = new TChannel();
+var client = new TChannel();
 
 // bidirectional messages
 server.register('ping', function onPing(arg1, arg2, peerInfo, pingCb) {
-	console.log('server got ping req from ' + peerInfo);
-	pingCb(null, 'pong', null);
+    console.log('server got ping req from ' + peerInfo);
+    pingCb(null, 'pong', null);
 });
 client.register('ping', function onPing(arg1, arg2, peerInfo, pingCb) {
-	console.log('client got ping req from ' + peerInfo);
-	pingCb(null, 'pong', null);
+    console.log('client got ping req from ' + peerInfo);
+    pingCb(null, 'pong', null);
 });
-client.send({host: '127.0.0.1:4040'}, 'ping', null, null, function (err, res1, res2) {
-	console.log('ping res from client: ' + res1 + ' ' + res2);
-	server.send({host: '127.0.0.1:4041'}, 'ping', null, null, function (err, res1, res2) {
-		console.log('ping res server: ' + res1 + ' ' + res2);
-	});
+
+var listening = after(2, function (err) {
+    if (err) {
+        throw err;
+    }
+
+    client.send({host: '127.0.0.1:4040'}, 'ping', null, null, function (err, res1, res2) {
+        console.log('ping res from client: ' + res1 + ' ' + res2);
+        server.send({host: '127.0.0.1:4041'}, 'ping', null, null, function (err, res1, res2) {
+            console.log('ping res server: ' + res1 + ' ' + res2);
+        });
+    });
+
 });
+
+server.listen(4040, '127.0.0.1', listening);
+client.listen(4041, '127.0.0.1', listening);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "tape": "^3.0.3",
     "time-mock": "^0.1.2",
     "uber-licence": "^1.1.0",
-    "xtend": "^4.0.0"
+    "xtend": "^4.0.0",
+    "after": "^0.8.1"
   },
   "pre-commit": [
     "test",

--- a/test/safe-quit.js
+++ b/test/safe-quit.js
@@ -25,10 +25,8 @@ var test = require('tape');
 var TChannel = require('../index.js');
 
 test('can call quit() safely async', function t(assert) {
-    var channel = TChannel({
-        host: 'localhost',
-        port: randomPort()
-    });
+    var channel = TChannel();
+    channel.listen(0, 'localhost');
 
     channel.once('listening', function onListen() {
         assert.doesNotThrow(function noThrow() {
@@ -40,10 +38,8 @@ test('can call quit() safely async', function t(assert) {
 });
 
 test('can call quit() safely sync', function t(assert) {
-    var channel = TChannel({
-        host: 'localhost',
-        port: randomPort()
-    });
+    var channel = TChannel();
+    channel.listen(0, 'localhost');
 
     assert.doesNotThrow(function noThrow() {
         channel.quit();
@@ -52,10 +48,9 @@ test('can call quit() safely sync', function t(assert) {
 });
 
 test('can call quit() safely async w/ callback', function t(assert) {
-    var channel = TChannel({
-        host: 'localhost',
-        port: randomPort()
-    });
+    var channel = TChannel();
+    channel.listen(0, 'localhost');
+
     channel.once('listening', function onListen() {
         assert.doesNotThrow(function noThrow() {
             channel.quit(assert.end);
@@ -64,15 +59,10 @@ test('can call quit() safely async w/ callback', function t(assert) {
 });
 
 test('can call quit() safely sync w/ callback', function t(assert) {
-    var channel = TChannel({
-        host: 'localhost',
-        port: randomPort()
-    });
+    var channel = TChannel();
+    channel.listen(0, 'localhost');
     assert.doesNotThrow(function noThrow() {
         channel.quit(assert.end);
     });
 });
 
-function randomPort() {
-    return 20000 + Math.floor(Math.random() * 20000);
-}

--- a/test/tchannel.js
+++ b/test/tchannel.js
@@ -23,155 +23,186 @@
 var test = require('tape');
 var TChannel = require('../index.js');
 
-var serverOptions = {host: '127.0.0.1', port: 4040, listening: false};
-var clientOptions = {host: '127.0.0.1', port: 4041, listening: false};
-var client1Options = {host: '127.0.0.1', port: 4042, listening: false};
+var serverOptions = {host: '127.0.0.1', port: 4040};
+var clientOptions = {host: '127.0.0.1', port: 4041};
+var client1Options = {host: '127.0.0.1', port: 4042};
 var serverName = serverOptions.host + ':' + serverOptions.port;
 var clientName = clientOptions.host + ':' + clientOptions.port;
 var client1Name = client1Options.host + ':' + client1Options.port;
 
 
 test('add peer: refuse to add self', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  assert.throws(function () {
-    server.addPeer(serverName);
-  }, new Error('refusing to add self peer'),
-    'Should refuse to add self as a peer');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.once('listening', function () {
+    assert.throws(function () {
+      server.addPeer(serverName);
+    }, new Error('refusing to add self peer'),
+      'Should refuse to add self as a peer');
+    server.quit(assert.end);
+  });
 });
 
 
 test('add peer: should successfully add peer', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  assert.doesNotThrow(function () {
-    server.addPeer(clientName);
-  }, new Error('refusing to add self peer'),
-    'Should successfully add peer');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.once('listening', function () {
+    assert.doesNotThrow(function () {
+      server.addPeer(clientName);
+    }, new Error('refusing to add self peer'),
+      'Should successfully add peer');
+    server.quit(assert.end);
+  });
 });
 
 
 test('add peer: get connection', function t(assert) {
-  var server = new TChannel(serverOptions);
-  var connection = server.addPeer(clientName);
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.once('listening', function handleListening() {
+    var connection = server.addPeer(clientName);
 
-  assert.ok(connection, 'A connection object should be returned');
-  assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
-  assert.end();
+    assert.ok(connection, 'A connection object should be returned');
+    assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    server.quit(assert.end);
+  });
 });
 
 
 test('set peer: refuse to set self', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  assert.throws(function () {
-    server.setPeer(serverName);
-  }, new Error('refusing to set self peer'),
-    'Should refuse to set self as a peer');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.once('listening', function () {
+    assert.throws(function () {
+      server.setPeer(serverName);
+    }, new Error('refusing to set self peer'),
+      'Should refuse to set self as a peer');
+    server.quit(assert.end);
+  });
 });
 
 
 test('set peer: should successfully set peer', function t(assert) {
-  var server = new TChannel(serverOptions);
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
   var conn = server.makeOutConnection(clientName);
+  server.on('listening', function () {
 
-  assert.doesNotThrow(function () {
-    server.setPeer(clientName, conn);
-  }, new Error('refusing to set self peer'),
-    'Should successfully set peer');
-  assert.end();
+    assert.doesNotThrow(function () {
+      server.setPeer(clientName, conn);
+    }, new Error('refusing to set self peer'),
+      'Should successfully set peer');
+    server.quit(assert.end);
+  });
 });
 
 
 test('set peer: get connection', function t(assert) {
-  var server = new TChannel(serverOptions);
-  var conn = server.makeOutConnection(clientName);
-  var connection = server.setPeer(clientName, conn);
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    var conn = server.makeOutConnection(clientName);
+    var connection = server.setPeer(clientName, conn);
 
-  assert.ok(connection, 'A connection object should be returned');
-  assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
-  assert.end();
+    assert.ok(connection, 'A connection object should be returned');
+    assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    server.quit(assert.end);
+  });
 });
 
 
 test('get peer: should fail to get non existent peer', function t(assert) {
-  var server = new TChannel(serverOptions),
-    peer = server.getPeer("idontexist");
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    var peer = server.getPeer("idontexist");
 
-  assert.notOk(peer, 'Non existent peer should not be retuned');
-  assert.end();
+    assert.notOk(peer, 'Non existent peer should not be retuned');
+    server.quit(assert.end);
+  });
 });
 
 
 test('get peer: should return requested peer', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  server.addPeer(clientName);
-  assert.equals(clientName, server.getPeer(clientName).remoteAddr,
-    'The added peer should be returned');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    server.addPeer(clientName);
+    assert.equals(clientName, server.getPeer(clientName).remoteAddr,
+      'The added peer should be returned');
+    server.quit(assert.end);
+  });
 });
 
 
 test('get peers: should get all peers', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  server.addPeer(clientName);
-  server.addPeer(client1Name);
-  assert.equals(server.getPeers().length, 2);
-  assert.equals(clientName, server.getPeers()[0].remoteAddr,
-    'Peer added first should be returned');
-  assert.equals(client1Name, server.getPeers()[1].remoteAddr,
-    'Peer added second should be returned');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    server.addPeer(clientName);
+    server.addPeer(client1Name);
+    assert.equals(server.getPeers().length, 2);
+    assert.equals(clientName, server.getPeers()[0].remoteAddr,
+      'Peer added first should be returned');
+    assert.equals(client1Name, server.getPeers()[1].remoteAddr,
+      'Peer added second should be returned');
+    server.quit(assert.end);
+  });
 });
 
 
 test('remove peer: should remove requested peer', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  server.removePeer(clientName, server.addPeer(clientName));
-  assert.notOk(server.getPeer(clientName),
-    'Added peer should have been deleted. Nothing should be returned');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    server.removePeer(clientName, server.addPeer(clientName));
+    assert.notOk(server.getPeer(clientName),
+      'Added peer should have been deleted. Nothing should be returned');
+    server.quit(assert.end);
+  });
 });
 
 
 test('getOut connection: get for existing peer', function t(assert) {
-  var server = new TChannel(serverOptions);
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
 
-  server.addPeer(clientName);
+    server.addPeer(clientName);
 
-  assert.ok(server.getOutConnection(clientName),
-    'Added connection should be returned');
-  assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
-    'Remote address should match the client');
-  assert.end();
+    assert.ok(server.getOutConnection(clientName),
+      'Added connection should be returned');
+    assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
+      'Remote address should match the client');
+    server.quit(assert.end);
+  });
 });
 
 
 test('getOut connection: add and get for provided peer', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  assert.ok(server.getOutConnection(clientName),
-    'Added connection should be returned');
-  assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
-    'Remote address should match the client');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    assert.ok(server.getOutConnection(clientName),
+      'Added connection should be returned');
+    assert.equals(server.getOutConnection(clientName).remoteAddr, clientName,
+      'Remote address should match the client');
+    server.quit(assert.end);
+  });
 });
 
 
 test('make socket: should throw for invalid destination', function t(assert) {
-  var server = new TChannel(serverOptions);
-
-  assert.throws(function () {
-    server.makeSocket('localhost');
-  }, new Error('invalid destination'),
-    'Should reject invalid destination');
-  assert.end();
+  var server = new TChannel();
+  server.listen(serverOptions.port, serverOptions.host);
+  server.on('listening', function () {
+    assert.throws(function () {
+      server.makeSocket('localhost');
+    }, new Error('invalid destination'),
+      'Should reject invalid destination');
+    server.quit(assert.end);
+  });
 });
 
 
@@ -179,7 +210,8 @@ test('make socket: should throw for invalid destination', function t(assert) {
 // also cant test makeOutConnection for same reason.
 //test('make socket: should create for valid destination', function t(assert) {
 //  
-//  var server = new TChannel(serverOptions);
+//  var server = new TChannel();
+//  server.listen(serverOptions.port, serverOptions.host);
 //  
 //  assert.doesNotThrow(function() {
 //    server.makeSocket(clientName);


### PR DESCRIPTION
Note that this is a backward incompatible change.  addPeer depends on
the channel to know its own name, and the name is now only knowable
after the channel is listening.  I have removed support for
options.listening and server.listening is now a flag indicating that the
server is listening.  Tests have been adjusted to listen, and those that
required a random, available port, now use port 0 and need not wonder
whether the port was actually available.