### PR TITLE
Add Travis build badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TChannel
+# TChannel [![Build Status](https://travis-ci.org/uber/tchannel.svg?branch=master)] (https://travis-ci.org/uber/tchannel)
 
 Network multiplexing and framing protocol for RPC
 


### PR DESCRIPTION
It's green and shiny.

Preview: https://github.com/uber/tchannel/blob/build-badge/README.md

Not in love with the markdown syntax/sooper-long line but this seems to be the way people do this.