### PR TITLE
ensure the socket is always closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,6 +428,8 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     self.handler.on('error', function onHandlerError(err) {
         self.resetAll(err);
+        // resetAll() does not close the socket
+        self.socket.destroy();
     });
 
     if (direction === 'out') {


### PR DESCRIPTION
The `resetAll()` method does not call socket.destroy().
There are only 3 callsites for it.

 - when the socket closes or errors, resetAll()
 - when the server quits, end the socket then resetAll()
 - when the handler has an error resetAll()

When the handler has an error we do not destroy the socket
which would leak a socket until the net timeout cleaned it
up.

reviewers: @jcorbin @kriskowal

cc: @jsu1212