### PR TITLE
Golang tracing

### DIFF
--- a/golang/examples/client/main.go
+++ b/golang/examples/client/main.go
@@ -1,5 +1,25 @@
 package main
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"code.google.com/p/getopt"
 	"github.com/uber/tchannel/golang"

--- a/golang/examples/logger.go
+++ b/golang/examples/logger.go
@@ -1,5 +1,25 @@
 package examples
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	log "github.com/Sirupsen/logrus"
 )

--- a/golang/examples/server/main.go
+++ b/golang/examples/server/main.go
@@ -1,5 +1,25 @@
 package main
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"code.google.com/p/getopt"
 	"github.com/uber/tchannel/golang"

--- a/golang/logger.go
+++ b/golang/logger.go
@@ -1,5 +1,25 @@
 package tchannel
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // Logger provides an abstract interface for logging from TChannel.  Applications
 // can use whatever logging library they prefer as long as they implement this
 // interface

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -219,24 +219,11 @@ func (ch callHeaders) write(w typed.WriteBuffer) error {
 	return nil
 }
 
-// Tracing represents Zipkin-style tracing info
-type Tracing struct {
-	// The outer trace id.  Established at the outermost edge service and propagated through all calls
-	TraceID uint64
-
-	// The id of the parent span in this call graph
-	ParentID uint64
-
-	// The id of this specific RPC
-	SpanID uint64
-}
-
 // A CallReq for service
 type callReq struct {
 	id         uint32
 	TimeToLive time.Duration
-	Tracing    Tracing
-	TraceFlags byte
+	Tracing    Span
 	Headers    callHeaders
 	Service    []byte
 }
@@ -251,22 +238,22 @@ func (m *callReq) read(r typed.ReadBuffer) error {
 	}
 
 	m.TimeToLive = time.Duration(ttl) * time.Millisecond
-	m.Tracing.TraceID, err = r.ReadUint64()
+	m.Tracing.traceID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.Tracing.ParentID, err = r.ReadUint64()
+	m.Tracing.parentID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.Tracing.SpanID, err = r.ReadUint64()
+	m.Tracing.spanID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.TraceFlags, err = r.ReadByte()
+	m.Tracing.flags, err = r.ReadByte()
 	if err != nil {
 		return err
 	}
