### PR TITLE
Rework the request sending api

### DIFF
--- a/node/MIGRATION.md
+++ b/node/MIGRATION.md
@@ -10,9 +10,22 @@ chan
     .send(options, a1, a2, a3, cb);
 ```
 
-After:
+After (simple):
 ```
 chan
-    .request(options, cb)
+    .request(options)
+    .send(a1, a2, a3, cb);
+```
+
+After (if needed/useful):
+```
+chan
+    .request(options)
+    .on('error', function onError(err) {
+        console.error('too bad:', err);
+    })
+    .on('response', function onResponse(res) {
+        console.log('got:', res.arg2, res.arg3);
+    })
     .send(a1, a2, a3);
 ```

--- a/node/README.md
+++ b/node/README.md
@@ -35,15 +35,15 @@ var listening = ready(function (err) {
         cb(new Error('it failed'));
     });
     client
-        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
-            console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
-        })
-        .send('func 1', "arg 1", "arg 2");
+        .request({host: '127.0.0.1:4040'})
+        .send('func 1', "arg 1", "arg 2", function (err, res) {
+            console.log('normal res: ' + res.arg2.toString() + ' ' + res.arg3.toString());
+        });
     client
-        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
+        .request({host: '127.0.0.1:4040'})
+        .send('func 2', "arg 1", "arg 2", function (err, res) {
             console.log('err res: ' + err.message);
-        })
-        .send('func 2', "arg 1", "arg 2");
+        });
 
 });
 
@@ -122,7 +122,13 @@ tchannel : (options: {
 }
 
 tchannelRequest : {
-    send: (arg1: Buffer|String, arg2: Buffer|String, arg3: Buffer|String) => void
+    on: (name: String, listener: Function) => void,
+    send: (
+        arg1: Buffer|String,
+        arg2: Buffer|String,
+        arg3: Buffer|String,
+        cb: ?Function
+    ) => void
 }
 
 ```
@@ -297,10 +303,12 @@ request: (
 ) => tchannelRequest
 
 tchannelRequest : {
+    on: (name: String, listener: Function) => void,
     send: (
         arg1: Buffer | String,
         arg2: Buffer | String,
-        arg3: Buffer | String
+        arg3: Buffer | String,
+        cb: ?Function
     ) => void
 }
 

--- a/node/benchmarks/multi_bench.js
+++ b/node/benchmarks/multi_bench.js
@@ -81,7 +81,7 @@ Test.prototype.new_client = function (id) {
     new_client.listen(port, "127.0.0.1", function (err) {
         // sending a ping to pre-connect the socket
         new_client
-            .request({host: '127.0.0.1:4040'}, noop)
+            .request({host: '127.0.0.1:4040'})
             .send('ping', null, null);
 
         new_client.on("identified", function (peer) {
@@ -146,10 +146,10 @@ Test.prototype.send_next = function () {
                 benchHeader2: 'bench value two',
                 benchHeader3: 'bench value three'
             }
-        }, done)
-        .send(this.arg1, this.arg2, this.arg3);
+        })
+        .send(this.arg1, this.arg2, this.arg3, done);
 
-    function done(err, res1, res2) {
+    function done(err, res) {
         if (err) {
             throw err;
         }
@@ -230,6 +230,3 @@ function next(i, j, done) {
 next(0, 0, function() {
     process.exit(0);
 });
-
-function noop() {
-}

--- a/node/examples/example1.js
+++ b/node/examples/example1.js
@@ -41,15 +41,15 @@ var listening = ready(function (err) {
     }
 
     client
-        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
-            console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
-        })
-        .send('func 1', "arg 1", "arg 2");
+        .request({host: '127.0.0.1:4040'})
+        .send('func 1', "arg 1", "arg 2", function (err, res) {
+            console.log('normal res: ' + res.arg2.toString() + ' ' + res.arg3.toString());
+        });
     client
-        .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
+        .request({host: '127.0.0.1:4040'})
+        .send('func 2', "arg 1", "arg 2", function (err, res) {
             console.log('err res: ' + err.message);
-        })
-        .send('func 2', "arg 1", "arg 2");
+        });
 
 });
 

