### PR TITLE
add ping payloads

### DIFF
--- a/node/lib/read.js
+++ b/node/lib/read.js
@@ -92,6 +92,11 @@ module.exports.UInt32BE = readWidth(4, function UInt32BE(buffer, offset) {
     return buffer.readUInt32BE(offset);
 });
 
+module.exports.null = naught;
+function naught(buffer, offset) {
+    return [null, offset, null];
+};
+
 module.exports.skip = skip;
 
 function skip(n) {

--- a/node/lib/write.js
+++ b/node/lib/write.js
@@ -195,6 +195,10 @@ module.exports.fixed = function(n, source, name) {
     });
 };
 
+module.exports.null = function naught(buffer, offset) {
+    return offset;
+};
+
 module.exports.fill = function(c, n) {
     return new BufferWriter(n, function writeFill(buffer, offset) {
         var end = offset + n;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -70,6 +70,10 @@ TChannelV2Handler.prototype._write = function _write(frame, encoding, callback) 
             return self.handleCallRequest(frame, callback);
         case v2.Types.CallResponse:
             return self.handleCallResponse(frame, callback);
+        case v2.Types.PingRequest:
+            return self.handlePingRequest(frame, callback);
+        case v2.Types.PingResponse:
+            return self.handlePingResponse(frame, callback);
         case v2.Types.Error:
             return self.handleError(frame, callback);
         default:
@@ -135,6 +139,29 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
     }
     var res = self.buildIncomingResponse(resFrame);
     self.emit('call.incoming.response', res);
+    callback();
+};
+
+TChannelV2Handler.prototype.handlePingRequest = function handlePingRequest(reqFrame, callback) {
+    var self = this;
+    if (self.remoteHostPort === null) {
+        return callback(new Error('ping request before init request')); // TODO typed error
+    }
+    // TODO parse request frame for frame identifier
+    // TODO construct ping response for given request identifier
+    // TODO respond with ping response on selfsame connection
+    self.emit('ping.incoming.request');
+    callback();
+};
+
+TChannelV2Handler.prototype.handlePingResponse = function handlePingResponse(resFrame, callback) {
+    var self = this;
+    if (self.remoteHostPort === null) {
+        return callback(new Error('ping response before init request')); // TODO typed error
+    }
+    // TODO parse response frame for identifier
+    // TODO forward ping response to callback attached to ping identifier
+    self.emit('ping.incoming.response');
     callback();
 };
 

--- a/node/v2/index.js
+++ b/node/v2/index.js
@@ -43,6 +43,14 @@ Frame.Types[Types.CallResponse] = call.Response;
 module.exports.CallRequest = call.Request;
 module.exports.CallResponse = call.Response;
 
+var ping = require('./ping');
+Types.PingRequest = ping.Request.TypeCode;
+Types.PingResponse = ping.Request.TypeCode;
+Frame.Types[Types.PingRequest] = ping.Requst;
+Frame.Types[Types.PingResponse] = ping.Response;
+module.exports.PingRequest = ping.Request;
+module.exports.PingResponse = ping.Response;
+
 var ErrorResponse = require('./error_response');
 Types.ErrorResponse = ErrorResponse.TypeCode;
 Frame.Types[Types.ErrorResponse] = ErrorResponse;

--- a/node/v2/ping.js
+++ b/node/v2/ping.js
@@ -34,9 +34,7 @@ function PingRequest(version, headers) {
 PingRequest.TypeCode = 0xd0;
 
 // Pings requests have no body.
-PingRequest.read = function (buffer, offset) {
-    return [];
-};
+PingRequest.read = read.skip(0);
 
 function PingResponse(version, headers) {
     var self = this;
@@ -48,6 +46,4 @@ function PingResponse(version, headers) {
 PingResponse.TypeCode = 0xd1;
 
 // Pongs  have no body.
-PingResponse.read = function (buffer, offset) {
-    return [];
-};
+PingResponse.read = read.skip(0);

--- a/node/v2/ping.js
+++ b/node/v2/ping.js
@@ -33,7 +33,8 @@ function PingRequest(version, headers) {
 PingRequest.TypeCode = 0xd0;
 
 // Pings requests have no body.
-PingRequest.read = read.skip(0);
+PingRequest.read = read.null;
+PingRequest.write = write.null;
 
 function PingResponse(version, headers) {
     var self = this;
@@ -45,4 +46,5 @@ function PingResponse(version, headers) {
 PingResponse.TypeCode = 0xd1;
 
 // Pongs  have no body.
-PingResponse.read = read.skip(0);
+PingResponse.read = read.null;
+PingResponse.write = write.null;

--- a/node/v2/ping.js
+++ b/node/v2/ping.js
@@ -1,0 +1,53 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var read = require('../lib/read');
+var write = require('../lib/write');
+
+module.exports.Request = PingRequest;
+module.exports.Response = PingResponse;
+
+function PingRequest(version, headers) {
+    var self = this;
+    self.type = PingRequest.TypeCode;
+    self.version = version || 0;
+    self.headers = headers || {};
+}
+
+PingRequest.TypeCode = 0xd0;
+
+// Pings requests have no body.
+PingRequest.read = function (buffer, offset) {
+    return [];
+};
+
+function PingResponse(version, headers) {
+    var self = this;
+    self.type = PingResponse.TypeCode;
+    self.version = version || 0;
+    self.headers = headers || {};
+}
+
+PingResponse.TypeCode = 0xd1;
+
+// Pongs  have no body.
+PingResponse.read = function (buffer, offset) {
+    return [];
+};

--- a/node/v2/ping.js
+++ b/node/v2/ping.js
@@ -19,7 +19,6 @@
 'use strict';
 
 var read = require('../lib/read');
-var write = require('../lib/write');
 
 module.exports.Request = PingRequest;
 module.exports.Response = PingResponse;


### PR DESCRIPTION
tcap isn't able to show these frames because tchannel doesn't know how to parse type codes `0xd0` and `0xd1`. These don't have bodies and so I think `skip(0)` is right but I'm not sure how the `write` method should look. @jcorbin thoughts?

cc @kriskowal 