### PR TITLE
remove the error event for outgoingresponse

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -735,9 +735,10 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
     //   that once they do finish that their callback will swallow the response.
     inOpKeys.forEach(function eachInOp(id) {
         // TODO: we could support an op.cancel opt-in callback
-        var op = self.inOps[id];
         delete self.inOps[id];
-        op.res.emit('error', err);
+        // TODO consider closing any pending outgoingResponses
+        // with an error frame.
+        // TODO consider shutting down the socket.
     });
 
     // for all outgoing requests, forward the triggering error to the user callback


### PR DESCRIPTION
This is a breaking change from v1 that causes ringpop integration tests to fail (error crashes the process).

There really is not much we can do with this error in the `CallResponse` object in the `EndpointHandler`.

The socket is gone so we cant really do anything.

I recommend we remove it and think about how to do stuff with it later.

reviewers: @kriskowal @jcorbin 