### PR TITLE
Add Channel.RoundTrip to simplify the common...

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -148,6 +148,34 @@ func (ch *TChannel) BeginCall(ctx context.Context, hostPort,
 	return call, nil
 }
 
+// RoundTrip calls a peer and waits for the response
+func (ch *TChannel) RoundTrip(ctx context.Context, hostPort, serviceName, operationName string,
+	reqArg2, reqArg3 Output, resArg2, resArg3 Input) (bool, error) {
+
+	call, err := ch.BeginCall(ctx, hostPort, serviceName, operationName)
+	if err != nil {
+		return false, err
+	}
+
+	if err := call.WriteArg2(reqArg2); err != nil {
+		return false, err
+	}
+
+	if err := call.WriteArg3(reqArg3); err != nil {
+		return false, err
+	}
+
+	if err := call.Response().ReadArg2(resArg2); err != nil {
+		return false, err
+	}
+
+	if err := call.Response().ReadArg3(resArg3); err != nil {
+		return false, err
+	}
+
+	return call.Response().ApplicationError(), nil
+}
+
 // ListenAndHandle runs a listener to accept and manage new incoming connections.
 // Blocks until the channel is closed.
 func (ch *TChannel) ListenAndHandle() error {

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -157,26 +157,11 @@ func testFragmentation(t *testing.T) {
 func sendRecv(ctx context.Context, ch *TChannel, hostPort string, serviceName, operation string,
 	arg2, arg3 []byte) ([]byte, []byte, error) {
 
-	call, err := ch.BeginCall(ctx, hostPort, serviceName, operation)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := call.WriteArg2(BytesOutput(arg2)); err != nil {
-		return nil, nil, err
-	}
-
-	if err := call.WriteArg3(BytesOutput(arg3)); err != nil {
-		return nil, nil, err
-	}
-
 	var respArg2 BytesInput
-	if err := call.Response().ReadArg2(&respArg2); err != nil {
-		return nil, nil, err
-	}
-
 	var respArg3 BytesInput
-	if err := call.Response().ReadArg3(&respArg3); err != nil {
+	_, err := ch.RoundTrip(ctx, hostPort, serviceName, operation,
+		BytesOutput(arg2), BytesOutput(arg3), &respArg2, &respArg3)
+	if err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
...case where clients just want to call a peer with known inputs and
outputs

