### PR TITLE
Use null prototypes in checksum types

### DIFF
--- a/node/v2/checksum.js
+++ b/node/v2/checksum.js
@@ -64,11 +64,10 @@ Checksum.objOrType = function objOrType(arg) {
     }
 };
 
-Checksum.Types = {
-    None: 0x00,
-    CRC32: 0x01,
-    Farm32: 0x02
-};
+Checksum.Types = Object.create(null);
+Checksum.Types.None = 0x00;
+Checksum.Types.CRC32 = 0x01;
+Checksum.Types.Farm32 = 0x02;
 
 Checksum.read = read.chained(read.UInt8, function(type, buffer, offset) {
     switch (type) {


### PR DESCRIPTION
reviewers: @kriskowal @Raynos 