### PR TITLE
Remove `resp.send()` in OutgoingCallResponse.

### DIFF
--- a/node/MIGRATION.md
+++ b/node/MIGRATION.md
@@ -30,10 +30,10 @@ chan.handler.register('my-endpoint', function (req, res) {
     // req.arg2, req.arg3, req.remoteAddr
 
     // either
-    res.send(new Error('oops'));
+    res.sendNotOk(null, 'oops');
 
     // or
-    res.send(null, 'res1', 'res2');
+    res.sendOk(null, 'res1', 'res2');
 });
 ```
 
@@ -42,14 +42,23 @@ chan.handler.register('my-endpoint', function (req, res) {
 Before:
 ```
 chan
-    .send(options, a1, a2, a3, cb);
+    .send(options, a1, a2, a3, function (err, res1, res2) {
+        // CallResponse error is in `err`
+        // CallResponse ok is in `res1`, `res2`
+    });
 ```
 
 After (simple):
 ```
 chan
     .request(options)
-    .send(a1, a2, a3, cb);
+    .send(a1, a2, a3, function (err, res) {
+        // CallResponse is in `res.arg2`, `res.arg3`
+        // res has an `.ok` field that is tells whether it is
+        // an error or not.
+
+        // `err` is for IO & timeouts. Also tchannel error frames
+    });
 ```
 
 After (if needed/useful):

--- a/node/MIGRATION.md
+++ b/node/MIGRATION.md
@@ -57,7 +57,11 @@ chan
         // res has an `.ok` field that is tells whether it is
         // an error or not.
 
-        // `err` is for IO & timeouts. Also tchannel error frames
+        // This means that an application error returns
+        // `err` === null and a `resp` where `.ok` is false.
+
+        // If `err` is non null then it will be an err related
+        // to client TCP IO errors or TChannel error frames.
     });
 ```
 

