### PR TITLE
destroy sockets on close

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -380,7 +380,7 @@ TChannel.prototype.close = function close(callback) {
         });
         conn.closing = true;
         conn.resetAll(new Error('shutdown from quit')); // TODO typed error
-        sock.end();
+        sock.destroy();
     });
 
     var serverSocket = self.serverSocket;


### PR DESCRIPTION
The current semantics of calling `.end()` on peers
is incorrect.

This only ends the Writable sends. This means existing
Incoming Peer objects for this server still have an
open readable side.

This means the server can still receive incoming
CallRequests from already accepted sockets.

To close() the server we have to destroy() these
sockets to end both the Writable and Readable side.

reviewers: @rf @jcorbin

cc: @jsu1212