### PR TITLE
node: better error objects from handleError

### DIFF
--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -72,31 +72,38 @@ CodeNames[Codes.ProtocolError] = 'protocol error';
 var CodeErrors = {};
 CodeErrors[Codes.Timeout] = TypedError({
     type: 'tchannel.timeout',
-    errorCode: Codes.Timeout
+    errorCode: Codes.Timeout,
+    originalId: null
 });
 CodeErrors[Codes.Cancelled] = TypedError({
     type: 'tchannel.canceled',
-    errorCode: Codes.Cancelled
+    errorCode: Codes.Cancelled,
+    originalId: null
 });
 CodeErrors[Codes.Busy] = TypedError({
     type: 'tchannel.busy',
-    errorCode: Codes.Busy
+    errorCode: Codes.Busy,
+    originalId: null
 });
 CodeErrors[Codes.Declined] = TypedError({
     type: 'tchannel.declined',
-    errorCode: Codes.Declined
+    errorCode: Codes.Declined,
+    originalId: null
 });
 CodeErrors[Codes.UnexpectedError] = TypedError({
     type: 'tchannel.unexpected',
-    errorCode: Codes.UnexpectedError
+    errorCode: Codes.UnexpectedError,
+    originalId: null
 });
 CodeErrors[Codes.BadRequest] = TypedError({
     type: 'tchannel.bad-request',
-    errorCode: Codes.BadRequest
+    errorCode: Codes.BadRequest,
+    originalId: null
 });
 CodeErrors[Codes.ProtocolError] = TypedError({
     type: 'tchannel.protocol',
-    errorCode: Codes.ProtocolError
+    errorCode: Codes.ProtocolError,
+    originalId: null
 });
 
 ErrorResponse.Codes = Codes;

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -71,25 +71,32 @@ CodeNames[Codes.ProtocolError] = 'protocol error';
 
 var CodeErrors = {};
 CodeErrors[Codes.Timeout] = TypedError({
-    type: 'tchannel.timeout'
+    type: 'tchannel.timeout',
+    errorCode: Codes.Timeout
 });
 CodeErrors[Codes.Cancelled] = TypedError({
-    type: 'tchannel.canceled'
+    type: 'tchannel.canceled',
+    errorCode: Codes.Cancelled
 });
 CodeErrors[Codes.Busy] = TypedError({
-    type: 'tchannel.busy'
+    type: 'tchannel.busy',
+    errorCode: Codes.Busy
 });
 CodeErrors[Codes.Declined] = TypedError({
-    type: 'tchannel.declined'
+    type: 'tchannel.declined',
+    errorCode: Codes.Declined
 });
 CodeErrors[Codes.UnexpectedError] = TypedError({
-    type: 'tchannel.unexpected'
+    type: 'tchannel.unexpected',
+    errorCode: Codes.UnexpectedError
 });
 CodeErrors[Codes.BadRequest] = TypedError({
-    type: 'tchannel.bad-request'
+    type: 'tchannel.bad-request',
+    errorCode: Codes.BadRequest
 });
 CodeErrors[Codes.ProtocolError] = TypedError({
-    type: 'tchannel.protocol'
+    type: 'tchannel.protocol',
+    errorCode: Codes.ProtocolError
 });
 
 ErrorResponse.Codes = Codes;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -174,7 +174,10 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame) {
     var id = errFrame.id;
     var code = errFrame.body.code;
     var message = errFrame.body.message;
-    var err = v2.ErrorResponse.CodeErrors[code]({message: message});
+    var err = v2.ErrorResponse.CodeErrors[code]({
+        originalId: id,
+        message: message
+    });
     self.completeOutOp(err, id, null, null);
 };
 


### PR DESCRIPTION
- expose code number in `.errorCode`
- pass along error res's original message id field in `.originalId`