### PR TITLE
throw an exception on double registration

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,11 @@ TChannel.prototype.getEndpointHandler = function getEndpointHandler(name) {
 
 TChannel.prototype.register = function register(op, callback) {
     var self = this;
+
+    if (self.endpoints[op]) {
+        throw new Error('endpoint ' + op + ' is already defined'); // TODO typed error
+    }
+
     self.endpoints[op] = callback;
 };
 


### PR DESCRIPTION
Currently if someone registers the same endpoint twice
we just silently overwrite. This makes debugging a lot
harder.

My use case is that I want my application and ringpop to
share a single tchannel server. It's a lot easier if
to do this if i know that any conflict between ringpop
and my application results in a programmer error.

reviewers: @jwolski @jcorbin @kriskowal

cc: @jsu1212
