### PR TITLE
add NODE_DEBUG=tchannelhexer support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@
 
 var v2 = require('./v2');
 var nullLogger = require('./null-logger.js');
+var debuglog = require('./lib/debug-log.js');
 var globalClearTimeout = require('timers').clearTimeout;
 var globalSetTimeout = require('timers').setTimeout;
 var globalNow = Date.now;
@@ -29,6 +30,9 @@ var globalRandom = Math.random;
 var net = require('net');
 var format = require('util').format;
 var inspect = require('util').inspect;
+var hexer = require('hexer');
+
+var debugHex = debuglog('tchannelhexer');
 
 function TChannel(options) {
     if (!(this instanceof TChannel)) {
@@ -721,6 +725,9 @@ TChannelConnection.prototype._writeFrame = function _writeFrame(frame, callback)
         }
     } else {
         var buffer = frame.toBuffer();
+        if (debugHex.enabled) {
+            debugHex('outgoing frame: \n%s', hexer(buffer));
+        }
         self.socket.write(buffer, null, callback);
     }
 };

--- a/lib/debug-log.js
+++ b/lib/debug-log.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+// Modified to expose an enabled boolean
+// https://github.com/joyent/node/blob/fbfe562d71ae8d8f8bbf627808c755e513e4e905/lib/util.js#L96-L114
+var util = require('util');
+var debugEnv = process.env.NODE_DEBUG || '';
+var cache = {};
+
+module.exports = function (set) {
+    set = set.toUpperCase();
+
+    if (!cache[set]) {
+        if (new RegExp('\\b' + set + '\\b', 'i').test(debugEnv)) {
+            var pid = process.pid;
+
+            cache[set] = function () {
+                console.error('%s %d: %s', set, pid, util.format.apply(util, arguments));
+            };
+            // addition
+            cache[set].enabled = true;
+        } else {
+            cache[set] = function () {};
+            // addition
+            cache[set].enabled = false;
+        }
+    }
+
+    return cache[set];
+};

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   },
   "dependencies": {
     "crc": "^3.2.1",
+    "debuglog": "^1.0.1",
     "error": "^5.1.1",
-    "farmhash": "^0.2.0"
+    "farmhash": "^0.2.0",
+    "hexer": "^1.1.0"
   },
   "devDependencies": {
     "ansi-color": "^0.2.1",

--- a/v2/parser.js
+++ b/v2/parser.js
@@ -23,7 +23,12 @@
 var TypedError = require('error/typed');
 var inherits = require('util').inherits;
 var Transform = require('stream').Transform;
+var hexer = require('hexer');
+
 var ParseBuffer = require('./parse_buffer');
+var debuglog = require('../lib/debug-log.js');
+
+var debugHex = debuglog('tchannelhexer');
 
 var BrokenParserStateError = TypedError({
     type: 'tchannel.broken-parser-state',
@@ -135,6 +140,11 @@ ChunkParser.prototype.handleFrame = function handleFrame(chunk, callback) {
     if (!callback) {
         callback = emitFrame;
     }
+
+    if (debugHex.enabled) {
+        debugHex('incoming frame: \n%s', hexer(chunk));
+    }
+
     var res = self.FrameType.read(chunk, 0);
     var err = res[0];
     var end = res[1];


### PR DESCRIPTION
This instruments `tchannel` itself with both hexer and `debuglog`.

I've copied the `debuglog` to add an `enabled` true/false flag.

This means we will only call out to hexer when `enabled` is set to true.
I wanted to write the frames, so i've instrumented the v2 parser as that was the nicest place to put it.

This allows us to run any program, like `tcurl` with `NODE_DEBUG=tchannelhexer` and it will pretty print all the frames coming in & out.

reviewers: @jcorbin @kriskowal 

cc: @jsu1212 