### PR TITLE
Implement `resp.sendErrorFrame()`

### DIFF
--- a/node/reqres.js
+++ b/node/reqres.js
@@ -129,7 +129,7 @@ function TChannelOutgoingResponse(id, options, senders) {
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
-    self.sendCallResponseFrame = senders.callResponseFrame
+    self.sendCallResponseFrame = senders.callResponseFrame;
     self.sendErrorFrame = senders.errorFrame;
     self.sent = false;
 }

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -112,9 +112,13 @@ TChannelOutgoingRequest.prototype.hookupCallback = function hookupCallback(callb
     return self;
 };
 
-function TChannelOutgoingResponse(id, options, sendFrame) {
+function TChannelOutgoingResponse(
+    id, options, sendCallResponseFrame, sendErrorFrame
+) {
     if (!(this instanceof TChannelOutgoingResponse)) {
-        return new TChannelOutgoingResponse(id, options, sendFrame);
+        return new TChannelOutgoingResponse(
+            id, options, sendCallResponseFrame, sendErrorFrame
+        );
     }
     options = options || {};
     var self = this;
@@ -128,7 +132,8 @@ function TChannelOutgoingResponse(id, options, sendFrame) {
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
-    self.sendFrame = sendFrame;
+    self.sendCallResponseFrame = sendCallResponseFrame;
+    self.sendErrorFrame = sendErrorFrame;
     self.sent = false;
 }
 
@@ -143,7 +148,7 @@ TChannelOutgoingResponse.prototype.sendOk = function send(res1, res2) {
     self.sent = true;
     self.ok = true;
 
-    self.sendFrame(self.arg1, res1, res2);
+    self.sendCallResponseFrame(self.arg1, res1, res2);
     self.emit('end');
 };
 
@@ -157,7 +162,7 @@ TChannelOutgoingResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
     self.ok = false;
     self.code = 1;
 
-    self.sendFrame(self.arg1, res1, res2);
+    self.sendCallResponseFrame(self.arg1, res1, res2);
     self.emit('end');
 };
 

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -112,14 +112,11 @@ TChannelOutgoingRequest.prototype.hookupCallback = function hookupCallback(callb
     return self;
 };
 
-function TChannelOutgoingResponse(
-    id, options, sendCallResponseFrame, sendErrorFrame
-) {
+function TChannelOutgoingResponse(id, options, senders) {
     if (!(this instanceof TChannelOutgoingResponse)) {
-        return new TChannelOutgoingResponse(
-            id, options, sendCallResponseFrame, sendErrorFrame
-        );
+        return new TChannelOutgoingResponse(id, options, senders);
     }
+
     options = options || {};
     var self = this;
     EventEmitter.call(self);
@@ -132,8 +129,8 @@ function TChannelOutgoingResponse(
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
-    self.sendCallResponseFrame = sendCallResponseFrame;
-    self.sendErrorFrame = sendErrorFrame;
+    self.sendCallResponseFrame = senders.callResponseFrame
+    self.sendErrorFrame = senders.errorFrame;
     self.sent = false;
 }
 

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -133,6 +133,7 @@ ErrorResponse.read = read.chained(read.series([
 
 ErrorResponse.prototype.write = function writeErrorRes() {
     var self = this;
+
     return write.series([
         write.UInt8(self.code, 'ErrorResponse code'),  // code:1
         write.UInt32BE(self.id, 'ErrorResponse id'),   // id:4

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -45,6 +45,8 @@ function ErrorResponse(code, id, message) {
         self.id = id;
     }
     self.message = message ? write.bufferOrString(message) : emptyBuffer;
+
+    self.type = ErrorResponse.TypeCode;
 }
 
 ErrorResponse.TypeCode = 0xff;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -140,9 +140,10 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
 
 TChannelV2Handler.prototype.handleError = function handleError(errFrame, callback) {
     var self = this;
+
     var id = errFrame.id;
     var code = errFrame.body.code;
-    var message = errFrame.body.message;
+    var message = String(errFrame.body.message);
     var err = v2.ErrorResponse.CodeErrors[code]({
         originalId: id,
         message: message

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -70,7 +70,7 @@ TChannelV2Handler.prototype._write = function _write(frame, encoding, callback) 
             return self.handleCallRequest(frame, callback);
         case v2.Types.CallResponse:
             return self.handleCallResponse(frame, callback);
-        case v2.Types.Error:
+        case v2.Types.ErrorResponse:
             return self.handleError(frame, callback);
         default:
             return callback(TChannelUnhandledFrameTypeError({


### PR DESCRIPTION
This implements and test the ability to send error frames
as a response to an incoming call request.

This interface is not publically documented in purpose.
I believe it should only be used by autobahn and by
tchannel-as-*.

reviewers: @jcorbin @kriskowal

cc: @jsu1212