### PR TITLE
Drive checksumming from v2/handler

### DIFF
--- a/node/reqres.js
+++ b/node/reqres.js
@@ -40,6 +40,7 @@ function TChannelIncomingRequest(id, options) {
     self.service = options.service || '';
     self.remoteAddr = null;
     self.headers = options.headers || {};
+    self.checksum = options.checksum || null;
     self.checksumType = options.checksumType || 0;
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
@@ -57,6 +58,7 @@ function TChannelIncomingResponse(id, options) {
     EventEmitter.call(self);
     self.id = id || 0;
     self.code = options.code || 0;
+    self.checksum = options.checksum || null;
     self.arg1 = options.arg1 || emptyBuffer;
     self.arg2 = options.arg2 || emptyBuffer;
     self.arg3 = options.arg3 || emptyBuffer;
@@ -81,6 +83,7 @@ function TChannelOutgoingRequest(id, options) {
     self.service = options.service || '';
     self.headers = options.headers || {};
     self.checksumType = options.checksumType || 0;
+    self.checksum = options.checksum || null;
     self.sendFrame = options.sendFrame;
     self.sent = false;
 }
@@ -137,6 +140,7 @@ function TChannelOutgoingResponse(id, options) {
     self.tracing = options.tracing || null;
     self.headers = options.headers || {};
     self.checksumType = options.checksumType || 0;
+    self.checksum = options.checksum || null;
     self.ok = true;
     self.sendFrame = options.sendFrame;
     self.arg1 = options.arg1 || emptyBuffer;

--- a/node/test/v2/call.js
+++ b/node/test/v2/call.js
@@ -33,65 +33,97 @@ var testTracing = Tracing(
     24
 );
 
+var testReq = Call.Request(
+    0, 1024, testTracing, 'apache', {key: 'val'},
+    Checksum.Types.Farm32,
+    Buffer('on'),
+    Buffer('to'),
+    Buffer('te')
+);
+testReq.updateChecksum();
+
+var testReqBytes = [
+    0x00,                   // flags:1
+    0x00, 0x00, 0x04, 0x00, // ttl:4
+    0x00, 0x01, 0x02, 0x03, // tracing:24
+    0x04, 0x05, 0x06, 0x07, // ...
+    0x08, 0x09, 0x0a, 0x0b, // ...
+    0x0c, 0x0d, 0x0e, 0x0f, // ...
+    0x10, 0x11, 0x12, 0x13, // ...
+    0x14, 0x15, 0x16, 0x17, // ...
+    0x18,                   // traceflags:1
+    0x06,                   // service~1
+    0x61, 0x70, 0x61, 0x63, // ...
+    0x68, 0x65,             // ...
+    0x01,                   // nh:1
+    0x03, 0x6b, 0x65, 0x79, // (hk~1 hv~1){nh}
+    0x03, 0x76, 0x61, 0x6c, // ...
+    Checksum.Types.Farm32,  // csumtype:1
+    0x8e, 0x09, 0xa1, 0xbd, // (csum:4){0,1}
+    0x00, 0x02, 0x6f, 0x6e, // arg1~2
+    0x00, 0x02, 0x74, 0x6f, // arg2~2
+    0x00, 0x02, 0x74, 0x65  // arg3~2
+];
+
 test('Call.Request.RW: read/write payload', testRW.cases(Call.Request.RW, [
-    [
-        Call.Request(
-            0, 1024, testTracing, 'apache', {key: 'val'},
-            Checksum.Types.Farm32,
-            Buffer('on'),
-            Buffer('to'),
-            Buffer('te')
-        ), [
-            0x00,                   // flags:1
-            0x00, 0x00, 0x04, 0x00, // ttl:4
-            0x00, 0x01, 0x02, 0x03, // tracing:24
-            0x04, 0x05, 0x06, 0x07, // ...
-            0x08, 0x09, 0x0a, 0x0b, // ...
-            0x0c, 0x0d, 0x0e, 0x0f, // ...
-            0x10, 0x11, 0x12, 0x13, // ...
-            0x14, 0x15, 0x16, 0x17, // ...
-            0x18,                   // traceflags:1
-            0x06,                   // service~1
-            0x61, 0x70, 0x61, 0x63, // ...
-            0x68, 0x65,             // ...
-            0x01,                   // nh:1
-            0x03, 0x6b, 0x65, 0x79, // (hk~1 hv~1){nh}
-            0x03, 0x76, 0x61, 0x6c, // ...
-            Checksum.Types.Farm32,  // csumtype:1
-            0x8e, 0x09, 0xa1, 0xbd, // (csum:4){0,1}
-            0x00, 0x02, 0x6f, 0x6e, // arg1~2
-            0x00, 0x02, 0x74, 0x6f, // arg2~2
-            0x00, 0x02, 0x74, 0x65  // arg3~2
-        ]
-    ]
+    {
+        lengthTest: {
+            length: testReqBytes.length,
+            value: testReq
+        },
+        writeTest: {
+            bytes: testReqBytes,
+            value: testReq
+        },
+        readTest: {
+            bytes: testReqBytes,
+            value: testReq
+        }
+    }
 ]));
 
+var testRes = Call.Response(
+    0, Call.Response.Codes.OK, testTracing, {key: 'val'},
+    Checksum.Types.Farm32,
+    Buffer('ON'),
+    Buffer('TO'),
+    Buffer('TE')
+);
+testRes.updateChecksum();
+
+var testResBytes = [
+    0x00,                   // flags:1
+    Call.Response.Codes.OK, // code:1
+    0x00, 0x01, 0x02, 0x03, // tracing:24
+    0x04, 0x05, 0x06, 0x07, // ...
+    0x08, 0x09, 0x0a, 0x0b, // ...
+    0x0c, 0x0d, 0x0e, 0x0f, // ...
+    0x10, 0x11, 0x12, 0x13, // ...
+    0x14, 0x15, 0x16, 0x17, // ...
+    0x18,                   // traceflags:1
+    0x01,                   // nh:1
+    0x03, 0x6b, 0x65, 0x79, // (hk~1 hv~1){nh}
+    0x03, 0x76, 0x61, 0x6c, // ...
+    Checksum.Types.Farm32,  // csumtype:1
+    0x8d, 0x82, 0xe8, 0xba, // (csum:4){0,1}
+    0x00, 0x02, 0x4f, 0x4e, // arg1~2
+    0x00, 0x02, 0x54, 0x4f, // arg2~2
+    0x00, 0x02, 0x54, 0x45  // arg3~2
+];
+
 test('Call.Response.RW: read/write payload', testRW.cases(Call.Response.RW, [
-    [
-        Call.Response(
-            0, Call.Response.Codes.OK, testTracing, {key: 'val'},
-            Checksum.Types.Farm32,
-            Buffer('ON'),
-            Buffer('TO'),
-            Buffer('TE')
-        ), [
-            0x00,                   // flags:1
-            Call.Response.Codes.OK, // code:1
-            0x00, 0x01, 0x02, 0x03, // tracing:24
-            0x04, 0x05, 0x06, 0x07, // ...
-            0x08, 0x09, 0x0a, 0x0b, // ...
-            0x0c, 0x0d, 0x0e, 0x0f, // ...
-            0x10, 0x11, 0x12, 0x13, // ...
-            0x14, 0x15, 0x16, 0x17, // ...
-            0x18,                   // traceflags:1
-            0x01,                   // nh:1
-            0x03, 0x6b, 0x65, 0x79, // (hk~1 hv~1){nh}
-            0x03, 0x76, 0x61, 0x6c, // ...
-            Checksum.Types.Farm32,  // csumtype:1
-            0x8d, 0x82, 0xe8, 0xba, // (csum:4){0,1}
-            0x00, 0x02, 0x4f, 0x4e, // arg1~2
-            0x00, 0x02, 0x54, 0x4f, // arg2~2
-            0x00, 0x02, 0x54, 0x45  // arg3~2
-        ]
-    ]
+    {
+        lengthTest: {
+            length: testResBytes.length,
+            value: testRes
+        },
+        writeTest: {
+            bytes: testResBytes,
+            value: testRes
+        },
+        readTest: {
+            bytes: testResBytes,
+            value: testRes
+        }
+    }
 ]));

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -152,7 +152,6 @@ function prepareWrite(body, buffer, offset) {
             new Error('streaming call not implemented'),
             offset);
     }
-    body.updateChecksum();
     return WriteResult.just(offset);
 }
 
@@ -161,10 +160,6 @@ function readGuard(body, buffer, offset) {
         return ReadResult.error(
             new Error('streaming call not implemented'),
             offset);
-    }
-    var err = body.verifyChecksum();
-    if (err) {
-        return ReadResult.error(err, offset);
     }
     return ReadResult.just(offset);
 }

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -303,7 +303,8 @@ TChannelV2Handler.prototype.buildIncomingRequest = function buildIncomingRequest
         checksumType: reqFrame.body.csum.type,
         arg1: reqFrame.body.args[0],
         arg2: reqFrame.body.args[1],
-        arg3: reqFrame.body.args[2]
+        arg3: reqFrame.body.args[2],
+        checksum: reqFrame.body.csum
     });
     return req;
 };
@@ -313,7 +314,8 @@ TChannelV2Handler.prototype.buildIncomingResponse = function buildIncomingRespon
         code: resFrame.body.code,
         arg1: resFrame.body.args[0],
         arg2: resFrame.body.args[1],
-        arg3: resFrame.body.args[2]
+        arg3: resFrame.body.args[2],
+        checksum: resFrame.body.csum
     });
     return res;
 };

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -216,6 +216,7 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
     reqBody.updateChecksum();
     var reqFrame = v2.Frame(req.id, reqBody);
     self.push(reqFrame);
+    req.checksum = reqBody.csum;
 };
 
 TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFrame(res, arg1, arg2, arg3) {
@@ -235,6 +236,7 @@ TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFra
     resBody.updateChecksum();
     var resFrame = v2.Frame(res.id, resBody);
     self.push(resFrame);
+    res.checksum = resBody.csum;
 };
 /* jshint maxparams:4 */
 


### PR DESCRIPTION
Sets up so that we can carry prior checksum state between continuation frames.

reviewers: @Raynos @kriskowal 