### PR TITLE
V2 unerror

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "crc": "^3.2.1",
-    "error": "^5.1.0",
+    "error": "^5.1.1",
     "farmhash": "^0.2.0"
   },
   "devDependencies": {

--- a/test/v2/checksum.js
+++ b/test/v2/checksum.js
@@ -59,7 +59,7 @@ test('read and verify crc32 checksum', function t(assert) {
         var good = csum.verify(parts[0], parts[1], parts[2]);
         assert.equal(good, null, 'crc32 expected to verify parts');
         var bad = csum.verify(uparts[0], uparts[1], uparts[2]);
-        assert.equal(bad && bad.type, 'tchannel.checksum-error', 'crc32 expected to fail');
+        assert.equal(bad && bad.type, 'tchannel.checksum', 'crc32 expected to fail');
         done();
     });
 });
@@ -70,7 +70,7 @@ test('read and verify farmhash32 checksum', function t(assert) {
         var good = csum.verify(parts[0], parts[1], parts[2]);
         assert.equal(good, null, 'farmhash32 expected to verify parts');
         var bad = csum.verify(uparts[0], uparts[1], uparts[2]);
-        assert.equal(bad && bad.type, 'tchannel.checksum-error', 'farmhash32 expected to fail');
+        assert.equal(bad && bad.type, 'tchannel.checksum', 'farmhash32 expected to fail');
         done();
     });
 });

--- a/test/v2/test_frame.js
+++ b/test/v2/test_frame.js
@@ -25,7 +25,7 @@ var read = require('../../lib/read.js');
 var write = require('../../lib/write.js');
 
 var SizeMismatchError = TypedError({
-    type: 'test-frame.size-mismatch-error',
+    type: 'test-frame.size-mismatch',
     message: 'size ({size}) mismatches buffer length ({bufferLength})',
     size: null,
     bufferLength: null

--- a/v2/checksum.js
+++ b/v2/checksum.js
@@ -28,7 +28,7 @@ var read = require('../lib/read');
 var write = require('../lib/write');
 
 var ChecksumError = TypedError({
-    type: 'tchannel.checksum-error',
+    type: 'tchannel.checksum',
     message: 'invalid checksum',
     checksumType: null,
     expectedValue: null,


### PR DESCRIPTION
Turns out typed-error does a `name += "Error"`