--- a/node/MIGRATION.md
+++ b/node/MIGRATION.md
@@ -33,7 +33,7 @@ chan.handler.register('my-endpoint', function (req, res) {
     res.sendNotOk(null, 'oops');
 
     // or
-    res.sendOk(null, 'res1', 'res2');
+    res.sendOk('res1', 'res2');
 });
 ```
 

--- a/node/README.md
+++ b/node/README.md
@@ -241,10 +241,8 @@ type TChannelOutgoingResponse : {
     arg2: Buffer,
     arg3: Buffer,
 
-    send: (
-        ((err: Error, res1: Buffer) => void) &
-        ((err: null, res1: Buffer, res2: Buffer) => void)
-    )
+    sendOk: (res1: Buffer, res2: Buffer) => void,
+    sendNotOk: (res1: Buffer, res2: Buffer) => void
 }
 
 type TChannelHandler : {
@@ -270,12 +268,11 @@ The incoming req has
  - `arg3` as a `Buffer`.
  - `service` as a `String`
 
-The outgoing response has a `send()` method.
+The outgoing response has a `sendOk()` and `sendNotOk()` method.
 
- - You can call `send(Error, res1)` to send a not-ok response.
-   It will serialize your error for you, with the message as
-   res2.
- - You can call `send(null, res1, res2)` to set `res1` and `res2`
+ - You can call `sendNotOk(res1, res2)` to send a not-ok response.
+   `res1` and `res2` are buffers.
+ - You can call `sendOk(res1, res2)` to set `res1` and `res2`
    as Buffers for the Call response
 
 ### `channel.listen(port, host, callback?)`
@@ -304,8 +301,11 @@ request: (options: {
         arg3: Buffer | String,
         cb: (
             err?: Error,
-            res1: Buffer,
-            res2: Buffer
+            res: {
+                ok: Boolean,
+                arg2: Buffer,
+                arg3: Buffer
+            }
         ) => void
     ) => void
 }
@@ -349,19 +349,22 @@ The second argument will be the `head` to send to the server,
 The third argument will be the `body` to send to the server.
     This will be `arg2` in the servers operation function.
 
-#### `cb(err, res1, res2)`
+#### `cb(err, res)`
 
 When you `request.send()` a message to another tchannel server it will
 give you a callback
 
 The callback will either get called with `cb(err)` or with
-    `cb(null, res1, res2)`
+    `cb(null, resp)`
 
- - `err` will either be `null` or an `Error`. This can be an
-    error send from the remote server or another type of error
-    like a timeout, IO or 404 error.
- - `res1` will be the `head` response from the server as a buffer
- - `res2` will be the `body` response from the server as a buffer
+ - `err` will either be `null` or an `Error`. This can be 
+    an error like a timeout, IO or tchannel error frame.
+ - `resp` will be set, this can be an OK response or an error
+    from the remote server.
+ - `resp.ok` will be a boolean, dependening on whether this is
+    an OK response or an application level error.
+ - `resp.arg2` will be the `head` response from the server as a buffer
+ - `resp.arg3` will be the `body` response from the server as a buffer
 
 ### `channel.close(cb)`
 

--- a/node/README.md
+++ b/node/README.md
@@ -27,11 +27,11 @@ var client = new TChannel();
 // normal response
 server.handler.register('func 1', function (req, res) {
     console.log('func 1 responding immediately 1:' + req.arg2.toString() + ' 2:' + req.arg3.toString());
-    res.send(null, 'result', 'indeed it did');
+    res.sendOk('result', 'indeed it did');
 });
 // err response
 server.handler.register('func 2', function (req, res) {
-    res.send(new Error('it failed'));
+    res.sendNotOk(null, 'it failed');
 });
 
 var ready = CountedReadySignal(2);
@@ -48,14 +48,14 @@ var listening = ready(function (err) {
     client
         .request({host: '127.0.0.1:4040'})
         .send('func 2', "arg 1", "arg 2", function (err, res) {
-            console.log('err res: ' + err.message);
+            console.log('err res: ' + res.ok + 
+                ' message: ' + String(res.arg3));
         });
 
 });
 
 server.listen(4040, '127.0.0.1', ready.signal);
 client.listen(4041, '127.0.0.1', ready.signal);
-
 ```
 
 This example registers two functions on the "server". "func 1" always works and "func 2" always