--- a/node/examples/example2.js
+++ b/node/examples/example2.js
@@ -46,20 +46,20 @@ var listening = ready(function (err) {
     async.series([
         function pingOne(done) {
             client
-                .request({host: '127.0.0.1:4040'}, function (err, res1, res2) {
-                    console.log('ping res from client: ' + res1 + ' ' + res2);
+                .request({host: '127.0.0.1:4040'})
+                .send('ping', null, null, function (err, res) {
+                    console.log('ping res from client: ' + res.arg2 + ' ' + res.arg3);
                     done();
-                })
-                .send('ping', null, null);
+                });
         },
 
         function pingTwo(done) {
             server
-                .request({host: '127.0.0.1:4041'}, function (err, res1, res2) {
-                    console.log('ping res server: ' + res1 + ' ' + res2);
+                .request({host: '127.0.0.1:4041'})
+                .send('ping', null, null, function (err, res) {
+                    console.log('ping res server: ' + res.arg2 + ' ' + res.arg3);
                     done();
-                })
-                .send('ping', null, null);
+                });
         }
 
     ], function() {});

--- a/node/examples/send_test.js
+++ b/node/examples/send_test.js
@@ -27,30 +27,30 @@ var client2 = new TChannel({timeoutCheckInterval: 100, timeoutFuzz: 5});
 
 // normal response
 server.register('func 1', function (arg1, arg2, peerInfo, cb) {
-	console.log('func 1 responding immediately');
-	cb(null, 'result', 'indeed it did');
+    console.log('func 1 responding immediately');
+    cb(null, 'result', 'indeed it did');
 });
 // err response
 server.register('func 2', function (arg1, arg2, peerInfo, cb) {
-	cb(new Error('it failed'));
+    cb(new Error('it failed'));
 });
 // slow response
 server.register('func 3', function (arg1, arg2, peerInfo, cb) {
-	console.log('func 3 starting response timer');
-	setTimeout(function () {
-		console.log('func 3 responding now');
-		cb(null, 'slow result', 'sorry for the delay');
-	}, 1000);
+    console.log('func 3 starting response timer');
+    setTimeout(function () {
+        console.log('func 3 responding now');
+        cb(null, 'slow result', 'sorry for the delay');
+    }, 1000);
 });
 
 // bidirectional messages
 server.register('ping', function onPing(arg1, arg2, peerInfo, pingCb) {
-	console.log('server got ping req from ' + peerInfo);
-	pingCb(null, 'pong', null);
+    console.log('server got ping req from ' + peerInfo);
+    pingCb(null, 'pong', null);
 });
 client.register('ping', function onPing(arg1, arg2, peerInfo, pingCb) {
-	console.log('client got ping req from ' + peerInfo);
-	pingCb(null, 'pong', null);
+    console.log('client got ping req from ' + peerInfo);
+    pingCb(null, 'pong', null);
 });
 
 var ready = CountedReadySignal(3);
@@ -87,16 +87,16 @@ client.listen(4041, '127.0.0.1', ready.signal);
 client2.listen(4042, '127.0.0.1', ready.signal);
 
 function formatRes(err, res1, res2) {
-	var ret = [];
+    var ret = [];
 
-	if (err) {
-		ret.push('err=' + err.message);
-	}
-	if (res1) {
-		ret.push('res1=' + res1.toString());
-	}
-	if (res2) {
-		ret.push('res2=' + res2.toString());
-	}
-	return ret.join(' ');
+    if (err) {
+        ret.push('err=' + err.message);
+    }
+    if (res1) {
+        ret.push('res1=' + res1.toString());
+    }
+    if (res2) {
+        ret.push('res2=' + res2.toString());
+    }
+    return ret.join(' ');
 }

--- a/node/examples/send_test.js
+++ b/node/examples/send_test.js
@@ -57,28 +57,40 @@ var ready = CountedReadySignal(3);
 
 var listening = ready(function (err) {
 
-    client.send({host: '127.0.0.1:4040'}, 'ping', null, null, function (err, res1, res2) {
-        console.log('ping res from client: ' + res1 + ' ' + res2);
-        server.send({host: '127.0.0.1:4041'}, 'ping', null, null, function (err, res1, res2) {
-            console.log('ping res server: ' + res1 + ' ' + res2);
+    client
+        .request({host: '127.0.0.1:4040'})
+        .send('ping', null, null, function (err, res) {
+            console.log('ping res from client: ' + res.arg2 + ' ' + res.arg3);
+            server
+                .request({host: '127.0.0.1:4041'})
+                .send('ping', null, null, function (err, res) {
+                    console.log('ping res server: ' + res.arg2 + ' ' + res.arg3);
+                });
         });
-    });
 
     // very aggressive settings. Not recommended for real life.
-    client2.send({host: '127.0.0.1:4040', timeout: 500}, 'func 3', 'arg2', 'arg3', function (err, res1, res2) {
-        console.log('2 slow res: ' + formatRes(err, res1, res2));
-        client2.send({host: '127.0.0.1:4040', timeout: 500}, 'func 3', 'arg2', 'arg3', function (err, res1, res2) {
-            console.log('3 slow res: ' + formatRes(err, res1, res2));
+    client2
+        .request({host: '127.0.0.1:4040', timeout: 500})
+        .send('func 3', 'arg2', 'arg3', function (err, res) {
+            console.log('2 slow res: ' + formatRes(err, res));
+            client2
+                .request({host: '127.0.0.1:4040', timeout: 500})
+                .send('func 3', 'arg2', 'arg3', function (err, res) {
+                    console.log('3 slow res: ' + formatRes(err, res));
+                });
+
+            client2
+                .request({host: '127.0.0.1:4040', timeout: 500})
+                .send('func 3', 'arg2', 'arg3', function (err, res) {
+                    console.log('4 slow res: ' + formatRes(err, res));
+                });
         });
 
-        client2.send({host: '127.0.0.1:4040', timeout: 500}, 'func 3', 'arg2', 'arg3', function (err, res1, res2) {
-            console.log('4 slow res: ' + formatRes(err, res1, res2));
+    client2
+        .request({host: '127.0.0.1:4040', timeout: 500})
+        .send('func 1', 'arg2', 'arg3', function (err, res) {
+            console.log('1 fast res: ' + formatRes(err, res));
         });
-    });
-
-    client2.send({host: '127.0.0.1:4040', timeout: 500}, 'func 1', 'arg2', 'arg3', function (err, res1, res2) {
-        console.log('1 fast res: ' + formatRes(err, res1, res2));
-    });
 
 });
 
@@ -86,17 +98,17 @@ server.listen(4040, '127.0.0.1', ready.signal);
 client.listen(4041, '127.0.0.1', ready.signal);
 client2.listen(4042, '127.0.0.1', ready.signal);
 
-function formatRes(err, res1, res2) {
+function formatRes(err, res) {
     var ret = [];
 
     if (err) {
         ret.push('err=' + err.message);
     }
-    if (res1) {
-        ret.push('res1=' + res1.toString());
+    if (res.arg2) {
+        ret.push('arg2=' + res.arg2.toString());
     }
-    if (res2) {
-        ret.push('res2=' + res2.toString());
+    if (res.arg3) {
+        ret.push('arg3=' + res.arg3.toString());
     }
     return ret.join(' ');
 }

--- a/node/index.js
+++ b/node/index.js
@@ -627,7 +627,8 @@ TChannelConnection.prototype.checkOutOpsForTimeout = function checkOutOpsForTime
 TChannelConnection.prototype.onReqTimeout = function onReqTimeout(op) {
     var self = this;
     op.timedOut = true;
-    op.callback(new Error('timed out'), null, null); // TODO typed error
+    op.req.emit('error', new Error('timed out')); // TODO typed error
+    // TODO: why don't we pop the op?
     self.lastTimeoutTime = self.channel.now();
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -750,9 +750,9 @@ TChannelConnection.prototype.runInOp = function runInOp(handler, req, res) {
 };
 
 /* jshint maxparams:6 */
-function TChannelServerOp(connection, handler, start, options, callback) {
+function TChannelServerOp(connection, handler, start, req, callback) {
     var self = this;
-    self.options = options;
+    self.req = req;
     self.connection = connection;
     self.logger = connection.logger;
     self.handler = handler;
@@ -761,7 +761,7 @@ function TChannelServerOp(connection, handler, start, options, callback) {
     self.callback = callback;
     self.responseSent = false;
     process.nextTick(function runHandler() {
-        self.handler(self.options.arg2, self.options.arg3, connection.remoteName, sendResponse);
+        self.handler(self.req.arg2, self.req.arg3, connection.remoteName, sendResponse);
     });
     function sendResponse(err, res1, res2) {
         self.sendResponse(err, res1, res2);

--- a/node/index.js
+++ b/node/index.js
@@ -692,7 +692,7 @@ TChannelConnection.prototype.onFrame = function onFrame(/* frame */) {
     }
 };
 
-TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg1, arg2) {
+TChannelConnection.prototype.popOutOp = function popOutOp(id) {
     var self = this;
     var op = self.outOps[id];
     if (!op) {
@@ -703,6 +703,12 @@ TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg
     }
     delete self.outOps[id];
     self.outPending--;
+    return op;
+};
+
+TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg1, arg2) {
+    var self = this;
+    var op = self.popOutOp(id);
     op.callback(err, arg1, arg2);
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -281,7 +281,7 @@ TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
 };
 /* jshint maxparams:4 */
 
-TChannel.prototype.request = function send(options, callback) {
+TChannel.prototype.request = function send(options) {
     var self = this;
     if (self.destroyed) {
         throw new Error('cannot send() to destroyed tchannel'); // TODO typed error
@@ -293,7 +293,7 @@ TChannel.prototype.request = function send(options, callback) {
     }
 
     var peer = self.getOutConnection(dest);
-    return peer.request(options, callback);
+    return peer.request(options);
 };
 
 TChannel.prototype.getOutConnection = function getOutConnection(dest) {
@@ -717,7 +717,7 @@ TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg
 };
 
 // create a request
-TChannelConnection.prototype.request = function request(options, callback) {
+TChannelConnection.prototype.request = function request(options) {
     var self = this;
     // TODO: use this to protect against >4Mi outstanding messages edge case
     // (e.g. zombie operation bug, incredible throughput, or simply very long
@@ -732,7 +732,7 @@ TChannelConnection.prototype.request = function request(options, callback) {
     options.ttl = options.timeout || 1; // TODO: better default, support for dynamic
     var req = self.handler.buildOutgoingRequest(options);
     var id = req.id;
-    self.outOps[id] = new TChannelClientOp(req, self.channel.now(), callback);
+    self.outOps[id] = new TChannelClientOp(req, self.channel.now());
     self.pendingCount++;
     return req;
 };
@@ -793,10 +793,9 @@ TChannelServerOp.prototype.sendResponse = function sendResponse(err, res1, res2)
     self.callback(err, res1, res2);
 };
 
-function TChannelClientOp(req, start, callback) {
+function TChannelClientOp(req, start) {
     var self = this;
     self.req = req;
-    self.callback = callback;
     self.start = start;
     self.timedOut = false;
 }

--- a/node/index.js
+++ b/node/index.js
@@ -710,12 +710,6 @@ TChannelConnection.prototype.popOutOp = function popOutOp(id) {
     return op;
 };
 
-TChannelConnection.prototype.completeOutOp = function completeOutOp(id, err, arg1, arg2) {
-    var self = this;
-    var op = self.popOutOp(id);
-    op.callback(err, arg1, arg2);
-};
-
 // create a request
 TChannelConnection.prototype.request = function request(options) {
     var self = this;

--- a/node/index.js
+++ b/node/index.js
@@ -422,10 +422,10 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     });
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
+        var op = self.popOutOp(res.id);
         if (res.isOK()) {
-            self.completeOutOp(res.id, null, res.arg2, res.arg3);
+            op.req.emit('response', res);
         } else {
-            var op = self.popOutOp(res.id);
             op.req.emit('error', TChannelApplicationError({
                 code: res.code,
                 arg1: res.arg1,

--- a/node/index.js
+++ b/node/index.js
@@ -275,8 +275,9 @@ TChannel.prototype.addPeer = function addPeer(hostPort, connection) {
 // TODO: deprecated, callers should use .request directly
 TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
     var self = this;
-    var req = self.request(options, callback);
-    req.send(arg1, arg2, arg3);
+    return self
+        .request(options)
+        .send(arg1, arg2, arg3, callback);
 };
 /* jshint maxparams:4 */
 

--- a/node/index.js
+++ b/node/index.js
@@ -728,12 +728,12 @@ TChannelConnection.prototype.request = function request(options, callback) {
     return req;
 };
 
-TChannelConnection.prototype.runInOp = function runInOp(handler, options, res) {
+TChannelConnection.prototype.runInOp = function runInOp(handler, req, res) {
     var self = this;
-    var id = options.id;
+    var id = req.id;
     self.inPending++;
     var op = self.inOps[id] = new TChannelServerOp(self,
-        handler, self.channel.now(), options, opDone);
+        handler, self.channel.now(), req, opDone);
 
     function opDone(err, res1, res2) {
         if (self.inOps[id] !== op) {

--- a/node/index.js
+++ b/node/index.js
@@ -435,7 +435,8 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     });
 
     self.handler.on('call.incoming.error', function onCallError(err) {
-        self.completeOutOp(err.originalId, err, null, null);
+        var op = self.popOutOp(err.originalId);
+        op.req.emit('error', err);
     });
 
     self.socket.setNoDelay(true);

--- a/node/index.js
+++ b/node/index.js
@@ -670,7 +670,7 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
         var op = self.outOps[id];
         delete self.outOps[id];
         // TODO: shared mutable object... use Object.create(err)?
-        op.callback(err, null, null);
+        op.req.emit('error', err);
     });
 
     self.inPending = 0;

--- a/node/index.js
+++ b/node/index.js
@@ -425,12 +425,13 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         if (res.isOK()) {
             self.completeOutOp(res.id, null, res.arg2, res.arg3);
         } else {
-            self.completeOutOp(res.id, TChannelApplicationError({
+            var op = self.popOutOp(res.id);
+            op.req.emit('error', TChannelApplicationError({
                 code: res.code,
                 arg1: res.arg1,
                 arg2: res.arg2,
                 arg3: res.arg3
-            }), res.arg2, null);
+            }));
         }
     });
 

--- a/node/index.js
+++ b/node/index.js
@@ -614,7 +614,7 @@ TChannelConnection.prototype.checkOutOpsForTimeout = function checkOutOpsForTime
                 });
             continue;
         }
-        var timeout = op.options.timeout || self.channel.reqTimeoutDefault;
+        var timeout = op.req.ttl || self.channel.reqTimeoutDefault;
         var duration = now - op.start;
         if (duration > timeout) {
             delete ops[opKey];
@@ -722,8 +722,7 @@ TChannelConnection.prototype.request = function request(options, callback) {
     options.ttl = options.timeout || 1; // TODO: better default, support for dynamic
     var req = self.handler.buildOutgoingRequest(options);
     var id = req.id;
-    self.outOps[id] = new TChannelClientOp(
-        options, self.channel.now(), callback);
+    self.outOps[id] = new TChannelClientOp(req, self.channel.now(), callback);
     self.pendingCount++;
     return req;
 };
@@ -784,9 +783,9 @@ TChannelServerOp.prototype.sendResponse = function sendResponse(err, res1, res2)
     self.callback(err, res1, res2);
 };
 
-function TChannelClientOp(options, start, callback) {
+function TChannelClientOp(req, start, callback) {
     var self = this;
-    self.options = options;
+    self.req = req;
     self.callback = callback;
     self.start = start;
     self.timedOut = false;

--- a/node/index.js
+++ b/node/index.js
@@ -424,7 +424,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
         var op = self.popOutOp(res.id);
-        if (res.isOK()) {
+        if (res.ok) {
             op.req.emit('response', res);
         } else {
             op.req.emit('error', TChannelApplicationError({

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -20,6 +20,9 @@
 
 'use strict';
 
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
+
 var emptyTracing = Buffer(25); // TODO: proper tracing object
 var emptyBuffer = Buffer(0);
 
@@ -31,6 +34,7 @@ function TChannelIncomingRequest(id, options) {
     }
     options = options || {};
     var self = this;
+    EventEmitter.call(self);
     self.id = id || 0;
     self.ttl = options.ttl || 0;
     self.tracing = options.tracing || emptyTracing;
@@ -42,18 +46,23 @@ function TChannelIncomingRequest(id, options) {
     self.arg3 = options.arg3 || emptyBuffer;
 }
 
+inherits(TChannelIncomingRequest, EventEmitter);
+
 function TChannelIncomingResponse(id, options) {
     if (!(this instanceof TChannelIncomingResponse)) {
         return new TChannelIncomingResponse(id, options);
     }
     options = options || {};
     var self = this;
+    EventEmitter.call(self);
     self.id = id || 0;
     self.code = options.code || 0;
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
 }
+
+inherits(TChannelIncomingResponse, EventEmitter);
 
 TChannelIncomingResponse.prototype.isOK = function isOK() {
     var self = this;
@@ -66,6 +75,7 @@ function TChannelOutgoingRequest(id, options, sendFrame) {
     }
     options = options || {};
     var self = this;
+    EventEmitter.call(self);
     self.id = id || 0;
     self.ttl = options.ttl || 0;
     self.tracing = options.tracing || emptyTracing;
@@ -74,6 +84,8 @@ function TChannelOutgoingRequest(id, options, sendFrame) {
     self.checksumType = options.checksumType || 0;
     self.sendFrame = sendFrame;
 }
+
+inherits(TChannelOutgoingRequest, EventEmitter);
 
 TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3) {
     var self = this;
@@ -86,6 +98,7 @@ function TChannelOutgoingResponse(id, options, sendFrame) {
     }
     options = options || {};
     var self = this;
+    EventEmitter.call(self);
     self.id = id || 0;
     self.code = options.code || 0;
     self.tracing = options.tracing || emptyTracing;
@@ -96,6 +109,8 @@ function TChannelOutgoingResponse(id, options, sendFrame) {
     self.arg3 = options.arg3 || emptyBuffer;
     self.sendFrame = sendFrame;
 }
+
+inherits(TChannelOutgoingResponse, EventEmitter);
 
 TChannelOutgoingResponse.prototype.send = function send(err, res1, res2) {
     var self = this;

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -121,6 +121,7 @@ function TChannelOutgoingResponse(id, options, sendFrame) {
     self.tracing = options.tracing || emptyTracing;
     self.headers = options.headers || {};
     self.checksumType = options.checksumType || 0;
+    self.ok = true;
     self.name = options.name || '';
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
@@ -131,10 +132,22 @@ inherits(TChannelOutgoingResponse, EventEmitter);
 
 TChannelOutgoingResponse.prototype.send = function send(err, res1, res2) {
     var self = this;
-    self.sendFrame(err, res1, res2);
+    if (err) {
+        self.ok = false;
+        var errArg = isError(err) ? err.message : JSON.stringify(err); // TODO: better
+        self.sendFrame(self.name, res1, errArg);
+    } else {
+        self.sendFrame(self.name, res1, res2);
+    }
 };
 
 module.exports.IncomingRequest = TChannelIncomingRequest;
 module.exports.IncomingResponse = TChannelIncomingResponse;
 module.exports.OutgoingRequest = TChannelOutgoingRequest;
 module.exports.OutgoingResponse = TChannelOutgoingResponse;
+
+function isError(obj) {
+    return typeof obj === 'object' && (
+        Object.prototype.toString.call(obj) === '[object Error]' ||
+        obj instanceof Error);
+}

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -87,9 +87,26 @@ function TChannelOutgoingRequest(id, options, sendFrame) {
 
 inherits(TChannelOutgoingRequest, EventEmitter);
 
-TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3) {
+TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     var self = this;
     self.sendFrame(arg1, arg2, arg3);
+    if (callback) self.hookupCallback(callback);
+    return self;
+};
+
+TChannelOutgoingRequest.prototype.hookupCallback = function hookupCallback(callback) {
+    var self = this;
+    self.once('error', onError);
+    self.once('response', onResponse);
+    function onError(err) {
+        self.removeListener('response', onResponse);
+        callback(err, null);
+    }
+    function onResponse(res) {
+        self.removeListener('error', onError);
+        callback(null, res);
+    }
+    return self;
 };
 
 function TChannelOutgoingResponse(id, options, sendFrame) {

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -60,14 +60,10 @@ function TChannelIncomingResponse(id, options) {
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
+    self.ok = self.code === 0; // TODO: probably okay, but a bit jank
 }
 
 inherits(TChannelIncomingResponse, EventEmitter);
-
-TChannelIncomingResponse.prototype.isOK = function isOK() {
-    var self = this;
-    return self.code === 0; // TODO: probably okay, but a bit jank
-};
 
 function TChannelOutgoingRequest(id, options, sendFrame) {
     if (!(this instanceof TChannelOutgoingRequest)) {

--- a/node/test/emits-endpoint.js
+++ b/node/test/emits-endpoint.js
@@ -45,14 +45,14 @@ allocCluster.test('emits endpoint event', 2, {
     two
         .request({
             host: cluster.hosts[0]
-        }, onHello)
-        .send('/hello', '', '');
+        })
+        .send('/hello', '', '', onHello);
 
-    function onHello(err, res1, res2) {
+    function onHello(err, res) {
         assert.ifError(err);
 
-        assert.equal(String(res1), '');
-        assert.equal(String(res2), 'hello');
+        assert.equal(String(res.arg2), '');
+        assert.equal(String(res.arg3), 'hello');
 
         assert.deepEqual(endpoints, [
             {

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -108,9 +108,8 @@ allocCluster.test('register() with different results', 2, function t(cluster, as
 
         var errorCall = results.errorCall;
         assert.ok(errorCall.err);
+        assert.equal(String(errorCall.err.arg2), '');
         assert.equal(String(errorCall.err.arg3), 'abc');
-        assert.deepEqual(errorCall.head, Buffer(0));
-        assert.equal(errorCall.body, null);
 
         var bufferHead = results.bufferHead;
         assert.equal(bufferHead.err, null);
@@ -188,14 +187,14 @@ allocCluster.test('register() with different results', 2, function t(cluster, as
 
 function sendCall(channel, opts, op, cb) {
     channel
-        .request(opts, onResult)
-        .send(op, null, null);
+        .request(opts)
+        .send(op, null, null, onResult);
 
-    function onResult(err, res1, res2) {
+    function onResult(err, res) {
         cb(null, {
             err: err,
-            head: res1,
-            body: res2
+            head: res && res.arg2,
+            body: res && res.arg3
         });
     }
 }

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -35,8 +35,8 @@ allocCluster.test('does not leak inOps', 2, {
         .request({
             host: cluster.hosts[0],
             timeout: 100
-        }, onTimeout)
-        .send('/timeout', 'h', 'b');
+        })
+        .send('/timeout', 'h', 'b', onTimeout);
 
     function onTimeout(err) {
         two.timeoutCheckInterval = 99999;

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -175,13 +175,13 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
 /*jshint maxparams: 6 */
 function sendRes(channel, opts, op, h, b, cb) {
     channel
-        .request(opts, onResult)
-        .send(op, h, b);
+        .request(opts)
+        .send(op, h, b, onResult);
 
-    function onResult(err, res1, res2) {
+    function onResult(err, res) {
         cb(err, {
-            head: res1,
-            body: res2
+            head: res.arg2,
+            body: res.arg3
         });
     }
 }

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -38,21 +38,21 @@ allocCluster.test('requests will timeout', 2, {
         .request({
             host: hostOne,
             timeout: 1000
-        }, onResp)
-        .send('/normal-proxy', 'h', 'b');
+        })
+        .send('/normal-proxy', 'h', 'b', onResp);
 
-    function onResp(err, h, b) {
+    function onResp(err, res) {
         assert.ifError(err);
 
-        assert.equal(String(h), 'h');
-        assert.equal(String(b), 'b');
+        assert.equal(String(res.arg2), 'h');
+        assert.equal(String(res.arg3), 'b');
 
         two
             .request({
                 host: hostOne,
                 timeout: 1000
-            }, onTimeout)
-            .send('/timeout', 'h', 'b');
+            })
+            .send('/timeout', 'h', 'b', onTimeout);
 
         timers.advance(2500);
     }


### PR DESCRIPTION
reviewers: @Raynos @kriskowal 

Old:
```
.send(opt, a1, a2, a3, cb)
```

New:
```
.request(opt)
.send(a1, a2, a3, cb)
```

New option:
```
.request(opt)
.on('error', onError)
.on('response', onResponse)
.send(a1, a2, a3)
```