### PR TITLE
Fix bug for null response

### DIFF
--- a/node/examples/polling.js
+++ b/node/examples/polling.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var TChannel = require('../index.js');
+var CountedReadySignal = require('ready-signal/counted');
+
+var server = new TChannel();
+var client = new TChannel();
+
+server.register('ping', function (arg1, arg2, peerInfo, cb) {
+    setTimeout(function () {
+        cb(null, 'pong');
+    }, 1000)
+});
+
+var ready = CountedReadySignal(2);
+var listening = ready(function (err) {
+    if (err) {
+        throw err;
+    }
+
+    setInterval(function () {
+        console.log('ping');
+        client
+            .request({host: '127.0.0.1:4040'})
+            .send('ping', '', '', function (err, res) {
+                console.log('response', res);
+            });
+    }, 1000);
+
+});
+
+server.listen(4040, '127.0.0.1', ready.signal);
+client.listen(4041, '127.0.0.1', ready.signal);


### PR DESCRIPTION
This may be masking a larger systemic issue. The polling example drives
this issue, but nothing weird is going on that would cause a response to
arrive after it has been popped. Further investigation required.

I created the polling example to exercise tcap tracking frames from an already open connection.