### PR TITLE
Allow extending logger with additional context

### DIFF
--- a/golang/examples/client/main.go
+++ b/golang/examples/client/main.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var log = examples.LogrusLogger{}
+var log = examples.StandardLogger()
 
 var peerAddr = getopt.StringLong("peer", 'p', "", "Host and port of remote peer")
 var serviceName = getopt.StringLong("service", 's', "", "Name of service to invoke")

--- a/golang/examples/logger.go
+++ b/golang/examples/logger.go
@@ -1,13 +1,31 @@
 package examples
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
+	"github.com/uber/tchannel/golang"
 )
 
-// LogrusLogger implements a tchannel.Logger on tope of logrus
-type LogrusLogger struct{}
+// lgrusLogger implements a tchannel.Logger on top of logrus
+type logrusLogger struct {
+	log *logrus.Entry
+}
 
-func (l LogrusLogger) Errorf(msg string, args ...interface{}) { log.Errorf(msg, args...) }
-func (l LogrusLogger) Warnf(msg string, args ...interface{})  { log.Warnf(msg, args...) }
-func (l LogrusLogger) Infof(msg string, args ...interface{})  { log.Infof(msg, args...) }
-func (l LogrusLogger) Debugf(msg string, args ...interface{}) { log.Debugf(msg, args...) }
+var (
+	std = NewLogger(logrus.StandardLogger())
+)
+
+// StandardLogger returns the standard tchannel Logger
+func StandardLogger() tchannel.ContextLogger { return std }
+
+// NewLogger creates a new tchannel Logger around a logrus Logger
+func NewLogger(log *logrus.Logger) tchannel.ContextLogger {
+	return &logrusLogger{log: logrus.NewEntry(log)}
+}
+
+func (l *logrusLogger) Errorf(msg string, args ...interface{}) { l.log.Errorf(msg, args...) }
+func (l *logrusLogger) Warnf(msg string, args ...interface{})  { l.log.Warnf(msg, args...) }
+func (l *logrusLogger) Infof(msg string, args ...interface{})  { l.log.Infof(msg, args...) }
+func (l *logrusLogger) Debugf(msg string, args ...interface{}) { l.log.Debugf(msg, args...) }
+func (l *logrusLogger) WithContext(context tchannel.LogContext) tchannel.ContextLogger {
+	return &logrusLogger{l.log.WithFields(logrus.Fields(context))}
+}

--- a/golang/examples/server/main.go
+++ b/golang/examples/server/main.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-var log = examples.LogrusLogger{}
+var log = examples.StandardLogger()
 
 func echo(ctx context.Context, call *tchannel.InboundCall) {
 	var inArg2 tchannel.BytesInput

--- a/golang/logger.go
+++ b/golang/logger.go
@@ -17,6 +17,19 @@ type Logger interface {
 	Debugf(msg string, args ...interface{})
 }
 
+// LogContext is additional context information that can be passed to a Logger
+type LogContext map[string]interface{}
+
+// A ContextLogger is a Logger which can be extended with additional context information
+// in the form of name/value pairs.  Useful for wrapping structured log libraries (e.g. logrus)
+type ContextLogger interface {
+	Logger
+
+	// WithContext extends this logger with additional context information, returning
+	// a new logger that will include this context in log events
+	WithContext(context LogContext) ContextLogger
+}
+
 // NullLogger is a logger that emits nowhere
 type NullLogger struct{}
 


### PR DESCRIPTION
Use this context to specify the localPeerInfo and remotePeerInfo on
connections