### PR TITLE
Provide explicit request/response objects

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -411,7 +411,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     self.handler.on('call.incoming.request', function onCallRequest(req) {
         var handler = self.channel.getEndpointHandler(req.name);
         var res = self.handler.buildOutgoingResponse(req);
-        self.runInOp(handler, req, res.send.bind(res));
+        self.runInOp(handler, req, res);
     });
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
@@ -717,7 +717,7 @@ TChannelConnection.prototype.send = function send(options, arg1, arg2, arg3, cal
 };
 /* jshint maxparams:4 */
 
-TChannelConnection.prototype.runInOp = function runInOp(handler, options, sendResponseFrame) {
+TChannelConnection.prototype.runInOp = function runInOp(handler, options, res) {
     var self = this;
     var id = options.id;
     self.inPending++;
@@ -732,7 +732,7 @@ TChannelConnection.prototype.runInOp = function runInOp(handler, options, sendRe
             });
             return;
         }
-        sendResponseFrame(err, res1, res2);
+        res.send(err, res1, res2);
         delete self.inOps[id];
         self.inPending--;
     }

--- a/node/index.js
+++ b/node/index.js
@@ -407,6 +407,10 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         }
     });
 
+    self.handler.on('call.incoming.error', function onCallError(err) {
+        self.completeOutOp(err.originalId, err, null, null);
+    });
+
     self.socket.setNoDelay(true);
 
     self.socket.on('error', function onSocketError(err) {

--- a/node/index.js
+++ b/node/index.js
@@ -411,9 +411,6 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         // fulfill to
         runInOp: function runInOp(handler, options, sendResponseFrame) {
             self.runInOp(handler, options, sendResponseFrame);
-        },
-        completeOutOp: function completeOutOp(err, id, res1, res2) {
-            self.completeOutOp(id, err, res1, res2);
         }
     });
 

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -1,0 +1,108 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var emptyTracing = Buffer(25); // TODO: proper tracing object
+var emptyBuffer = Buffer(0);
+
+// TODO: provide streams for arg2/3
+
+function TChannelIncomingRequest(id, options) {
+    if (!(this instanceof TChannelIncomingRequest)) {
+        return new TChannelIncomingRequest(id, options);
+    }
+    options = options || {};
+    var self = this;
+    self.id = id || 0;
+    self.ttl = options.ttl || 0;
+    self.tracing = options.tracing || emptyTracing;
+    self.service = options.service || '';
+    self.headers = options.headers || {};
+    self.checksumType = options.checksumType || 0;
+    self.name = options.name || '';
+    self.arg2 = options.arg2 || emptyBuffer;
+    self.arg3 = options.arg3 || emptyBuffer;
+}
+
+function TChannelIncomingResponse(id, options) {
+    if (!(this instanceof TChannelIncomingResponse)) {
+        return new TChannelIncomingResponse(id, options);
+    }
+    options = options || {};
+    var self = this;
+    self.id = id || 0;
+    self.code = options.code || 0;
+    self.arg1 = options.arg1 || emptyBuffer;
+    self.arg2 = options.arg2 || emptyBuffer;
+    self.arg3 = options.arg3 || emptyBuffer;
+}
+
+TChannelIncomingResponse.prototype.isOK = function isOK() {
+    var self = this;
+    return self.code === 0; // TODO: probably okay, but a bit jank
+};
+
+function TChannelOutgoingRequest(id, options, sendFrame) {
+    if (!(this instanceof TChannelOutgoingRequest)) {
+        return new TChannelOutgoingRequest(id, options, sendFrame);
+    }
+    options = options || {};
+    var self = this;
+    self.id = id || 0;
+    self.ttl = options.ttl || 0;
+    self.tracing = options.tracing || emptyTracing;
+    self.service = options.service || '';
+    self.headers = options.headers || {};
+    self.checksumType = options.checksumType || 0;
+    self.sendFrame = sendFrame;
+}
+
+TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3) {
+    var self = this;
+    self.sendFrame(arg1, arg2, arg3);
+};
+
+function TChannelOutgoingResponse(id, options, sendFrame) {
+    if (!(this instanceof TChannelOutgoingResponse)) {
+        return new TChannelOutgoingResponse(id, options, sendFrame);
+    }
+    options = options || {};
+    var self = this;
+    self.id = id || 0;
+    self.code = options.code || 0;
+    self.tracing = options.tracing || emptyTracing;
+    self.headers = options.headers || {};
+    self.checksumType = options.checksumType || 0;
+    self.name = options.name || '';
+    self.arg2 = options.arg2 || emptyBuffer;
+    self.arg3 = options.arg3 || emptyBuffer;
+    self.sendFrame = sendFrame;
+}
+
+TChannelOutgoingResponse.prototype.send = function send(err, res1, res2) {
+    var self = this;
+    self.sendFrame(err, res1, res2);
+};
+
+module.exports.IncomingRequest = TChannelIncomingRequest;
+module.exports.IncomingResponse = TChannelIncomingResponse;
+module.exports.OutgoingRequest = TChannelOutgoingRequest;
+module.exports.OutgoingResponse = TChannelOutgoingResponse;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -26,6 +26,7 @@ var util = require('util');
 
 var TChannelOutgoingResponse = require('../reqres').OutgoingResponse;
 var TChannelIncomingRequest = require('../reqres').IncomingRequest;
