### PR TITLE
V2 parse streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ldjson-stream": "^1.2.1",
     "metrics": "^0.1.8",
     "minimist": "^1.1.0",
+    "once": "^1.3.1",
     "opn": "^1.0.1",
     "pre-commit": "0.0.9",
     "ready-signal": "^1.1.0",

--- a/test/v2/test_frame.js
+++ b/test/v2/test_frame.js
@@ -52,8 +52,8 @@ TestFrame.read = read.chained(read.series([
     if (size !== buffer.length) {
         // parser shouldn't let this happen
         return [SizeMismatchError({
-            size: null,
-            bufferLength: null
+            size: size,
+            bufferLength: buffer.length
         }), offset, null];
     }
     var body = new TestFrame(payload);

--- a/v2/parse_buffer.js
+++ b/v2/parse_buffer.js
@@ -1,0 +1,83 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = ParseBuffer;
+
+function ParseBuffer() {
+    var self = this;
+    self.buffer = Buffer(0);
+}
+
+ParseBuffer.prototype.avail = function avail() {
+    var self = this;
+    return self.buffer.length;
+};
+
+ParseBuffer.prototype.free = function free() {
+    return 0;
+};
+
+ParseBuffer.prototype.clear = function clear() {
+    var self = this;
+    self.buffer = Buffer(0);
+};
+
+ParseBuffer.prototype.push = function push(chunk) {
+    var self = this;
+    if (self.buffer.length) {
+        self.buffer = Buffer.concat([self.buffer, chunk], self.buffer.length + chunk.length);
+    } else {
+        self.buffer = chunk;
+    }
+};
+
+ParseBuffer.prototype.shift = function shift(n) {
+    var self = this;
+    var chunk;
+    if (self.buffer.length < n) {
+        chunk = Buffer(0);
+    } else if (self.buffer.length > n) {
+        chunk = self.buffer.slice(0, n);
+        self.buffer = self.buffer.slice(n);
+    } else {
+        chunk = self.buffer;
+        self.buffer = Buffer(0);
+    }
+    return chunk;
+};
+
+ParseBuffer.prototype.readUInt8 = function readUInt8(offset) {
+    var self = this;
+    return self.buffer.readUInt8(offset);
+};
+
+ParseBuffer.prototype.readUInt16BE = function readUInt16BE(offset) {
+    var self = this;
+    return self.buffer.readUInt16BE(offset);
+};
+
+ParseBuffer.prototype.readUInt32BE = function readUInt32BE(offset) {
+    var self = this;
+    return self.buffer.readUInt32BE(offset);
+};
+
+// TODO: split out and complete buffer api


### PR DESCRIPTION
Refactor:
- factor textExpectations primitive out of parserTest
- factor out a parse buffer boundary for future experimentation
- v2 parser to be a transform stream

The parse buffer factor out was useful since `Readable.prototype.push` conflicted with our prior `ChunkParser.prototype.push` for the chunk buffering.

reviewers: @kriskowal @Raynos 