### PR TITLE
Add argstream module

### DIFF
--- a/node/argstream.js
+++ b/node/argstream.js
@@ -1,0 +1,272 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+/*
+ * Provides federated streams for handling call arguments
+ *
+ * InArgStream is for handling incoming arg parts from call frames.  It handles
+ * dispatching the arg chunks into .arg{1,2,3} streams.
+ *
+ * OutArgStream is for creating outgoing arg parts by writing to .arg{1,2,3}
+ * streams.  It handles buffering as many parts as are written within one event
+ * loop tick into an Array of arg chunks.  Such array is then flushed using
+ * setImmediate.
+ *
+ * Due to the semantic complexity involved here, this code is tested by an
+ * accompanying exhaistive search test in test/argstream.js.  This test has
+ * both unit tests (disabled by default for speed) and an integration test.
+ */
+
+var inherits = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
+var PassThrough = require('stream').PassThrough;
+var Ready = require('ready-signal');
+var TypedError = require('error/typed');
+
+var ArgChunkOutOfOrderError = TypedError({
+    type: 'arg-chunk-out-of-order',
+    message: 'out of order arg chunk, current: {current} got: {got}',
+    current: null,
+    got: null
+});
+
+var ArgChunkGapError = TypedError({
+    type: 'arg-chunk-gap',
+    message: 'arg chunk gap, current: {current} got: {got}',
+    current: null,
+    got: null
+});
+
+function ArgStream() {
+    var self = this;
+    EventEmitter.call(self);
+    self.arg1 = StreamArg();
+    self.arg2 = StreamArg();
+    self.arg3 = StreamArg();
+
+    self.arg1.on('error', passError);
+    self.arg2.on('error', passError);
+    self.arg3.on('error', passError);
+    function passError(err) {
+        self.emit('error', err);
+    }
+
+    self.arg2.on('start', function onArg2Start() {
+        if (!self.arg1._writableState.ended) self.arg1.end();
+    });
+    self.arg3.on('start', function onArg3Start() {
+        if (!self.arg2._writableState.ended) self.arg2.end();
+    });
+}
+
+inherits(ArgStream, EventEmitter);
+
+function InArgStream() {
+    var self = this;
+    ArgStream.call(self);
+    self.streams = [self.arg1, self.arg2, self.arg3];
+    self._iStream = 0;
+    self.finished = false;
+    self._numFinished = 0;
+    self.arg1.on('finish', argFinished);
+    self.arg2.on('finish', argFinished);
+    self.arg3.on('finish', argFinished);
+    function argFinished() {
+        if (++self._numFinished === 3) {
+            self.finished = true;
+            self.emit('finish');
+        }
+    }
+}
+
+inherits(InArgStream, ArgStream);
+
+InArgStream.prototype.handleFrame = function handleFrame(parts) {
+    var self = this;
+    var stream = self.streams[self._iStream];
+
+    if (parts === null) {
+        while (stream) stream = advance();
+        return;
+    }
+
+    if (self.finished) {
+        throw new Error('arg stream finished'); // TODO typed error
+    }
+
+    for (var i = 0; i < parts.length; i++) {
+        if (i > 0) stream = advance();
+        if (!stream) break;
+        if (parts[i].length) stream.write(parts[i]);
+    }
+    if (i < parts.length) {
+        throw new Error('frame parts exceeded stream arity'); // TODO clearer / typed error
+    }
+
+    function advance() {
+        if (self._iStream < self.streams.length) {
+            self.streams[self._iStream].end();
+            self._iStream++;
+        }
+        return self.streams[self._iStream];
+    }
+};
+
+function OutArgStream() {
+    var self = this;
+    ArgStream.call(self);
+    self._flushImmed = null;
+    self.finished = false;
+    self.frame = [Buffer(0)];
+    self.currentArgN = 1;
+    self.arg1.on('data', function onArg1Data(chunk) {
+        self._handleFrameChunk(1, chunk);
+    });
+    self.arg2.on('data', function onArg2Data(chunk) {
+        self._handleFrameChunk(2, chunk);
+    });
+    self.arg3.on('data', function onArg3Data(chunk) {
+        self._handleFrameChunk(3, chunk);
+    });
+
+    self.arg1.on('finish', function onArg1Finish() {
+        self._handleFrameChunk(1, null);
+    });
+    self.arg2.on('finish', function onArg2Finish() {
+        self._handleFrameChunk(2, null);
+    });
+    self.arg3.on('finish', function onArg3Finish() {
+        self._handleFrameChunk(3, null);
+        self._flushParts(true);
+        self.finished = true;
+        self.emit('finish');
+    });
+}
+
+inherits(OutArgStream, ArgStream);
+
+OutArgStream.prototype._handleFrameChunk = function _handleFrameChunk(n, chunk) {
+    var self = this;
+    if (n < self.currentArgN) {
+        self.emit('error', ArgChunkOutOfOrderError({
+            current: self.currentArgN,
+            got: n
+        }));
+    } else if (n > self.currentArgN) {
+        if (n - self.currentArgN > 1) {
+            self.emit('error', ArgChunkGapError({
+                current: self.currentArgN,
+                got: n
+            }));
+        }
+        self.currentArgN++;
+        self.frame.push(chunk);
+    } else if (chunk === null) {
+        if (++self.currentArgN <= 3) {
+            self.frame.push(Buffer(0));
+        }
+    } else {
+        self._appendFrameChunk(chunk);
+    }
+    self._deferFlushParts();
+};
+
+OutArgStream.prototype._appendFrameChunk = function _appendFrameChunk(chunk) {
+    var self = this;
+    var i = self.frame.length - 1;
+    var buf = self.frame[i];
+    if (buf.length) {
+        self.frame[i] = Buffer.concat([buf, chunk]);
+    } else {
+        self.frame[i] = chunk;
+    }
+};
+
+OutArgStream.prototype._deferFlushParts = function _deferFlushParts() {
+    var self = this;
+    if (!self._flushImmed) {
+        self._flushImmed = setImmediate(function() {
+            self._flushParts();
+        });
+    }
+};
+
+OutArgStream.prototype._flushParts = function _flushParts(isLast) {
+    var self = this;
+    if (self._flushImmed) {
+        clearImmediate(self._flushImmed);
+        self._flushImmed = null;
+    }
+    if (self.finished) return;
+    isLast = Boolean(isLast);
+    var frame = self.frame;
+    self.frame = [Buffer(0)];
+    if (frame.length) self.emit('frame', frame, isLast);
+};
+
+function StreamArg(options) {
+    if (!(this instanceof StreamArg)) {
+        return new StreamArg(options);
+    }
+    var self = this;
+    PassThrough.call(self, options);
+    self.started = false;
+    self.onValueReady = self.onValueReady.bind(self);
+}
+inherits(StreamArg, PassThrough);
+
+StreamArg.prototype._write = function _write(chunk, encoding, callback) {
+    var self = this;
+    if (!self.started) {
+        self.started = true;
+        self.emit('start');
+    }
+    PassThrough.prototype._write.call(self, chunk, encoding, callback);
+};
+
+StreamArg.prototype.onValueReady = function onValueReady(callback) {
+    var self = this;
+    self.onValueReady = Ready();
+    bufferStreamData(self, self.onValueReady.signal);
+    self.onValueReady(callback);
+};
+
+function bufferStreamData(stream, callback) {
+    var parts = [];
+    stream.on('data', onData);
+    stream.on('error', finish);
+    stream.on('end', finish);
+    function onData(chunk) {
+        parts.push(chunk);
+    }
+    function finish(err) {
+        stream.removeListener('data', onData);
+        stream.removeListener('error', finish);
+        stream.removeListener('end', finish);
+        var buf = Buffer.concat(parts);
+        if (err === undefined) err = null;
+        callback(err, buf);
+    }
+}
+
+module.exports.InArgStream = InArgStream;
+module.exports.OutArgStream = OutArgStream;

