### PR TITLE
throw exception on double close

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,6 +305,11 @@ TChannel.prototype.quit = function close(callback) {
 
 TChannel.prototype.close = function close(callback) {
     var self = this;
+
+    if (self.destroyed) {
+        throw new Error('double close'); // TODO typed error
+    }
+
     self.destroyed = true;
     var peers = self.getPeers();
     var counter = peers.length + 1;


### PR DESCRIPTION
I spend a bunch of time debugging something that was
a double close bug.

Throwing a hard exception will make this a lot easier
to see.

reviewers: @kriskowal @jcorbin

cc: @jsu1212