### PR TITLE
Use Fingerprint32 instead of Hash32.

### DIFF
--- a/node/test/v2/checksum.js
+++ b/node/test/v2/checksum.js
@@ -38,7 +38,7 @@ var CRC32Buffer = Buffer([
 ]);
 
 var Farm32Buffer = Buffer([
-    Checksum.Types.FarmHash32, // csumtype:1
+    Checksum.Types.Farm32, // csumtype:1
     0xee, 0xd8, 0x6e, 0xa9     // csum:4
 ]);
 
@@ -64,13 +64,13 @@ test('read and verify crc32 checksum', function t(assert) {
     });
 });
 
-test('read and verify farmhash32 checksum', function t(assert) {
+test('read and verify farm32 checksum', function t(assert) {
     testRead(assert, Checksum.read, Farm32Buffer, function checkFarmHash32(csum, done) {
-        assert.equal(csum.type, Checksum.Types.FarmHash32, 'expected type: farmhash32');
+        assert.equal(csum.type, Checksum.Types.Farm32, 'expected type: farm32');
         var good = csum.verify(parts[0], parts[1], parts[2]);
-        assert.equal(good, null, 'farmhash32 expected to verify parts');
+        assert.equal(good, null, 'farm32 expected to verify parts');
         var bad = csum.verify(uparts[0], uparts[1], uparts[2]);
-        assert.equal(bad && bad.type, 'tchannel.checksum', 'farmhash32 expected to fail');
+        assert.equal(bad && bad.type, 'tchannel.checksum', 'farm32 expected to fail');
         done();
     });
 });
@@ -101,15 +101,15 @@ test('write correct crc32 checksum', function t(assert) {
     assert.end();
 });
 
-test('write correct farmhash32 checksum', function t(assert) {
-    var csum = Checksum(Checksum.Types.FarmHash32);
+test('write correct farm32 checksum', function t(assert) {
+    var csum = Checksum(Checksum.Types.Farm32);
     csum.update(parts[0], parts[1], parts[2]);
     assert.deepEqual(
         csum.write().create(),
-        Farm32Buffer, 'farmhash32 writes correct checksum');
+        Farm32Buffer, 'farm32 writes correct checksum');
     csum.update(uparts[0], uparts[1], uparts[2]);
     assert.notDeepEqual(
         csum.write().create(),
-        Farm32Buffer, 'farmhash32 rejects bad data');
+        Farm32Buffer, 'farm32 rejects bad data');
     assert.end();
 });

--- a/node/test/v2/checksum.js
+++ b/node/test/v2/checksum.js
@@ -39,7 +39,7 @@ var CRC32Buffer = Buffer([
 
 var Farm32Buffer = Buffer([
     Checksum.Types.FarmHash32, // csumtype:1
-    0x9b, 0x59, 0xe9, 0xf3     // csum:4
+    0xee, 0xd8, 0x6e, 0xa9     // csum:4
 ]);
 
 test('read and verify none checksum', function t(assert) {

--- a/node/v2/checksum.js
+++ b/node/v2/checksum.js
@@ -67,7 +67,7 @@ Checksum.objOrType = function objOrType(arg) {
 Checksum.Types = {
     None: 0x00,
     CRC32: 0x01,
-    FarmHash32: 0x02
+    Farm32: 0x02
 };
 
 Checksum.read = read.chained(read.UInt8, function(type, buffer, offset) {

--- a/node/v2/checksum.js
+++ b/node/v2/checksum.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var farm32 = require('farmhash').hash32;
+var farm32 = require('farmhash').fingerprint32;
 var crc32 = require('crc').crc32;
 
 var TypedError = require('error/typed');

--- a/protocol.md
+++ b/protocol.md
@@ -673,11 +673,11 @@ This behavior changes slightly when messages are fragmented. See the
 
 ### Checksum types:
 
-`type:1` | scheme          | value length
----------|-----------------|-------------
-`0x00`   | none            | 0 bytes
-`0x01`   | crc32           | 4 bytes
-`0x02`   | farm hash32 x86 | 4 bytes
+`type:1` | scheme                 | value length
+---------|------------------------|-------------
+`0x00`   | none                   | 0 bytes
+`0x01`   | crc32                  | 4 bytes
+`0x02`   | farmhash Fingerprint32 | 4 bytes
 
 CRC32 is intended as a checksum, and many implementations exist, including
 SSE4.2 instructions on supported platforms.


### PR DESCRIPTION
Getting a consistent result from Hash32 across different runtimes is harder than we thought. We should use the slightly slower but more consistent Fingerprint32 instead.
