### PR TITLE
Refactor handling wrt req/res

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -417,9 +417,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     // TODO: refactor op boundary to pass full req/res around
     self.handler.on('call.incoming.request', function onCallRequest(req) {
-        var handler = self.channel.getEndpointHandler(req.name);
-        var res = self.handler.buildOutgoingResponse(req);
-        self.runInOp(handler, req, res);
+        self.handleCallRequest(req);
     });
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
@@ -731,8 +729,10 @@ TChannelConnection.prototype.request = function request(options) {
     return req;
 };
 
-TChannelConnection.prototype.runInOp = function runInOp(handler, req, res) {
+TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req) {
     var self = this;
+    var handler = self.channel.getEndpointHandler(req.name);
+    var res = self.handler.buildOutgoingResponse(req);
     var id = req.id;
     self.inPending++;
     var op = self.inOps[id] = new TChannelServerOp(self,

--- a/node/index.js
+++ b/node/index.js
@@ -731,6 +731,7 @@ TChannelConnection.prototype.request = function request(options) {
 
 TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req) {
     var self = this;
+    req.remoteAddr = self.remoteName;
     var handler = self.channel.getEndpointHandler(req.name);
     var res = self.handler.buildOutgoingResponse(req);
     var id = req.id;

--- a/node/index.js
+++ b/node/index.js
@@ -144,8 +144,9 @@ TChannel.prototype.address = function address() {
     return self.serverSocket.address();
 };
 
-TChannel.prototype.handleRequest = function handleRequest(req, callback) {
+TChannel.prototype.handleRequest = function handleRequest(req, res) {
     var self = this;
+
     var name = req.name;
     var handler = self.endpoints[name];
     if (typeof handler !== 'function') {
@@ -154,12 +155,14 @@ TChannel.prototype.handleRequest = function handleRequest(req, callback) {
         });
         var err = new Error('no such operation'); // TODO: typed error
         err.op = name;
-        callback(err, null, null);
+        res.send(err, null, null);
     } else if (self.endpoints[name]) {
         self.emit('endpoint', {
             name: name
         });
-        handler(req.arg2, req.arg3, req.remoteAddr, callback);
+        handler(req.arg2, req.arg3, req.remoteAddr, function handlerCallback(err, res1, res2) {
+            res.send(err, res1, res2);
+        });
     }
 };
 
@@ -739,9 +742,7 @@ TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req)
     process.nextTick(runHandler);
 
     function runHandler() {
-        self.channel.handleRequest(req, function handlerCallback(err, res1, res2) {
-            res.send(err, res1, res2);
-        });
+        self.channel.handleRequest(req, res);
     }
 
     function opDone() {

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -39,6 +39,7 @@ function TChannelIncomingRequest(id, options) {
     self.ttl = options.ttl || 0;
     self.tracing = options.tracing || emptyTracing;
     self.service = options.service || '';
+    self.remoteAddr = null;
     self.headers = options.headers || {};
     self.checksumType = options.checksumType || 0;
     self.name = options.name || '';


### PR DESCRIPTION
Use req/res objects throughout the handling paths; sets the stage for other forms of handling.

reviewers: @Raynos @kriskowal 
