### PR TITLE
Speed up Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,25 @@
 ---
-language: python
 
+#
+# use container-based infrastructure
+# @see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+# @see http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+#
+sudo: false
+
+#
+# testing multiple subdirectories
+# @see https://lord.io/blog/2014/travis-multiple-subdirs/
+# @see https://www.dominicrodger.com/tox-and-travis.html
+#
+language: python
 env:
   - SUBDIR=node
-  - SUBDIR=python
   - SUBDIR=golang
+  - SUBDIR=python TOX_ENV=py27
+  - SUBDIR=python TOX_ENV=py34
+  - SUBDIR=python TOX_ENV=cover
+  - SUBDIR=python TOX_ENV=flake8
 
 install:
   - make -C $SUBDIR install
@@ -14,3 +29,16 @@ script:
 
 after_success:
   - coveralls
+
+#
+# cache dependencies and directories
+# note this can be used on public repos when using container-based infra
+# @see http://docs.travis-ci.com/user/caching/
+# @see http://stackoverflow.com/questions/22024789/speeding-up-travis-ci-dependencies-installation-for-angularjs-project
+# @see https://github.com/rgalanakis/goless/blob/master/.travis.yml
+#
+cache:
+  directories:
+    - node_modules
+    - .tox
+    - $HOME/.cache/pip

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -276,7 +276,7 @@ func (m *callReq) read(r typed.ReadBuffer) error {
 		return err
 	}
 
-	serviceNameLen, err := r.ReadUint16()
+	serviceNameLen, err := r.ReadByte()
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func (m *callReq) write(w typed.WriteBuffer) error {
 		return err
 	}
 
-	if err := w.WriteUint16(uint16(len(m.Service))); err != nil {
+	if err := w.WriteByte(byte(len(m.Service))); err != nil {
 		return err
 	}
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -12,14 +12,14 @@ test_args := --cov-report term-missing
 .PHONY: install test test_ci test-lint testhtml clean lint
 
 install:
-	pip install -r requirements-test.txt
+	pip install -r requirements-test.txt --download-cache $(HOME)/.cache/pip
 	python setup.py develop
 
 test: clean
 	$(pytest) $(test_args)
 
 test_ci: clean
-	tox
+	tox -e $(TOX_ENV)
 
 testhtml: clean
 	$(pytest) $(html_report) && open htmlcov/index.html


### PR DESCRIPTION
Travis is taking a long time. This is for many reasons.

* We are not caching anything installed  by npm & pip.
* Tox runs in serial for every version of Python.
* We run python tests even when we dont edit that directory (same for node).