+var TChannelIncomingResponse = require('../reqres').IncomingResponse;
 var v2 = require('./index');
 
 module.exports = TChannelV2Handler;
@@ -147,12 +148,8 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
     if (self.remoteHostPort === null) {
         return callback(new Error('call response before init response')); // TODO typed error
     }
-    var id = resFrame.id;
-    var code = resFrame.body.code;
-    var arg1 = resFrame.body.arg1;
-    var arg2 = resFrame.body.arg2;
-    var arg3 = resFrame.body.arg3;
-    if (code === v2.CallResponse.Codes.OK) {
+    var res = self.buildIncomingResponse(resFrame);
+    if (res.isOK()) {
         self.completeOutOp(null, id, arg2, arg3);
     } else {
         self.completeOutOp(TChannelApplicationError({
@@ -282,6 +279,16 @@ TChannelV2Handler.prototype.buildIncomingRequest = function buildIncomingRequest
         arg3: reqFrame.body.arg3
     });
     return req;
+};
+
+TChannelV2Handler.prototype.buildIncomingResponse = function buildIncomingResponse(resFrame) {
+    var res = TChannelIncomingResponse(resFrame.id, {
+        code: resFrame.body.code,
+        arg1: resFrame.body.arg1,
+        arg2: resFrame.body.arg2,
+        arg3: resFrame.body.arg3
+    });
+    return res;
 };
 
 function isError(obj) {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -46,7 +46,6 @@ function TChannelV2Handler(channel, options) {
         objectMode: true
     });
     self.channel = channel;
-    self.runInOp = options.runInOp;
     self.remoteHostPort = null; // filled in by identify message
     self.lastSentFrameId = 0;
 }
@@ -124,9 +123,7 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         return callback(new Error('call request before init request')); // TODO typed error
     }
     var req = self.buildIncomingRequest(reqFrame);
-    var res = self.buildOutgoingResponse(req);
-    var handler = self.channel.getEndpointHandler(req.name);
-    self.runInOp(handler, req, res.send.bind(res));
+    self.emit('call.incoming.request', req);
     callback();
 };
 

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -46,11 +46,7 @@ function TChannelV2Handler(channel, options) {
         objectMode: true
     });
     self.channel = channel;
-    // TODO: may be better suited to pull out an operation collection
-    // abstraction and then encapsulate through that rather than this
-    // run/complete approach
     self.runInOp = options.runInOp;
-    self.completeOutOp = options.completeOutOp;
     self.remoteHostPort = null; // filled in by identify message
     self.lastSentFrameId = 0;
 }

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -175,7 +175,7 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
         // fatal error not associated with a prior frame
         callback(err);
     } else {
-        self.completeOutOp(err, id, null, null);
+        self.completeOutOp(err, err.originalId, null, null);
         callback();
     }
 };

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -37,15 +37,6 @@ var TChannelUnhandledFrameTypeError = TypedError({
     typeCode: null
 });
 
-var TChannelApplicationError = TypedError({
-    type: 'tchannel.application',
-    message: 'tchannel application error code {code}',
-    code: null,
-    arg1: null,
-    arg2: null,
-    arg3: null
-});
-
 function TChannelV2Handler(channel, options) {
     if (!(this instanceof TChannelV2Handler)) {
         return new TChannelV2Handler(channel, options);
@@ -149,16 +140,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
         return callback(new Error('call response before init response')); // TODO typed error
     }
     var res = self.buildIncomingResponse(resFrame);
-    if (res.isOK()) {
-        self.completeOutOp(null, id, arg2, arg3);
-    } else {
-        self.completeOutOp(TChannelApplicationError({
-            code: code,
-            arg1: arg1,
-            arg2: arg2,
-            arg3: arg3
-        }), id, arg2, null);
-    }
+    self.emit('call.incoming.response', res);
     callback();
 };
 

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -175,7 +175,7 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
         // fatal error not associated with a prior frame
         callback(err);
     } else {
-        self.completeOutOp(err, err.originalId, null, null);
+        self.emit('call.incoming.error', err);
         callback();
     }
 };


### PR DESCRIPTION
Reviewers: @Raynos @kriskowal 

- TChannelV2Handler is now coupled to TChannelConnection only by a loose event observer pattern
  - event `call.incoming.request` with a `req` object (`req :: TChannelIncomingRequest` defined in `reqres`)
  - event `call.incoming.response` with a `res` object (`res :: TChannelIncomingResponse` defined in `reqres`)
  - event `call.incoming.error` with an `err` object (`err :: {type, message, errorCode, originalId}` defined in `v2/error_response`)
- TChannelConnection then uses these events to drive completeOutOp and runInOp as before
- TChannelConnection uses `TChannelV2Handler.buildOutgoingResponse(req)` to get a `res :: TChannelOutgoingResponse` object