### PR TITLE
create proper server socket error

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -28,9 +28,9 @@ var globalNow = Date.now;
 var globalRandom = Math.random;
 var net = require('net');
 var format = require('util').format;
-var inspect = require('util').inspect;
 var Spy = require('./v2/spy');
 var TypedError = require('error/typed');
+var WrappedError = require('error/wrapped');
 
 var dumpEnabled = /\btchannel_dump\b/.test(process.env.NODE_DEBUG || '');
 
@@ -41,6 +41,13 @@ var TChannelApplicationError = TypedError({
     arg1: null,
     arg2: null,
     arg3: null
+});
+
+var TChannelListenError = WrappedError({
+    type: 'tchannel.server.listen-failed',
+    message: 'tchannel: {origMessage}',
+    requestedPort: null,
+    host: null
 });
 
 function TChannel(options) {
@@ -105,15 +112,20 @@ function TChannel(options) {
         }
     });
     self.serverSocket.on('error', function onServerSocketError(err) {
-        var serverError = new Error('tchannel: ' + err.message);
-        serverError.code = err.code;
-        serverError.errno = err.errno;
-        serverError.syscall = err.syscall;
-        serverError.requestedPort = self.requestedPort;
-        serverError.host = self.host;
+        if (err.code === 'EADDRINUSE') {
+            err = TChannelListenError(err, {
+                requestedPort: self.requestedPort,
+                host: self.host
+            });
+        }
 
-        self.logger.error(self.hostPort + ' server socket error: ' + inspect(serverError));
-        self.emit('error', serverError);
+        self.logger.error('server socket error', {
+            err: err,
+            requestedPort: self.requestedPort,
+            host: self.host,
+            hostPort: self.hostPort || null
+        });
+        self.emit('error', err);
     });
     self.serverSocket.on('close', function onServerSocketClose() {
         self.logger.warn('server socket close');

--- a/node/index.js
+++ b/node/index.js
@@ -105,7 +105,15 @@ function TChannel(options) {
         }
     });
     self.serverSocket.on('error', function onServerSocketError(err) {
-        self.logger.error(self.hostPort + ' server socket error: ' + inspect(err));
+        var serverError = new Error('tchannel: ' + err.message);
+        serverError.code = err.code;
+        serverError.errno = err.errno;
+        serverError.syscall = err.syscall;
+        serverError.requestedPort = self.requestedPort;
+        serverError.host = self.host;
+
+        self.logger.error(self.hostPort + ' server socket error: ' + inspect(serverError));
+        self.emit('error', serverError);
     });
     self.serverSocket.on('close', function onServerSocketClose() {
         self.logger.warn('server socket close');

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -29,3 +29,4 @@ require('./tchannel.js');
 require('./regression-inOps-leak.js');
 require('./emits-endpoint.js');
 require('./v2/index.js');
+require('./regression-listening-on-used-port.js');

--- a/node/test/regression-listening-on-used-port.js
+++ b/node/test/regression-listening-on-used-port.js
@@ -1,0 +1,34 @@
+var test = require('tape');
+
+var TChannel = require('../index.js');
+
+test('listening on a used port', function t(assert) {
+    var otherServer = TChannel();
+    var server = TChannel();
+
+    otherServer.once('listening', onPortAllocated);
+    otherServer.listen(0, 'localhost');
+
+    function onPortAllocated() {
+        server.on('error', onError);
+
+        server.listen(otherServer.address().port, 'localhost');
+    }
+
+    function onError(err) {
+        assert.notEqual(-1, err.message
+            .indexOf('tchannel: listen EADDRINUSE'));
+        assert.equal(err.type, 'tchannel.server.listen-failed');
+        assert.equal(err.requestedPort,
+            otherServer.address().port);
+        assert.equal(err.host, 'localhost');
+        assert.equal(err.code, 'EADDRINUSE');
+        assert.equal(err.errno, 'EADDRINUSE');
+        assert.equal(err.syscall, 'listen');
+        assert.notEqual(-1, err.origMessage
+            .indexOf('listen EADDRINUSE'));
+
+        otherServer.close();
+        assert.end();
+    }
+});


### PR DESCRIPTION
TChannel used to eat server errors and much sadness would be
had when you tried to figure out why your tests do not work.

My emitting an error we have insight into what's going on.

```
AUTOBAHN 30809: error: null server socket error: { [Error: tchannel: listen EADDRINUSE]
  code: 'EADDRINUSE',
  errno: 'EADDRINUSE',
  syscall: 'listen',
  requestedPort: 36431,
  host: '10.32.163.144' } ~ null

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: tchannel: listen EADDRINUSE
    at Server.onServerSocketError (/home/raynos/uber/autobahn/node_modules/tchannel/index.js:98:27)
    at Server.EventEmitter.emit (events.js:95:17)
    at net.js:1046:12
    at process._tickDomainCallback (node.js:459:13)
```

Above is an example of the print statement of this branch.

Here we see what the failure is and because we create a new error we see a useful stack trace. Also by prefixing the EADDRINUSE with `tchannel` we know its a `listen()` failure from a tchannel server.

reviewers: @jcorbin @kriskowal 