### PR TITLE
reset the socket on TChannel reader error

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -590,10 +590,6 @@ TChannelConnection.prototype.onReaderError = function onReaderError(err) {
         localName: self.channel.hostPort
     });
 
-    self.channel.logger.error('tchannel read error', {
-        error: err
-    });
-
     // TODO instead of resetting send an error frame first.
     // and reset the socket after sending an error frame
     self.resetAll(readError);

--- a/node/index.js
+++ b/node/index.js
@@ -46,6 +46,13 @@ var TChannelListenError = WrappedError({
     host: null
 });
 
+var TChannelReadProtocolError = WrappedError({
+    type: 'tchannel.protocol.read-failed',
+    message: 'tchannel read failure: {origMessage}',
+    remoteName: null,
+    localName: null
+});
+
 var NoHandlerError = TypedError({
     type: 'tchannel.no-handler',
     message: 'no handler defined'
@@ -577,15 +584,19 @@ require('util').inherits(TChannelConnection, require('events').EventEmitter);
 
 TChannelConnection.prototype.onReaderError = function onReaderError(err) {
     var self = this;
-    self.channel.logger.error('tchannel read error', {
+
+    var readError = TChannelReadProtocolError(err, {
         remoteName: self.remoteName,
-        localName: self.channel.hostPort,
+        localName: self.channel.hostPort
+    });
+
+    self.channel.logger.error('tchannel read error', {
         error: err
     });
 
     // TODO instead of resetting send an error frame first.
     // and reset the socket after sending an error frame
-    self.resetAll(new Error('tchannel read error'));
+    self.resetAll(readError);
     // resetAll() does not close the socket
     self.socket.destroy();
 };

--- a/node/index.js
+++ b/node/index.js
@@ -582,6 +582,12 @@ TChannelConnection.prototype.onReaderError = function onReaderError(err) {
         localName: self.channel.hostPort,
         error: err
     });
+
+    // TODO instead of resetting send an error frame first.
+    // and reset the socket after sending an error frame
+    self.resetAll(new Error('tchannel read error'));
+    // resetAll() does not close the socket
+    self.socket.destroy();
 };
 
 // timeout check runs every timeoutCheckInterval +/- some random fuzz. Range is from


### PR DESCRIPTION
Currently when the server gets a reader error. For example
parsing a `service~2` when the protocol is `service~1` it
does not close the TChannelConnection object.

This means that the client thinks it's a timeout (i.e. server
is unresponsive) instead of thinking it's a BadRequest.

Ideally we terminate with a BadRequest error frame but just
closing the socket and turning the client error into an
ECONNRESET error is a significant improvement over a timeout.

This change will make my tests fail with a loud error instead
of a quiet timeout.

reviewers: @jcorbin @kriskowal