### PR TITLE
do not set closing; set inside method

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -432,7 +432,6 @@ TChannel.prototype.close = function close(callback) {
             peerRemoteName: conn.remoteName,
             fromAddress: sock.address()
         });
-        conn.closing = true;
         conn.resetAll(new Error('shutdown from quit')); // TODO typed error
         sock.destroy();
     });


### PR DESCRIPTION
This is a breaking change from v1 to v2.

The resetAll() method now shortcircuits on `closing = true`.

We should not be setting it outside of the method. If we do
we leave a bunch of inOp and outOp in a pending state and
since we reset the connection the timeout sweeper is cancelled.

This is needed for ringpop. This also cannot land until #238
is landed.

reviewers: @kriskowal @jcorbin