### PR TITLE
.send() -> .request().send()

### DIFF
--- a/node/MIGRATION.md
+++ b/node/MIGRATION.md
@@ -1,0 +1,18 @@
+# Migration
+
+# Upgrading from 1.x to 2.x
+
+## .send() -> .request().send()
+
+Before:
+```
+chan
+    .send(options, a1, a2, a3, cb);
+```
+
+After:
+```
+chan
+    .request(options, cb)
+    .send(a1, a2, a3);
+```

--- a/node/docs.jsig
+++ b/node/docs.jsig
@@ -14,11 +14,19 @@ type Timers : {
 type IP : String
 type HostInfo : String
 type TChannelValue :
-    Buffer | String | Object | null | undefined | Any
+    Buffer | String | null | undefined
 
 type TChannelConnection : {
     direction: "in" | "out",
     remoteAddr: HostInfo
+}
+
+TChannelOutgoingRequest : {
+    send: (
+        arg1: Buffer | String,
+        arg2: TChannelValue,
+        arg3: TChannelValue
+    ) => void
 }
 
 type TChannel : {
@@ -32,20 +40,17 @@ type TChannel : {
             res2: TChannelValue
         ) => void
     ) => void) => void,
-    send: (
+    request: (
         options: {
             host: HostInfo,
             timeout?: Number
         },
-        arg1: Buffer | String,
-        arg2: TChannelValue,
-        arg3: TChannelValue,
         cb: (
             err?: Error,
             res1: Buffer | null,
             res2: Buffer | null
         ) => void
-    ) => void,
+    ) => TChannelOutgoingRequest,
     listen: (port:Number, hostname:String, Callback<Error>?) => void,
     close: (Callback<Error>) => void,
 

--- a/node/examples/example1.js
+++ b/node/examples/example1.js
@@ -40,12 +40,16 @@ var listening = ready(function (err) {
         throw err;
     }
 
-    client.send({host: '127.0.0.1:4040'}, 'func 1', "arg 1", "arg 2", function (err, res1, res2) {
-        console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
-    });
-    client.send({host: '127.0.0.1:4040'}, 'func 2', "arg 1", "arg 2", function (err, res1, res2) {
-        console.log('err res: ' + err.message);
-    });
+    client
+        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
+            console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
+        })
+        .send('func 1', "arg 1", "arg 2");
+    client
+        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
+            console.log('err res: ' + err.message);
+        })
+        .send('func 2', "arg 1", "arg 2");
 
 });
 

--- a/node/index.js
+++ b/node/index.js
@@ -709,11 +709,13 @@ TChannelConnection.prototype.send = function send(options, arg1, arg2, arg3, cal
     // if (self.outOps[id]) {
     //  throw new Error('duplicate frame id in flight'); // TODO typed error
     // }
-
-    var id = self.handler.sendRequestFrame(options, arg1, arg2, arg3);
+    var req = self.handler.buildOutgoingRequest(options);
+    var id = req.id;
     self.outOps[id] = new TChannelClientOp(
         options, self.channel.now(), callback);
     self.pendingCount++;
+    req.send(arg1, arg2, arg3);
+    return req;
 };
 /* jshint maxparams:4 */
 

--- a/node/index.js
+++ b/node/index.js
@@ -272,7 +272,15 @@ TChannel.prototype.addPeer = function addPeer(hostPort, connection) {
 };
 
 /* jshint maxparams:5 */
+// TODO: deprecated, callers should use .request directly
 TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
+    var self = this;
+    var req = self.request(options, callback);
+    req.send(arg1, arg2, arg3);
+};
+/* jshint maxparams:4 */
+
+TChannel.prototype.request = function send(options, callback) {
     var self = this;
     if (self.destroyed) {
         throw new Error('cannot send() to destroyed tchannel'); // TODO typed error
@@ -284,9 +292,8 @@ TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
     }
 
     var peer = self.getOutConnection(dest);
-    peer.send(options, arg1, arg2, arg3, callback);
+    return peer.request(options, callback);
 };
-/* jshint maxparams:4 */
 
 TChannel.prototype.getOutConnection = function getOutConnection(dest) {
     var self = this;
@@ -698,15 +705,6 @@ TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg
     self.outPending--;
     op.callback(err, arg1, arg2);
 };
