### PR TITLE
allocCluster: support specifying listen ports

### DIFF
--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -55,7 +55,8 @@ function allocCluster(n, opts) {
         var chan = TChannel(extend({
             logger: logger
         }, opts));
-        chan.listen(0, host);
+        var port = opts.listen && opts.listen[i] || 0;
+        chan.listen(port, host);
         ret.channels[i] = chan;
         chan.once('listening', chanReady);
 


### PR DESCRIPTION
This makes it easier to tcap a unit test, by temporarily adding something like `listen: [4040, 4041]` to a test's options.

reviewers: @Raynos @kriskowal 