### PR TITLE
Add node linting and dev/release branch updating targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ env:
   - SUBDIR=python
 
 install:
-  - pushd $SUBDIR && make install && popd
+  - make -C $SUBDIR install
 
 script:
-  - cd $SUBDIR && make test_ci
+  - make -C $SUBDIR test_ci
 
 after_success:
   - coveralls

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test_ci test
+.PHONY: install test_ci test lint
 
 .DEFAULT_GOAL := test
 
@@ -9,3 +9,6 @@ test_ci: test
 
 test:
 	npm test
+
+lint:
+	npm run lint

--- a/node/Makefile
+++ b/node/Makefile
@@ -5,7 +5,7 @@
 install:
 	npm install
 
-test_ci:
-	npm test
+test_ci: test
 
-test: test_ci
+test:
+	npm test

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,5 +1,8 @@
 .PHONY: install test_ci test lint
 
+DEV_BRANCH=dev_node
+RELEASE_BRANCH=release_node
+
 .DEFAULT_GOAL := test
 
 install:
@@ -12,3 +15,11 @@ test:
 
 lint:
 	npm run lint
+
+update_dev:
+	# git-subtree is sensitive to user git-config settings...
+	cd ..  && HOME= XDG_CONFIG_HOME= git subtree push --prefix=node . ${DEV_BRANCH}
+
+update_release:
+	# git-subtree is sensitive to user git-config settings...
+	cd .. && HOME= XDG_CONFIG_HOME= git subtree push --prefix=node . ${RELEASE_BRANCH}


### PR DESCRIPTION
Added git-subtree automating targets which update `dev_node` and `release_node` targets respectively.

We can then cut npm release tags off the `release_node` branch, and have internal projects install github references like `uber/tchannel#dev_node`.

Oh plus: we've got lint too, let's expose it.

When the future comes that we're ready to cut a new release tag, we can add tooling in place of `npm version` that writes `node-v*` tags instead.

cc @sectioneight @Raynos 