--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -32,7 +32,7 @@ server.on('socketClose', function (conn, err) {
 });
 
 server.handler.register('ping', function onPing(req, res) {
-	res.send(null, 'pong', null);
+	res.sendOk('pong', null);
 });
 
 function safeParse(str) {
@@ -46,15 +46,15 @@ function safeParse(str) {
 server.handler.register('set', function onSet(req, res) {
 	var parts = safeParse(req.arg2.toString('utf8'));
 	keys[parts[0]] = parts[1];
-	res.send(null, 'ok', 'really ok');
+	res.sendOk('ok', 'really ok');
 });
 
 server.handler.register('get', function onGet(req, res) {
 	var str = req.arg2.toString('utf8');
 	if (keys[str] !== undefined) {
-		res.send(null, JSON.stringify(keys[str].length), JSON.stringify(keys[str]));
+		res.sendOk(JSON.stringify(keys[str].length), JSON.stringify(keys[str]));
 	} else {
-		res.send(new Error('key not found: ' + str));
+		res.sendNotOk(null, 'key not found: ' + str);
 	}
 });
 

--- a/node/docs.jsig
+++ b/node/docs.jsig
@@ -21,6 +21,15 @@ type TChannelConnection : {
     remoteAddr: HostInfo
 }
 
+type TChannelIncomingResponse : {
+    id: Number,
+    ok: Boolean,
+
+    arg1: Buffer,
+    arg2: Buffer,
+    arg3: Buffer
+}
+
 type TChannelOutgoingRequest : {
     id: Number,
     service: String,
@@ -28,7 +37,8 @@ type TChannelOutgoingRequest : {
     send: (
         arg1: Buffer | String,
         arg2: TChannelValue,
-        arg3: TChannelValue
+        arg3: TChannelValue,
+        cb: Callback<Error, res: TChannelIncomingResponse>
     ) => void
 }
 
@@ -50,10 +60,8 @@ type TChannelOutgoingResponse : {
     arg2: Buffer,
     arg3: Buffer,
 
-    send: (
-        ((err: Error, res1: Buffer) => void) &
-        ((err: null, res1: Buffer, res2: Buffer) => void)
-    )
+    sendOk: (res1: Buffer, res2: Buffer) => void,
+    sendNotOk: (res1: Buffer, res2: Buffer) => void
 }
 
 type TChannelHandler : {

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -75,10 +75,10 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
     var name = String(req.arg1);
     var handler = self.endpoints[name];
     if (!handler) {
-        res.send(NoSuchEndpointError({
+        res.sendNotOk(null, NoSuchEndpointError({
             service: self.serviceName,
             endpoint: name
-        }));
+        }).message);
         return;
     }
     handler(req, res);

--- a/node/examples/example1.js
+++ b/node/examples/example1.js
@@ -30,11 +30,11 @@ var client = new TChannel();
 // normal response
 server.handler.register('func 1', function (req, res) {
     console.log('func 1 responding immediately 1:' + req.arg2.toString() + ' 2:' + req.arg3.toString());
-    res.send(null, 'result', 'indeed it did');
+    res.sendOk('result', 'indeed it did');
 });
 // err response
 server.handler.register('func 2', function (req, res) {
-    res.send(new Error('it failed'));
+    res.sendNotOk(null, 'it failed');
 });
 
 var ready = CountedReadySignal(2);
@@ -51,7 +51,8 @@ var listening = ready(function (err) {
     client
         .request({host: '127.0.0.1:4040'})
         .send('func 2', "arg 1", "arg 2", function (err, res) {
-            console.log('err res: ' + err.message);
+            console.log('err res: ' + res.ok + 
+                ' message: ' + String(res.arg3));
         });
 
 });

--- a/node/examples/example2.js
+++ b/node/examples/example2.js
@@ -34,11 +34,11 @@ var client = new TChannel({
 // bidirectional messages
 server.handler.register('ping', function onPing(req, res) {
     console.log('server got ping req from ' + req.remoteAddr);
-    res.send(null, 'pong', null);
+    res.sendOk('pong', null);
 });
 client.handler.register('ping', function onPing(req, res) {
     console.log('client got ping req from ' + req.remoteAddr);
-    res.send(null, 'pong', null);
+    res.sendOk('pong', null);
 });
 
 

--- a/node/examples/legacy_example.js
+++ b/node/examples/legacy_example.js
@@ -1,3 +1,23 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 'use strict';
 
 var console = require('console');

--- a/node/examples/legacy_example.js
+++ b/node/examples/legacy_example.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var console = require('console');
+var CountedReadySignal = require('ready-signal/counted');
+
+var TChannel = require('../index.js');
+
+var ready = CountedReadySignal(2);
+var server = new TChannel();
+server.listen(4040, '127.0.0.1', ready.signal);
+var client = new TChannel();
+client.listen(4041, '127.0.0.1', ready.signal);
+
+// normal response
+server.register('func 1', function func1(arg1, arg2, peerInfo, cb) {
+    console.log('func 1 responding immediately 1:' +
+        arg1.toString() + ' 2:' + arg2.toString());
+    cb(null, 'result', 'indeed it did');
+});
+
+// err response
+server.register('func 2', function func2(arg1, arg2, peerInfo, cb) {
+    cb(new Error('it failed'));
+});
+
+ready(function onReady() {
+    client.send({
+        host: '127.0.0.1:4040'
+    }, 'func 1', 'arg 1', 'arg 2', function onResp1(err, res1, res2) {
+        if (err) {
+            console.log('unexpected err: ' + err.message);
+        }
+        console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
+    });
+
+    client.send({
+        host: '127.0.0.1:4040'
+    }, 'func 2', 'arg 1', 'arg 2', function onResp2(err, res1, res2) {
+        console.log('err res: ' + err.message);
+    });
+});

--- a/node/examples/send_test.js
+++ b/node/examples/send_test.js
@@ -33,29 +33,29 @@ var client2 = new TChannel({timeoutCheckInterval: 100, timeoutFuzz: 5});
 // normal response
 server.handler.register('func 1', function (req, res) {
     console.log('func 1 responding immediately');
-    res.send(null, 'result', 'indeed it did');
+    res.sendOk('result', 'indeed it did');
 });
 // err response
 server.handler.register('func 2', function (req, res) {
-    res.send(new Error('it failed'));
+    res.sendNotOk(null, 'it failed');
 });
 // slow response
 server.handler.register('func 3', function (req, res) {
     console.log('func 3 starting response timer');
     setTimeout(function () {
         console.log('func 3 responding now');
-        res.send(null, 'slow result', 'sorry for the delay');
+        res.sendOk('slow result', 'sorry for the delay');
     }, 1000);
 });
 
 // bidirectional messages
 server.handler.register('ping', function onPing(req, res) {
     console.log('server got ping req from ' + req.remoteAddr);
-    res.send(null, 'pong', null);
+    res.sendOk('pong', null);
 });
 client.handler.register('ping', function onPing(req, res) {
     console.log('client got ping req from ' + req.remoteAddr);
-    res.send(null, 'pong', null);
+    res.sendOk('pong', null);
 });
 
 var ready = CountedReadySignal(3);

--- a/node/index.js
+++ b/node/index.js
@@ -210,7 +210,11 @@ TChannel.prototype.register = function register(name, handler) {
         );
 
         function onResponse(err, res1, res2) {
-            res.send(err, res1, res2);
+            if (err) {
+                res.sendNotOk(res1, err.message);
+            } else {
+                res.sendOk(res1, res2);
+            }
         }
     }
 };

--- a/node/index.js
+++ b/node/index.js
@@ -325,9 +325,22 @@ TChannel.prototype.addPeer = function addPeer(hostPort, connection) {
 // TODO: deprecated, callers should use .request directly
 TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
     var self = this;
+
     return self
         .request(options)
-        .send(arg1, arg2, arg3, callback);
+        .send(arg1, arg2, arg3, onResponse);
+
+    function onResponse(err, res) {
+        if (err) {
+            return callback(err);
+        }
+
+        if (!res.ok) {
+            return callback(new Error(String(res.arg3)));
+        }
+
+        return callback(null, res.arg2, res.arg3);
+    }
 };
 /* jshint maxparams:4 */
 

--- a/node/index.js
+++ b/node/index.js
@@ -60,7 +60,7 @@ var InvalidHandlerForRegister = TypedError({
 var noHandlerHandler = {
     type: 'no-handler.handler',
     handleRequest: function noHandlerHandler(req, res) {
-        res.send(NoHandlerError());
+        res.sendNotOk(null, NoHandlerError().message);
     }
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -36,15 +36,6 @@ var EndpointHandler = require('./endpoint-handler.js');
 
 var dumpEnabled = /\btchannel_dump\b/.test(process.env.NODE_DEBUG || '');
 
-var TChannelApplicationError = TypedError({
-    type: 'tchannel.application',
-    message: 'tchannel application error code {code}',
-    code: null,
-    arg1: null,
-    arg2: null,
-    arg3: null
-});
-
 var TChannelListenError = WrappedError({
     type: 'tchannel.server.listen-failed',
     message: 'tchannel: {origMessage}',
@@ -477,16 +468,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
         var op = self.popOutOp(res.id);
-        if (res.ok) {
-            op.req.emit('response', res);
-        } else {
-            op.req.emit('error', TChannelApplicationError({
-                code: res.code,
-                arg1: res.arg1,
-                arg2: res.arg2,
-                arg3: res.arg3
-            }));
-        }
+        op.req.emit('response', res);
     });
 
     self.handler.on('call.incoming.error', function onCallError(err) {

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -155,6 +155,7 @@ TChannelOutgoingResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
 
     self.sent = true;
     self.ok = false;
+    self.code = 1;
 
     self.sendFrame(self.arg1, res1, res2);
     self.emit('end');

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -134,19 +134,29 @@ function TChannelOutgoingResponse(id, options, sendFrame) {
 
 inherits(TChannelOutgoingResponse, EventEmitter);
 
-TChannelOutgoingResponse.prototype.send = function send(err, res1, res2) {
+TChannelOutgoingResponse.prototype.sendOk = function send(res1, res2) {
     var self = this;
     if (self.sent) {
         throw new Error('response already sent');
     }
+
     self.sent = true;
-    if (err) {
-        self.ok = false;
-        var errArg = isError(err) ? err.message : JSON.stringify(err); // TODO: better
-        self.sendFrame(self.arg1, res1, errArg);
-    } else {
-        self.sendFrame(self.arg1, res1, res2);
+    self.ok = true;
+
+    self.sendFrame(self.arg1, res1, res2);
+    self.emit('end');
+};
+
+TChannelOutgoingResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
+    var self = this;
+    if (self.sent) {
+        throw new Error('response already sent');
     }
+
+    self.sent = true;
+    self.ok = false;
+
+    self.sendFrame(self.arg1, res1, res2);
     self.emit('end');
 };
 
@@ -154,9 +164,3 @@ module.exports.IncomingRequest = TChannelIncomingRequest;
 module.exports.IncomingResponse = TChannelIncomingResponse;
 module.exports.OutgoingRequest = TChannelOutgoingRequest;
 module.exports.OutgoingResponse = TChannelOutgoingResponse;
-
-function isError(obj) {
-    return typeof obj === 'object' && (
-        Object.prototype.toString.call(obj) === '[object Error]' ||
-        obj instanceof Error);
-}

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -33,39 +33,39 @@ allocCluster.test('register() with different results', 2, function t(cluster, as
     one.handler = EndpointHandler();
 
     one.handler.register('/error', function error(req, res) {
-        res.send(new Error('abc'));
+        res.sendNotOk(null, 'abc');
     });
 
     one.handler.register('/buffer-head', function buffer(req, res) {
-        res.send(null, new Buffer('abc'), null);
+        res.sendOk(new Buffer('abc'), null);
     });
     one.handler.register('/string-head', function string(req, res) {
-        res.send(null, 'abc', null);
+        res.sendOk('abc', null);
     });
     one.handler.register('/object-head', function object(req, res) {
-        res.send(null, JSON.stringify({ value: 'abc' }), null);
+        res.sendOk(JSON.stringify({ value: 'abc' }), null);
     });
     one.handler.register('/null-head', function nullH(req, res) {
-        res.send(null, null, null);
+        res.sendOk(null, null);
     });
     one.handler.register('/undef-head', function undefH(req, res) {
-        res.send(null, undefined, null);
+        res.sendOk(undefined, null);
     });
 
     one.handler.register('/buffer-body', function buffer(req, res) {
-        res.send(null, null, new Buffer('abc'));
+        res.sendOk(null, new Buffer('abc'));
     });
     one.handler.register('/string-body', function string(req, res) {
-        res.send(null, null, 'abc');
+        res.sendOk(null, 'abc');
     });
     one.handler.register('/object-body', function object(req, res) {
-        res.send(null, null, JSON.stringify({ value: 'abc' }));
+        res.sendOk(null, JSON.stringify({ value: 'abc' }));
     });
     one.handler.register('/null-body', function nullB(req, res) {
-        res.send(null, null, null);
+        res.sendOk(null, null);
     });
     one.handler.register('/undef-body', function undefB(req, res) {
-        res.send(null, null, undefined);
+        res.sendOk(null, undefined);
     });
 
     parallel({
@@ -110,9 +110,11 @@ allocCluster.test('register() with different results', 2, function t(cluster, as
         assert.ifError(err);
 
         var errorCall = results.errorCall;
-        assert.ok(errorCall.err);
-        assert.equal(String(errorCall.err.arg2), '');
-        assert.equal(String(errorCall.err.arg3), 'abc');
+        assert.equal(errorCall.err, null);
+        assert.ok(Buffer.isBuffer(errorCall.head));
+        assert.equal(String(errorCall.head), '');
+        assert.ok(Buffer.isBuffer(errorCall.body));
+        assert.equal(String(errorCall.body), 'abc');
 
         var bufferHead = results.bufferHead;
         assert.equal(bufferHead.err, null);

--- a/node/test/regression-listening-on-used-port.js
+++ b/node/test/regression-listening-on-used-port.js
@@ -1,3 +1,23 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 var test = require('tape');
 
 var TChannel = require('../index.js');

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -35,7 +35,7 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
     one.handler.register('foo', function foo(req, res) {
         assert.ok(Buffer.isBuffer(req.arg2));
         assert.ok(Buffer.isBuffer(req.arg3));
-        res.send(null, req.arg2, req.arg3);
+        res.sendOk(req.arg2, req.arg3);
     });
 
     parallel({

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -89,7 +89,7 @@ allocCluster.test('requests will timeout', 2, {
     }
 
     function normalProxy(req, res) {
-        res.send(null, req.arg2, req.arg3);
+        res.sendOk(req.arg2, req.arg3);
     }
     function timeout(/* head, body, hostInfo, cb */) {
         // do not call cb();

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -72,36 +72,43 @@ CodeNames[Codes.ProtocolError] = 'protocol error';
 var CodeErrors = {};
 CodeErrors[Codes.Timeout] = TypedError({
     type: 'tchannel.timeout',
+    isErrorFrame: true,
     errorCode: Codes.Timeout,
     originalId: null
 });
 CodeErrors[Codes.Cancelled] = TypedError({
     type: 'tchannel.canceled',
+    isErrorFrame: true,
     errorCode: Codes.Cancelled,
     originalId: null
 });
 CodeErrors[Codes.Busy] = TypedError({
     type: 'tchannel.busy',
+    isErrorFrame: true,
     errorCode: Codes.Busy,
     originalId: null
 });
 CodeErrors[Codes.Declined] = TypedError({
     type: 'tchannel.declined',
+    isErrorFrame: true,
     errorCode: Codes.Declined,
     originalId: null
 });
 CodeErrors[Codes.UnexpectedError] = TypedError({
     type: 'tchannel.unexpected',
+    isErrorFrame: true,
     errorCode: Codes.UnexpectedError,
     originalId: null
 });
 CodeErrors[Codes.BadRequest] = TypedError({
     type: 'tchannel.bad-request',
+    isErrorFrame: true,
     errorCode: Codes.BadRequest,
     originalId: null
 });
 CodeErrors[Codes.ProtocolError] = TypedError({
     type: 'tchannel.protocol',
+    isErrorFrame: true,
     errorCode: Codes.ProtocolError,
     originalId: null
 });


### PR DESCRIPTION
This PR removes the automatic handling of errors
for the application developer.

It adds two new methods.

 - `resp.sendOk(arg2, arg3)`
 - `resp.sendNotOk(arg2, arg3)`

and removes `resp.send(err?, arg2, arg3)`

Since we are no longer having an opinion about error serialization
we also do not convert `IncomingCallResponse` into an error if
its `ok` boolean is set to `false`.

This means, just like with HTTP, the application developer
gets a response when making an outgoing `request` and has
to check the `ok` boolean on the response (similar to how you check
`statusCode` for HTTP).

The outgoing `request()` can still result in error objects though.
For example

 - time outs
 - network (TCP) issues
 - TChannel error frames

reviewers: @jcorbin @kriskowal

cc: @jsu1212