### PR TITLE
[python] fix a typo and restore test coverage

### DIFF
--- a/python/tchannel/messages/call_request.py
+++ b/python/tchannel/messages/call_request.py
@@ -108,7 +108,7 @@ class CallRequestMessage(BaseMessage):
 
         if cur != end:
             raise InvalidMessageException(
-                "Extra space exists in the end of payload!"
+                "Too many bytes in the payload"
             )
 
     def serialize_trace(self, out):

--- a/python/tchannel/messages/call_request.py
+++ b/python/tchannel/messages/call_request.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
-import logging
 import os
 
 from .base import BaseMessage
 from .types import Types
+from ..exceptions import InvalidMessageException
 from ..parser import read_number
 from ..parser import read_variable_length_key
 from ..parser import write_number
@@ -107,7 +107,9 @@ class CallRequestMessage(BaseMessage):
         end = payload.tell()
 
         if cur != end:
-            logging.error("Extra space exists in the end of payload!")
+            raise InvalidMessageException(
+                "Extra space exists in the end of payload!"
+            )
 
     def serialize_trace(self, out):
         out.extend(write_number(self.span_id, self.TRACE_SIZE))

--- a/python/tchannel/messages/call_response.py
+++ b/python/tchannel/messages/call_response.py
@@ -56,7 +56,7 @@ class CallResponseMessage(CallRequestMessage):
     def serialize(self, out):
         """Write a call request message out to a buffer."""
         out.extend(write_number(self.flags, self.FLAGS_SIZE))
-        out.extend(write_number(self.code, self.code_SIZE))
+        out.extend(write_number(self.code, self.CODE_SIZE))
 
         self.serialize_trace(out)
         self.serialize_header_and_checksum(out)

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -80,6 +80,9 @@ def test_valid_ping_request():
     (messages.InitRequestMessage, {
         'headers': {'one': '2'}
     }),
+    (messages.InitResponseMessage, {
+        'headers': {}
+    }),
     (messages.PingRequestMessage, {}),
     (messages.PingResponseMessage, {}),
     (messages.ErrorMessage, {
@@ -115,7 +118,21 @@ def test_valid_ping_request():
         'arg_1': b'hi',
         'arg_2': b'\x00',
         'arg_3': None,
-    })
+    }),
+    (messages.CallResponseMessage, {
+        'flags': 1,
+        'code': 1,
+        'span_id': 1,
+        'parent_id': 2,
+        'trace_id': 3,
+        'traceflags': 4,
+        'headers': {},
+        'checksum_type': 0x01,
+        'checksum': 1,
+        'arg_1': None,
+        'arg_2': None,
+        'arg_3': None,
+    }),
 ])
 def test_roundtrip_message(message_class, attrs):
     """Verify all message types serialize and deserialize properly."""

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -252,3 +252,7 @@ def test_call_res_parse():
     assert msg.arg_1 == b'on'
     assert msg.arg_2 == b'to'
     assert msg.arg_3 == b'te'
+
+
+def test_equality_check_against_none(init_request_with_headers):
+    assert (messages.InitRequestMessage() == None) is False

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -216,7 +216,7 @@ def test_call_req_parse(call_request_bytes):
     assert msg.arg_3 == b'te'
 
 
-def test_extra_space_check(caplog, call_request_bytes):
+def test_extra_space_check(call_request_bytes):
     buff = call_request_bytes
     message = messages.CallRequestMessage()
 

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -217,11 +217,11 @@ def test_call_req_parse(call_request_bytes):
 
 
 def test_extra_space_check(call_request_bytes):
-    buff = call_request_bytes
+    buff = call_request_bytes + bytearray(b'a little sumpin xtra')
     message = messages.CallRequestMessage()
 
     with pytest.raises(exceptions.InvalidMessageException):
-        message.parse(BytesIO(buff + 'sumpin xtra'), len(buff))
+        message.parse(BytesIO(buff), len(buff))
 
 
 def test_call_res_parse():


### PR DESCRIPTION
`s/code_SIZE/CODE_SIZE`
`s/98%/100%`

@uber/dsg 