### PR TITLE
Add error code table and cleanup call_res

### DIFF
--- a/python/tchannel/messages/call_response.py
+++ b/python/tchannel/messages/call_response.py
@@ -10,7 +10,7 @@ class CallResponseMessage(CallRequestMessage):
 
     __slots__ = (
         'flags',
-        'ttl',
+        'code',
 
         # Zipkin-style tracing data
         'span_id',
@@ -18,6 +18,12 @@ class CallResponseMessage(CallRequestMessage):
         'trace_id',
 
         'traceflags',
-        'service',
+
         'headers',
+        'checksum_type',
+        'checksum',
+
+        'arg_1',
+        'arg_2',
+        'arg_3',
     )

--- a/python/tchannel/messages/error.py
+++ b/python/tchannel/messages/error.py
@@ -17,6 +17,16 @@ class ErrorMessage(BaseMessage):
         'message',
     )
 
+    ERROR_CODES = {
+        0x01: 'timeout',
+        0x02: 'cancelled',
+        0x03: 'busy',
+        0x04: 'declined',
+        0x05: 'unexpected',
+        0x06: 'bad request',
+        0xff: 'fatal protocol error'
+    }
+
     def parse(self, payload, size):
         self.code = read_number(payload, 1)
         self.original_message_id = read_number(payload, 4)
@@ -26,3 +36,7 @@ class ErrorMessage(BaseMessage):
         out.extend(write_number(self.code, 1))
         out.extend(write_number(self.original_message_id, 4))
         write_variable_length_key(out, self.message, 2)
+
+    def error_name(self):
+        """Get a friendly error message."""
+        return self.ERROR_CODES.get(self.code)

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -140,3 +140,10 @@ def test_parse_message(message_class, byte_stream):
     """Verify all messages parse properly."""
     message = message_class()
     message.parse(BytesIO(byte_stream), len(byte_stream))
+
+
+def test_error_message_name():
+    """Smoke test the error dictionary."""
+    error = messages.ErrorMessage()
+    error.code = 0x03
+    assert error.error_name() == 'busy'


### PR DESCRIPTION
Call response now matches the fields in the most recent protocol
document. Error codes are added and translated in ErrorMessage.

@uber/soap