### PR TITLE
Remove library dependency on go-logging

### DIFF
--- a/golang/Godeps/Godeps.json
+++ b/golang/Godeps/Godeps.json
@@ -11,8 +11,9 @@
 			"Rev": "b23bed28ee5ccc4746cae29f3a2a808d112c6a83"
 		},
 		{
-			"ImportPath": "github.com/op/go-logging",
-			"Rev": "fb0230561a6ba1cab17beb95f1faedc16584fdb8"
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.6.6-2-g2cea0f0",
+			"Rev": "2cea0f0d141f56fae06df5b813ec4119d1c8ccbd"
 		},
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -23,7 +23,6 @@ package tchannel
 import (
 	"errors"
 	"fmt"
-	"github.com/op/go-logging"
 	"github.com/uber/tchannel/golang/typed"
 	"golang.org/x/net/context"
 	"net"
@@ -86,7 +85,7 @@ type ConnectionOptions struct {
 // Connection represents a connection to a remote peer.
 type Connection struct {
 	ch             *TChannel
-	log            *logging.Logger
+	log            Logger
 	checksumType   ChecksumType
 	framePool      FramePool
 	conn           net.Conn
@@ -388,7 +387,7 @@ func (c *Connection) closeNetwork() {
 	// NB(mmihic): The sender goroutine	will exit once the connection is closed; no need to close
 	// the send channel (and closing the send channel would be dangerous since other goroutine might be sending)
 	if err := c.conn.Close(); err != nil {
-		c.log.Warning("could not close connection to peer %s: %v", c.remotePeerInfo, err)
+		c.log.Warnf("could not close connection to peer %s: %v", c.remotePeerInfo, err)
 	}
 }
 

--- a/golang/examples/logger.go
+++ b/golang/examples/logger.go
@@ -1,0 +1,13 @@
+package examples
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+// LogrusLogger implements a tchannel.Logger on tope of logrus
+type LogrusLogger struct{}
+
+func (l LogrusLogger) Errorf(msg string, args ...interface{}) { log.Errorf(msg, args...) }
+func (l LogrusLogger) Warnf(msg string, args ...interface{})  { log.Warnf(msg, args...) }
+func (l LogrusLogger) Infof(msg string, args ...interface{})  { log.Infof(msg, args...) }
+func (l LogrusLogger) Debugf(msg string, args ...interface{}) { log.Debugf(msg, args...) }

--- a/golang/logger.go
+++ b/golang/logger.go
@@ -1,0 +1,33 @@
+package tchannel
+
+// Logger provides an abstract interface for logging from TChannel.  Applications
+// can use whatever logging library they prefer as long as they implement this
+// interface
+type Logger interface {
+	// Errorf logs a message at error priority
+	Errorf(msg string, args ...interface{})
+
+	// Warnf logs a message at warning priority
+	Warnf(msg string, args ...interface{})
+
+	// Infof logs a message at info priority
+	Infof(msg string, args ...interface{})
+
+	// Debugf logs a message at debug priority
+	Debugf(msg string, args ...interface{})
+}
+
+// NullLogger is a logger that emits nowhere
+type NullLogger struct{}
+
+// Errorf logs a message at error priority
+func (l NullLogger) Errorf(msg string, args ...interface{}) {}
+
+// Warnf logs a message at warning priority
+func (l NullLogger) Warnf(msg string, args ...interface{}) {}
+
+// Infof logs a message at info priority
+func (l NullLogger) Infof(msg string, args ...interface{}) {}
+
+// Debugf logs a message at debug priority
+func (l NullLogger) Debugf(msg string, args ...interface{}) {}


### PR DESCRIPTION
Applications can use any logging library they prefer by providing an
implementation of tchannel.Logger.