### PR TITLE
error handling for closed connections

### DIFF
--- a/python/tchannel/exceptions.py
+++ b/python/tchannel/exceptions.py
@@ -20,11 +20,16 @@ class TimeoutException(TChannelException):
     pass
 
 
+class ConnectionClosedException(TChannelException):
+    pass
+
+
 class TChannelApplicationException(TChannelException):
     """The remote application returned an exception.
 
     This is not a protocol error. This means a response was received with the
-    ``code`` flag set to fail."""
+    ``code`` flag set to fail.
+    """
     def __init__(self, code, arg_1, arg_2, arg_3):
         super(TChannelException, self).__init__(
             'TChannel application error (%s, %s, %s)' % (arg_1, arg_2, arg_3)

--- a/python/tchannel/tornado/connection.py
+++ b/python/tchannel/tornado/connection.py
@@ -251,7 +251,8 @@ class TornadoConnection(object):
                 resp_future = connection.awaiting_responses.pop(
                     context.message_id,
                 )
-                resp_future.set_result(context)
+                if resp_future.running():
+                    resp_future.set_result(context)
             else:
                 log.warn(
                     'unrecognized response for message %s',

--- a/python/tchannel/tornado/tchannel.py
+++ b/python/tchannel/tornado/tchannel.py
@@ -106,15 +106,12 @@ class TChannelClientOperation(object):
             message_id=message_id,
         )
 
-        log.debug("awaiting response for message %s", message_id)
-
         # Pull this out into its own loop, look up response message ids
         # and dispatch them to handlers.
-        response_future = tornado.gen.Future()
-        peer_connection.awaiting_responses[message_id] = response_future
 
-        with timeout(response_future):
-            response = yield response_future
+        #with timeout(response_future):
+        # TODO: better interface
+        response = yield peer_connection.awaiting_responses[message_id]
 
         log.debug("got response for message %s", response.message_id)
 

--- a/python/tchannel/tornado/tchannel.py
+++ b/python/tchannel/tornado/tchannel.py
@@ -9,7 +9,6 @@ import tornado.iostream
 from ..exceptions import InvalidMessageException
 from ..messages import CallRequestMessage
 from .connection import TornadoConnection
-from .timeout import timeout
 from .inbound_server import InboundServer
 
 log = logging.getLogger('tchannel')
@@ -101,6 +100,7 @@ class TChannelClientOperation(object):
 
         log.debug("framing and writing message %s", message_id)
 
+        # TODO: return response future here?
         yield peer_connection.frame_and_write(
             message,
             message_id=message_id,
@@ -108,9 +108,8 @@ class TChannelClientOperation(object):
 
         # Pull this out into its own loop, look up response message ids
         # and dispatch them to handlers.
-
-        #with timeout(response_future):
-        # TODO: better interface
+        # with timeout(response_future):
+        # TODO: better interface for these responses
         response = yield peer_connection.awaiting_responses[message_id]
 
         log.debug("got response for message %s", response.message_id)

--- a/python/tchannel/tornado/timeout.py
+++ b/python/tchannel/tornado/timeout.py
@@ -17,6 +17,6 @@ def timeout(future, seconds=2):
         if future.running():
             future.set_exception(TimeoutException())
 
-    tornado.ioloop.IOLoop.instance().add_callback(raise_timeout())
+    tornado.ioloop.IOLoop.instance().add_callback(raise_timeout)
 
     yield

--- a/python/tchannel/tornado/timeout.py
+++ b/python/tchannel/tornado/timeout.py
@@ -6,17 +6,19 @@ import tornado.ioloop
 from ..exceptions import TimeoutException
 
 
+import tornado
+
+
 @contextlib2.contextmanager
-def timeout(future, seconds=2):
+def timeout(future, seconds=1, io_loop=None):
     # TODO: This is probably too heavy to attach to every request, should do
     # this in the background.
+    io_loop = io_loop or tornado.ioloop.IOLoop.instance()
 
-    @tornado.gen.coroutine
-    def raise_timeout():
-        yield tornado.gen.sleep(seconds)
+    def raise_timeout(*args, **kwargs):
         if future.running():
             future.set_exception(TimeoutException())
 
-    tornado.ioloop.IOLoop.instance().add_callback(raise_timeout)
+    io_loop.call_later(seconds, raise_timeout)
 
     yield

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -27,4 +27,3 @@ def unused_port():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(('', 0))
     return sock.getsockname()[1]
-

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import socket
+
 import pytest
 
 
@@ -18,3 +20,11 @@ class _MockConnection(object):
 def connection():
     """Make a mock connection."""
     return _MockConnection()
+
+
+@pytest.fixture
+def unused_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('', 0))
+    return sock.getsockname()[1]
+

--- a/python/tests/integration/server_manager.py
+++ b/python/tests/integration/server_manager.py
@@ -107,9 +107,6 @@ class ServerManager(object):
     @contextmanager
     def client_connection(self):
         """Get an initiated Connection to this TChannel server."""
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(self.timeout)
-
         try:
             conn = tchannel.SocketConnection.outgoing(
                 'localhost:%d' % self.port
@@ -125,6 +122,7 @@ class ServerManager(object):
 
     def stop(self):
         self.server.shutdown()
+        self.thread.join()
 
     def __enter__(self):
         self.start()

--- a/python/tests/integration/server_manager.py
+++ b/python/tests/integration/server_manager.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import socket
 import threading
 try:
     import SocketServer

--- a/python/tests/integration/test_client_server.py
+++ b/python/tests/integration/test_client_server.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 
 import pytest
-import tornado.ioloop
 
 import tchannel.messages as tmessage
 from tchannel import tcurl
+from tchannel.exceptions import ConnectionClosedException
 from tchannel.exceptions import TChannelApplicationException
 from tchannel.outgoing import OutgoingTChannel
-from tchannel.tornado import TChannel
-from tchannel.exceptions import ConnectionClosedException
 from tchannel.tornado import TChannel
 from tchannel.tornado.connection import TornadoConnection
 
@@ -62,10 +60,6 @@ def test_outgoing_tchannel_exception(server_manager, call_response):
             ).and_return(call_response)
             chan.request(host_port).send(endpoint, None, None)
 
-        assert conn.closed is False
-
-    assert conn.closed is True
-
 
 def test_tcp_client_with_server_gone_away(server_manager):
 
@@ -74,7 +68,8 @@ def test_tcp_client_with_server_gone_away(server_manager):
 
         with pytest.raises(ConnectionClosedException):
             conn.ping()
-            assert conn.closed
+
+        assert conn.closed
 
 
 @pytest.mark.gen_test
@@ -89,8 +84,10 @@ def test_tornado_client_with_server_gone_away(server_manager):
 
     server_manager.stop()
 
+    conn.ping()
+
     with pytest.raises(ConnectionClosedException):
-        yield conn.ping()
+        yield conn.awaiting_responses.values()
 
     assert conn.closed
 

--- a/python/tests/integration/test_client_server.py
+++ b/python/tests/integration/test_client_server.py
@@ -17,7 +17,6 @@ def call_response():
 
 
 def test_tcp_ping_pong(server_manager):
-
     with server_manager.client_connection() as conn:
         resp = tmessage.PingResponseMessage()
         server_manager.expect_ping().and_return(resp)

--- a/python/tests/tornado/test_timeout.py
+++ b/python/tests/tornado/test_timeout.py
@@ -8,7 +8,7 @@ from tchannel.tornado.timeout import timeout
 
 
 @pytest.mark.gen_test
-def test_timeout():
+def test_timeout(io_loop):
 
     sleep_time = 0.01
 
@@ -19,6 +19,6 @@ def test_timeout():
 
     slow_future = slow_method()
 
-    with timeout(slow_future, sleep_time):
-        with pytest.raises(TimeoutException):
+    with pytest.raises(TimeoutException):
+        with timeout(slow_future, sleep_time, io_loop):
             yield slow_future


### PR DESCRIPTION
* cancel in-flight requests if our connection dies
* catch socket errors in `await`

We've still got a problem with callbacks in `await` where we hit an infinite recursion limit, looking into that.