@@ -293,19 +280,19 @@ func (m *callReq) write(w typed.WriteBuffer) error {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.TraceID); err != nil {
+	if err := w.WriteUint64(m.Tracing.traceID); err != nil {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.ParentID); err != nil {
+	if err := w.WriteUint64(m.Tracing.parentID); err != nil {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.SpanID); err != nil {
+	if err := w.WriteUint64(m.Tracing.spanID); err != nil {
 		return err
 	}
 
-	if err := w.WriteByte(m.TraceFlags); err != nil {
+	if err := w.WriteByte(m.Tracing.flags); err != nil {
 		return err
 	}
 
@@ -346,8 +333,7 @@ const (
 type callRes struct {
 	id           uint32
 	ResponseCode ResponseCode
-	Tracing      Tracing
-	TraceFlags   byte
+	Tracing      Span
 	Headers      callHeaders
 }
 
@@ -361,22 +347,22 @@ func (m *callRes) read(r typed.ReadBuffer) error {
 		return err
 	}
 	m.ResponseCode = ResponseCode(c)
-	m.Tracing.TraceID, err = r.ReadUint64()
+	m.Tracing.traceID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.Tracing.ParentID, err = r.ReadUint64()
+	m.Tracing.parentID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.Tracing.SpanID, err = r.ReadUint64()
+	m.Tracing.spanID, err = r.ReadUint64()
 	if err != nil {
 		return err
 	}
 
-	m.TraceFlags, err = r.ReadByte()
+	m.Tracing.flags, err = r.ReadByte()
 	if err != nil {
 		return err
 	}
@@ -394,19 +380,19 @@ func (m *callRes) write(w typed.WriteBuffer) error {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.TraceID); err != nil {
+	if err := w.WriteUint64(m.Tracing.traceID); err != nil {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.ParentID); err != nil {
+	if err := w.WriteUint64(m.Tracing.parentID); err != nil {
 		return err
 	}
 
-	if err := w.WriteUint64(m.Tracing.SpanID); err != nil {
+	if err := w.WriteUint64(m.Tracing.spanID); err != nil {
 		return err
 	}
 
-	if err := w.WriteByte(m.TraceFlags); err != nil {
+	if err := w.WriteByte(m.Tracing.flags); err != nil {
 		return err
 	}
 

--- a/golang/messages_test.go
+++ b/golang/messages_test.go
@@ -68,12 +68,12 @@ func TestCallReq(t *testing.T) {
 	r := callReq{
 		id:         0xDEADBEEF,
 		TimeToLive: time.Second * 45,
-		Tracing: Tracing{
-			TraceID:  294390430934,
-			ParentID: 398348934,
-			SpanID:   12762782,
+		Tracing: Span{
+			traceID:  294390430934,
+			parentID: 398348934,
+			spanID:   12762782,
+			flags:    0x01,
 		},
-		TraceFlags: 0x01,
 		Headers: callHeaders{
 			"r": "c",
 			"f": "d",
@@ -104,12 +104,12 @@ func TestCallRes(t *testing.T) {
 			"r": "c",
 			"f": "d",
 		},
-		Tracing: Tracing{
-			TraceID:  294390430934,
-			ParentID: 398348934,
-			SpanID:   12762782,
+		Tracing: Span{
+			traceID:  294390430934,
+			parentID: 398348934,
+			spanID:   12762782,
+			flags:    0x04,
 		},
-		TraceFlags: 0x04,
 	}
 
 	assert.Equal(t, uint32(0xDEADBEEF), r.ID())

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -23,8 +23,13 @@ package tchannel
 import (
 	"fmt"
 	"math/rand"
+	"time"
 
 	"golang.org/x/net/context"
+)
+
+var (
+	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 // Span represents Zipkin-style span
@@ -46,7 +51,7 @@ const (
 
 // NewRootSpan creates a new top-level Span for a call-graph within the provided context
 func NewRootSpan() *Span {
-	return &Span{traceID: uint64(rand.Int63())}
+	return &Span{traceID: uint64(rng.Int63())}
 }
 
 // TraceID returns the trace id for the entire call graph of requests. Established at the outermost
@@ -76,7 +81,7 @@ func (s Span) NewChildSpan() *Span {
 	return &Span{
 		traceID:  s.traceID,
 		parentID: s.spanID,
-		spanID:   uint64(rand.Int63()),
+		spanID:   uint64(rng.Int63()),
 		flags:    s.flags,
 	}
 }

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -62,8 +62,8 @@ func (s Span) NewChildSpan() *Span {
 }
 
 // NewRootContext creates a new root context for making outbound calls
-func NewRootContext() context.Context {
-	return context.WithValue(context.Background(), tracingKey, NewRootSpan())
+func NewRootContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, tracingKey, NewRootSpan())
 }
 
 // CurrentSpan returns the Span value for the provided Context

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -1,5 +1,25 @@
 package tchannel
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"fmt"
 	"math/rand"

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -1,0 +1,76 @@
+package tchannel
+
+import (
+	"fmt"
+	"math/rand"
+
+	"golang.org/x/net/context"
+)
+
+// Span represents Zipkin-style span
+type Span struct {
+	traceID  uint64
+	parentID uint64
+	spanID   uint64
+	flags    byte
+}
+
+func (s Span) String() string {
+	return fmt.Sprintf("TraceID=%d,ParentID=%d,SpanID=%d", s.traceID, s.parentID, s.spanID)
+}
+
+const (
+	tracingFlagEnabled byte = 0x01
+	tracingKey              = "tracing"
+)
+
+// NewRootSpan creates a new top-level Span for a call-graph within the provided context
+func NewRootSpan() *Span {
+	return &Span{traceID: uint64(rand.Int63())}
+}
+
+// TraceID returns the trace id for the entire call graph of requests. Established at the outermost
+// edge service and propagated through all calls
+func (s Span) TraceID() uint64 { return s.traceID }
+
+// ParentID returns the id of the parent span in this call graph
+func (s Span) ParentID() uint64 { return s.parentID }
+
+// SpanID returns the id of this specific RPC
+func (s Span) SpanID() uint64 { return s.spanID }
+
+// EnableTracing controls whether tracing is enabled for this context
+func (s *Span) EnableTracing(enabled bool) {
+	if enabled {
+		s.flags |= tracingFlagEnabled
+	} else {
+		s.flags &= ^tracingFlagEnabled
+	}
+}
+
+// TracingEnabled checks whether tracing is enabled for this context
+func (s Span) TracingEnabled() bool { return (s.flags & tracingFlagEnabled) == tracingFlagEnabled }
+
+// NewChildSpan begins a new child span in the provided Context
+func (s Span) NewChildSpan() *Span {
+	return &Span{
+		traceID:  s.traceID,
+		parentID: s.spanID,
+		spanID:   uint64(rand.Int63()),
+		flags:    s.flags,
+	}
+}
+
+// NewRootContext creates a new root context for making outbound calls
+func NewRootContext() context.Context {
+	return context.WithValue(context.Background(), tracingKey, NewRootSpan())
+}
+
+// CurrentSpan returns the Span value for the provided Context
+func CurrentSpan(ctx context.Context) *Span {
+	if span := ctx.Value(tracingKey); span != nil {
+		return span.(*Span)
+	}
+
+	return nil
+}

--- a/golang/tracing_test.go
+++ b/golang/tracing_test.go
@@ -1,0 +1,122 @@
+package tchannel
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+type TracingRequest struct{}
+
+type TracingResponse struct {
+	TraceID  uint64
+	SpanID   uint64
+	ParentID uint64
+	Child    *TracingResponse
+}
+
+type Headers map[string]string
+
+func TestTracingPropagates(t *testing.T) {
+	ch, err := NewChannel(":0", nil)
+	require.Nil(t, err)
+
+	srv1 := func(ctx context.Context, call *InboundCall) {
+		headers := Headers{}
+
+		var request TracingRequest
+		if err := call.ReadArg2(NewJSONInput(&headers)); err != nil {
+			return
+		}
+
+		if err := call.ReadArg3(NewJSONInput(&request)); err != nil {
+			return
+		}
+
+		span := CurrentSpan(ctx)
+
+		var childRequest TracingRequest
+		var childResponse TracingResponse
+		if _, err := ch.RoundTrip(ctx, ch.HostPort(), "TestService", "call2",
+			NewJSONOutput(headers), NewJSONOutput(childRequest),
+			NewJSONInput(&headers), NewJSONInput(&childResponse)); err != nil {
+			call.Response().SendSystemError(err)
+			return
+		}
+
+		response := TracingResponse{
+			TraceID: span.TraceID(),
+			SpanID:  span.SpanID(),
+			Child:   &childResponse,
+		}
+
+		call.Response().WriteArg2(NewJSONOutput(headers))
+		call.Response().WriteArg3(NewJSONOutput(response))
+	}
+
+	srv2 := func(ctx context.Context, call *InboundCall) {
+		span := CurrentSpan(ctx)
+		if span == nil {
+			call.Response().SendSystemError(NewSystemError(ErrorCodeUnexpected, "tracing not found"))
+			return
+		}
+
+		call.Response().WriteArg2(NewJSONOutput(Headers{}))
+		call.Response().WriteArg3(NewJSONOutput(TracingResponse{
+			SpanID:   span.SpanID(),
+			TraceID:  span.TraceID(),
+			ParentID: span.ParentID(),
+		}))
+	}
+
+	ch.Register(HandlerFunc(srv1), "TestService", "call1")
+	ch.Register(HandlerFunc(srv2), "TestService", "call2")
+
+	go ch.ListenAndHandle()
+
+	ctx, cancel := context.WithTimeout(NewRootContext(), 5*time.Second)
+	defer cancel()
+
+	headers := map[string]string{}
+	var request TracingRequest
+	var response TracingResponse
+
+	if _, err := ch.RoundTrip(ctx, ch.HostPort(), "TestService", "call1",
+		NewJSONOutput(headers), NewJSONOutput(&request),
+		NewJSONInput(&headers), NewJSONInput(&response)); err != nil {
+		require.Nil(t, err)
+	}
+
+	clientSpan := CurrentSpan(ctx)
+	require.NotNil(t, clientSpan)
+
+	assert.Equal(t, clientSpan.TraceID(), response.TraceID)
+	assert.Equal(t, clientSpan.SpanID(), response.ParentID)
+
+	nestedResponse := response.Child
+	require.NotNil(t, nestedResponse)
+	assert.Equal(t, clientSpan.TraceID(), nestedResponse.TraceID)
+	assert.Equal(t, response.SpanID, nestedResponse.ParentID)
+}

--- a/golang/tracing_test.go
+++ b/golang/tracing_test.go
@@ -96,7 +96,7 @@ func TestTracingPropagates(t *testing.T) {
 
 	go ch.ListenAndHandle()
 
-	ctx, cancel := context.WithTimeout(NewRootContext(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(NewRootContext(context.Background()), 5*time.Second)
 	defer cancel()
 
 	headers := map[string]string{}


### PR DESCRIPTION
Implements Zipkin span creation and propagation.  All outbound calls are automatically assigned new Spans, spans are propagated from caller to receiver, the current span is available from receiver via the context object.

R: @sectioneight 
