### PR TITLE
Always treat args as buffers after req/res

### DIFF
--- a/node/reqres.js
+++ b/node/reqres.js
@@ -92,7 +92,10 @@ TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3, callbac
         throw new Error('request already sent');
     }
     self.sent = true;
-    self.sendFrame(arg1, arg2, arg3);
+    self.sendFrame(
+        arg1 ? Buffer(arg1) : null,
+        arg2 ? Buffer(arg2) : null,
+        arg3 ? Buffer(arg3) : null);
     self.emit('end');
     return self;
 };
@@ -145,7 +148,9 @@ TChannelOutgoingResponse.prototype.sendOk = function send(res1, res2) {
     self.sent = true;
     self.ok = true;
 
-    self.sendCallResponseFrame(self.arg1, res1, res2);
+    self.sendCallResponseFrame(self.arg1,
+        res1 ? Buffer(res1) : null,
+        res2 ? Buffer(res2) : null);
     self.emit('end');
 };
 
@@ -159,7 +164,9 @@ TChannelOutgoingResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
     self.ok = false;
     self.code = 1;
 
-    self.sendCallResponseFrame(self.arg1, res1, res2);
+    self.sendCallResponseFrame(self.arg1,
+        res1 ? Buffer(res1) : null,
+        res2 ? Buffer(res2) : null);
     self.emit('end');
 };
 


### PR DESCRIPTION
This allows the frame reading/writing layer to be tighter

reviewers: @Raynos @kriskowal 