### PR TITLE
Refactor calls to take a Context object

### DIFF
--- a/python/docs/api.rst
+++ b/python/docs/api.rst
@@ -28,3 +28,10 @@ Connection
 
 .. automodule:: tchannel.connection
     :members:
+
+
+Context
+-------
+
+.. automodule:: tchannel.context
+    :members:

--- a/python/tchannel/connection.py
+++ b/python/tchannel/connection.py
@@ -76,8 +76,8 @@ class Connection(object):
 
         self.requested_version = message.version
 
-    def on_handshake(self, data):
-        frame, message = data
+    def on_handshake(self, context):
+        message = context.message
         if message.message_type != Types.INIT_REQ:
             raise InvalidMessageException(
                 'You need to shake my hand first. Got: %d' %
@@ -105,7 +105,7 @@ class Connection(object):
         return self.await(callback=self.on_handshake_reply)
 
     def on_handshake_reply(self, data):
-        frame, message = data
+        message = data.message
         if message.message_type != Types.INIT_RES:
             raise InvalidMessageException(
                 'Expected handshake response, got %d' %

--- a/python/tchannel/context.py
+++ b/python/tchannel/context.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+
+class Context(object):
+    """Represent a context.
+
+    This includes metadata such as message ID.
+    """
+    __slots__ = (
+        'message_id',
+        'message',
+    )
+
+    def __init__(self, message_id, message):
+        self.message_id = message_id
+        self.message = message

--- a/python/tchannel/frame.py
+++ b/python/tchannel/frame.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from .context import Context
 from .exceptions import ProtocolException
 from .mapping import get_message_class
 from .parser import read_number
@@ -56,8 +57,8 @@ class Frame(object):
         remaining_bytes = message_length - cls.PRELUDE_SIZE
         if remaining_bytes:
             message.parse(stream, remaining_bytes)
-        frame = cls(message=message, message_id=message_id)
-        return frame, message
+        context = Context(message_id=message_id, message=message)
+        return context
 
     def write(self, connection, callback=None):
         """Write a frame out to a connection."""

--- a/python/tchannel/socket.py
+++ b/python/tchannel/socket.py
@@ -31,8 +31,8 @@ class SocketConnection(Connection):
         self.reader = FrameReader(adapted).read()
 
     def handle_calls(self, handler):
-        for frame, message in self.reader:
-            handler(frame, message, connection=self)
+        for call in self.reader:
+            handler(call, connection=self)
 
     def await(self, callback):
         """Decode a full message and return"""

--- a/python/tests/test_frame.py
+++ b/python/tests/test_frame.py
@@ -67,4 +67,4 @@ def test_decode_invalid_message_id(dummy_frame):
 def test_decode_ping(dummy_frame):
     """Verify we can decode a ping message."""
     dummy_frame[2] = Types.PING_REQ
-    frame, message = Frame.decode(BytesIO(dummy_frame))
+    Frame.decode(BytesIO(dummy_frame))

--- a/python/tests/test_socket.py
+++ b/python/tests/test_socket.py
@@ -92,7 +92,7 @@ def test_handle_calls(tchannel_pair):
     class _MyException(Exception):
         pass
 
-    def my_handler(context, message, connection):
+    def my_handler(context, connection):
         raise _MyException()
 
     server, client = tchannel_pair
@@ -107,6 +107,6 @@ def test_finish_connection(tchannel_pair):
     client.ping()
     client._connection._connection.close()
 
-    def _handle(context, message, connection):
+    def _handle(data, connection):
         pass
     server.handle_calls(_handle)

--- a/python/tests/tornado/test_connection.py
+++ b/python/tests/tornado/test_connection.py
@@ -34,8 +34,8 @@ class ConnectionTestCase(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_handle_calls(self):
         """Verify calls are sent to handler properly."""
-        def _handle(data, connection):
-            _, message = data
+        def _handle(call, connection):
+            message = call.message
             # Not a rigorous assertion, but makes sure the data is well-formed.
             assert message.message_type
 


### PR DESCRIPTION
I want to remove the knowledge of Framing from any library/layer outside
of TChannel, similar to how TCP just exposes a stream. Part of this
includes returning a Context object instead of a Frame.

I attached the Message into the context to avoid the awkward tuple unpacking.

@uber/soap