-
-/* jshint maxparams:5 */
-// TODO: deprecated, callers should use .request directly
-TChannelConnection.prototype.send = function send(options, arg1, arg2, arg3, callback) {
-    var self = this;
-    var req = self.request(options, callback);
-    req.send(arg1, arg2, arg3);
-};
-/* jshint maxparams:4 */
 
 // create a request
 TChannelConnection.prototype.request = function request(options, callback) {

--- a/node/test/emits-endpoint.js
+++ b/node/test/emits-endpoint.js
@@ -42,9 +42,11 @@ allocCluster.test('emits endpoint event', 2, {
         endpoints.push(name);
     });
 
-    two.send({
-        host: cluster.hosts[0]
-    }, '/hello', '', '', onHello);
+    two
+        .request({
+            host: cluster.hosts[0]
+        }, onHello)
+        .send('/hello', '', '');
 
     function onHello(err, res1, res2) {
         assert.ifError(err);

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -187,7 +187,9 @@ allocCluster.test('register() with different results', 2, function t(cluster, as
 });
 
 function sendCall(channel, opts, op, cb) {
-    channel.send(opts, op, null, null, onResult);
+    channel
+        .request(opts, onResult)
+        .send(op, null, null);
 
     function onResult(err, res1, res2) {
         cb(null, {

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -31,10 +31,12 @@ allocCluster.test('does not leak inOps', 2, {
 
     one.register('/timeout', timeout);
 
-    two.send({
-        host: cluster.hosts[0],
-        timeout: 100
-    }, '/timeout', 'h', 'b', onTimeout);
+    two
+        .request({
+            host: cluster.hosts[0],
+            timeout: 100
+        }, onTimeout)
+        .send('/timeout', 'h', 'b');
 
     function onTimeout(err) {
         two.timeoutCheckInterval = 99999;

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -24,7 +24,7 @@ var parallel = require('run-parallel');
 var Buffer = require('buffer').Buffer;
 var allocCluster = require('./lib/alloc-cluster.js');
 
-allocCluster.test('send() to a server', 2, function t(cluster, assert) {
+allocCluster.test('request().send() to a server', 2, function t(cluster, assert) {
     var one = cluster.channels[0];
     var two = cluster.channels[1];
     var hostOne = cluster.hosts[0];
@@ -174,7 +174,9 @@ allocCluster.test('send() to a server', 2, function t(cluster, assert) {
 /*eslint max-params: [2, 6] */
 /*jshint maxparams: 6 */
 function sendRes(channel, opts, op, h, b, cb) {
-    channel.send(opts, op, h, b, onResult);
+    channel
+        .request(opts, onResult)
+        .send(op, h, b);
 
     function onResult(err, res1, res2) {
         cb(err, {

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -34,21 +34,28 @@ allocCluster.test('requests will timeout', 2, {
     one.register('/normal-proxy', normalProxy);
     one.register('/timeout', timeout);
 
-    two.send({
-        host: hostOne,
-        timeout: 1000
-    }, '/normal-proxy', 'h', 'b', function onResp(err, h, b) {
+    two
+        .request({
+            host: hostOne,
+            timeout: 1000
+        }, onResp)
+        .send('/normal-proxy', 'h', 'b');
+
+    function onResp(err, h, b) {
         assert.ifError(err);
 
         assert.equal(String(h), 'h');
         assert.equal(String(b), 'b');
 
-        two.send({
-            host: hostOne,
-            timeout: 1000
-        }, '/timeout', 'h', 'b', onTimeout);
+        two
+            .request({
+                host: hostOne,
+                timeout: 1000
+            }, onTimeout)
+            .send('/timeout', 'h', 'b');
+
         timers.advance(2500);
-    });
+    }
 
     function onTimeout(err) {
         assert.equal(err && err.message, 'timed out', 'expected timeout error');

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -223,15 +223,9 @@ TChannelV2Handler.prototype.sendResponseFrame = function sendResponseFrame(res, 
 TChannelV2Handler.prototype.buildOutgoingRequest = function buildOutgoingRequest(options) {
     var self = this;
     var id = self.nextFrameId();
-    // TODO: provide some sort of channel default for "service"
-    // TODO: generate tracing if empty?
-    // TODO: refactor callers
-    if (options.checksum === undefined || options.checksum === null) {
+    if (options.checksumType === undefined || options.checksumType === null) {
         options.checksumType = v2.Checksum.Types.FarmHash32;
-    } else {
-        options.checksumType = options.checksum;
     }
-    options.ttl = options.timeout || 1; // TODO: better default, support for dynamic
     var req = TChannelOutgoingRequest(id, options, sendRequestFrame);
     return req;
     function sendRequestFrame(arg1, arg2, arg3) {


### PR DESCRIPTION
Non breaking move forward which uses TChannelOutgoingRequest to send client calls.

Deprecates the old 5-arg .send in lieu of `.request(opt, cb).send(a1, a2, a3)`.

reviewers: @Raynos @kriskowal 