--- a/node/test/argstream.js
+++ b/node/test/argstream.js
@@ -1,0 +1,381 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+/*
+ * HOWDO:
+ *
+ * This test tests argstream by exhaustive search.
+ *
+ * For speed concerns, it's set to only run the integration test which is
+ * sufficient to catch regressions.
+ *
+ * However, since you're reading this, you'll probably want to instead change
+ * it to run the unit tests to help understand which side the failure is on.
+ *
+ * If you doubt the exhaustive or correct nature of the search, you may be
+ * served by running the sanity test to iterate on the searcher itself.
+ */
+
+var test = require('tape');
+var util = require('util');
+
+var TestSearch = require('./lib/test_search');
+var argstream = require('../argstream');
+
+/* jshint camelcase:false */
+
+// Useful for verifying the searcher
+test.skip('setup sanity', argSearchTest(function t(state, assert) {
+    var frames = state.frames;
+    var args = state.args;
+
+    // should only combine to 3 args
+    assert.equal(args.length, 3);
+
+    // shouldn't have any duplicate letters
+    var counts = chrCounts(frames.map(function each(frame) {
+        return frame.join('');
+    }).join(''));
+    var ks = Object.keys(counts);
+    for (var i = 0; i < ks.length; i++) {
+        if (counts[ks[i]] > 1) {
+            assert.fail(util.format('bad test state', state));
+            break;
+        }
+    }
+
+    assert.end();
+}));
+
+test('argstream', function t(assert) {
+    var verbose = true;
+    if (module === require.main) {
+        var argv = require('minimist', {
+            boolean: {
+                verbose: true
+            },
+            default: {
+                verbose: verbose
+            }
+        })(process.argv.slice(2));
+        verbose = argv.verbose;
+    }
+
+    assert.test('unit test OutArgStream', {skip: !verbose}, argSearchTest(function t(state, assert) {
+        var frames = state.frames;
+        var expect = realFrames(frames);
+        var gotI = 0;
+        var s = new argstream.OutArgStream();
+        s.on('frame', function onFrame(parts) {
+            var expected = expect[gotI++];
+            if (!expected) {
+                assert.fail(util.format('unexpected frame %s: ', gotI, parts));
+            } else {
+                assert.deepEqual(parts, expected.map(function(part) {
+                    return new Buffer(part);
+                }), 'expected frame ' + gotI);
+            }
+        });
+        s.once('finish', function() {
+            assert.equal(gotI, expect.length, 'got all expected frames');
+        });
+        hookupEnd(s, finish);
+        writeFrames(frames, s, finish);
+        function finish(err) {
+            assert.ifError(err, 'no unexpected error');
+            assert.end();
+        }
+    }));
+
+    assert.test('unit test InArgStream', {skip: !verbose}, argSearchTest(function t(state, assert) {
+        var frames = state.frames;
+        var args = state.args;
+        var s = new argstream.InArgStream();
+        hookupEnd(s, finish);
+        realFrames(frames).forEach(function eachFrame(parts) {
+            s.handleFrame(parts);
+        });
+        s.handleFrame(null);
+        function finish(err) {
+            assert.ifError(err, 'no end error');
+            assert.equal(getArg(s.arg1), args[0] || null, 'expected arg1');
+            assert.equal(getArg(s.arg2), args[1] || null, 'expected arg2');
+            assert.equal(getArg(s.arg3), args[2] || null, 'expected arg3');
+            assert.end();
+        }
+    }));
+
+    assert.test('integration test {Out -> In}ArgStream', {skip: verbose}, argSearchTest(function t(state, assert) {
+        var frames = state.frames;
+        var args = state.args;
+        var o = new argstream.OutArgStream();
+        var i = new argstream.InArgStream();
+        o.on('frame', function onFrame(parts) {
+            i.handleFrame(parts);
+        });
+        hookupEnd(o, finish);
+        writeFrames(frames, o, finish);
+        function finish(err) {
+            assert.ifError(err, 'no end error');
+            i.handleFrame(null);
+            assert.equal(getArg(i.arg1), args[0] || null, 'expected arg1');
+            assert.equal(getArg(i.arg2), args[1] || null, 'expected arg2');
+            assert.equal(getArg(i.arg3), args[2] || null, 'expected arg3');
+            assert.end();
+        }
+    }));
+});
+
+function argSearchTest(testFunc) {
+    var search = TestSearch({
+        describeState: function describe(state) {
+            return state.frames.map(function each(frame) {
+                return frame.join('.');
+            }).join('_');
+        },
+
+        init: function init() {
+            var self = this;
+            self.frontier.push({
+                frames: [['', '', '']]
+            });
+        },
+
+        test: function test(state, assert) {
+            var self = this;
+            var frames = state.frames;
+
+            var args = state.args = [];
+            var i = 0;
+            args[i] = '';
+            for (var j = 0; j < frames.length; j++) {
+                var frame = frames[j];
+                for (var k = 0; k < frame.length; k++) {
+                    if (k > 0) args[++i] = '';
+                    args[i] += frame[k];
+                }
+            }
+
+            testFunc.call(self, state, assert);
+        },
+
+        next: function next(state, _emit) {
+            var layers = [
+                addPauses,
+                addContent,
+            ];
+            gen(state.frames, 0, emit);
+
+            function gen(frames, i, emit) {
+                if (i < layers.length) {
+                    layers[i](frames, function(frames) {
+                        if (filter(frames)) {
+                            gen(frames, i+1, emit);
+                        }
+                    });
+                } else if (filter(frames)) {
+                    emit(frames);
+                }
+            }
+
+            function emit(frames) {
+                _emit({frames: relabel(frames)});
+            }
+        }
+    });
+    return search.run.bind(search);
+}
+
+function realFrames(frames) {
+    return frames.filter(function(frame) {
+        if (!frame.length) return false;
+        if (frame.length === 1 && !frame[0].length) return false;
+        return true;
+    });
+}
+
+function writeFrames(frames, s, callback) {
+    var writingArg = 1;
+    eachFrame(0);
+    function eachFrame(i) {
+        var stream = s['arg' + writingArg];
+        if (i >= frames.length) {
+            if (stream) stream.end();
+            return;
+        }
+        var frame = frames[i];
+        if (!stream) return callback(new Error('ran out of arg streams'));
+        for (var j = 0; j < frame.length; j++) {
+            if (j > 0) {
+                stream.end();
+                stream = s['arg' + (++writingArg)];
+                if (!stream) return callback(new Error('ran out of arg streams'));
+            }
+            if (j === frame.length - 1 && i === frames.length - 1) {
+                stream.end(frame[j]);
+                writingArg++;
+            } else {
+                stream.write(frame[j]);
+            }
+        }
+        setImmediate(eachFrame, i+1);
+    }
+}
+
+function chrCounts(s) {
+    var counts = {};
+    s.split('').forEach(function(chr) {
+        counts[chr] = (counts[chr] || 0) + 1;
+    });
+    return counts;
+}
+
+function addPauses(frames, emit) {
+    for (var i = 0; i<frames.length; i++) {
+        var head = frames.slice(0, i);
+        var tail = frames.slice(i + 1);
+        var frame = frames[i];
+        for (var j = 0; j<frame.length; j++) {
+            var a = frame.slice(0, j);
+            var b = frame.slice(j);
+            if (a.length && b.length) {
+                emit(head.concat([a.concat(['']), b]).concat(tail));
+                emit(head.concat([a, [''].concat(b)]).concat(tail));
+            } else if (a.length || b.length) {
+                emit(head.concat([a, b]).concat(tail));
+            }
+        }
+    }
+}
+
+function addContent(frames, emit) {
+    var chr = greatestChr(frames);
+    for (var i = 0; i < frames.length; i++) {
+        var head = frames.slice(0, i);
+        var tail = frames.slice(i + 1);
+        var frame = frames[i];
+        for (var j = 0; j < frame.length; j++) {
+            if (!frame[j].length) {
+                var part = frame.slice(0, j)
+                    .concat([String.fromCharCode(chr)])
+                    .concat(frame.slice(j+1));
+                emit(head.concat([part]).concat(tail));
+            }
+        }
+    }
+}
+
+function greatestChr(frames) {
+    var chr = 0x41;
+    for (var i = 0; i<frames.length; i++) {
+        var frame = frames[i];
+        for (var j = 0; j<frame.length; j++) {
+            if (frame[j].length) {
+                chr = Math.max(chr, frame[j].charCodeAt(0) + 1);
+            }
+        }
+    }
+    return chr;
+}
+
+function relabel(frames) {
+    var chr = 0x41;
+    var ret = new Array(frames.length);
+    for (var i = 0; i < frames.length; i++) {
+        var frame = frames[i];
+        ret[i] = new Array(frame.length);
+        for (var j = 0; j < frame.length; j++) {
+            ret[i][j] = frame[j].length ? String.fromCharCode(chr++) : '';
+        }
+    }
+    return ret;
+}
+
+function filter(frames) {
+    var i;
+    var ends = 0;
+    for (i = 0; i < frames.length; i++) {
+        if (frames[i].length > 1) ends++;
+    }
+    if (ends > 3) return false;
+    var run = 0;
+    for (i = 1; i < frames.length; i++) {
+        if (run || frames[i-1].length === 1) {
+            if (frames[i].length === 1) {
+                if (++run > 2) return false;
+            } else if (frames[i].length > 1 && run) {
+                return false;
+            } else {
+                run = 0;
+            }
+        }
+    }
+    simplify(frames);
+    return true;
+}
+
+function simplify(frames) {
+    var i = 1;
+    while (i < frames.length) {
+        var a = frames[i-1];
+        var b = frames[i];
+        if (!b.length) {
+            if (!a.length) {
+                frames.splice(i-1, 2, []);
+            } else {
+                frames.splice(i, 1);
+            }
+        } else if (b.length === 1 && b[0] === '') {
+            if (a.length === 1 && a[0] === '') {
+                frames.splice(i-1, 2, ['']);
+            } else {
+                frames.splice(i, 1);
+            }
+        } else {
+            i++;
+        }
+    }
+}
+
+function hookupEnd(stream, callback) {
+    stream.on('finish', onFinish);
+    stream.on('error', onError);
+    function onError(err) {
+        stream.removeListener('finish', onFinish);
+        stream.removeListener('error', onError);
+        callback(err);
+    }
+    function onFinish() {
+        stream.removeListener('finish', onFinish);
+        stream.removeListener('error', onError);
+        callback();
+    }
+}
+
+function getArg(arg) {
+    var val = arg.read();
+    if (val !== null) {
+        return val.toString();
+    } else {
+        return val;
+    }
+}

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+require('./argstream.js');
 require('./safe-quit.js');
 require('./timeouts.js');
 require('./send.js');

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -79,8 +79,8 @@ allocCluster.test = function testCluster(desc, n, opts, t) {
         t = opts;
         opts = {};
     }
-    allocCluster(n, opts).ready(function clusterReady(cluster) {
-        test(desc, function t2(assert) {
+    test(desc, function t2(assert) {
+        allocCluster(n, opts).ready(function clusterReady(cluster) {
             assert.once('end', function testEnded() {
                 cluster.destroy();
             });


### PR DESCRIPTION
First step towards implementing streaming.

This module is the core piece that knows how to split/combine arg chunks from/to arg streams.

Test is an exhaustive integration test, the current search space covered is 649 cases, however it still gets to run fast since `setImmediate` deferral is sufficient "asynchrony" for this test.

reviewers: @Raynos @kriskowal 