### PR TITLE
Golang protocol updates

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -101,6 +101,7 @@ func NewChannel(hostPort string, opts *ChannelOptions) (*TChannel, error) {
 	ch.hostPort = l.Addr().String()
 	ch.connectionOptions.PeerInfo.HostPort = ch.hostPort
 	ch.connectionOptions.PeerInfo.ProcessName = ch.processName
+	ch.connectionOptions.ChecksumType = ChecksumTypeCrc32
 	ch.log.Infof("%s listening on %s", ch.processName, ch.hostPort)
 	return ch, nil
 }

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -273,11 +273,6 @@ func (m *callReq) read(r *typed.ReadBuffer) error {
 		return err
 	}
 
-	m.Headers = callHeaders{}
-	if err := m.Headers.read(r); err != nil {
-		return err
-	}
-
 	serviceNameLen, err := r.ReadByte()
 	if err != nil {
 		return err
@@ -287,6 +282,10 @@ func (m *callReq) read(r *typed.ReadBuffer) error {
 		return err
 	}
 
+	m.Headers = callHeaders{}
+	if err := m.Headers.read(r); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -311,15 +310,15 @@ func (m *callReq) write(w *typed.WriteBuffer) error {
 		return err
 	}
 
-	if err := m.Headers.write(w); err != nil {
-		return err
-	}
-
 	if err := w.WriteByte(byte(len(m.Service))); err != nil {
 		return err
 	}
 
 	if err := w.WriteBytes(m.Service); err != nil {
+		return err
+	}
+
+	if err := m.Headers.write(w); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes drifts from the spec, mainly that service~1 should precede headers in call req/res, and that call-res should include an empty arg1.


