### PR TITLE
[python] add a fixture to test tcurl against tchannel servers

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -2,7 +2,7 @@ project := tchannel
 
 flake8 := flake8
 pytest := py.test --tb short --cov-config .coveragerc --cov $(project) \
-          --async-test-timeout=1 tests
+          --async-test-timeout=1 --timeout=30 tests
 
 html_report := --cov-report html
 test_args := --cov-report term-missing

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,8 +1,8 @@
 project := tchannel
 
 flake8 := flake8
-pytest := py.test --tb short --cov-config .coveragerc --cov \
-          $(project) tests
+pytest := py.test --tb short --cov-config .coveragerc --cov $(project) \
+          --async-test-timeout=1 tests
 
 html_report := --cov-report html
 test_args := --cov-report term-missing

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,6 +1,7 @@
 # Testing and coverage
 pytest
 pytest-cov
+pytest-timeout
 pytest-tornado
 
 # Test all the pythons

--- a/python/tchannel/handler.py
+++ b/python/tchannel/handler.py
@@ -47,7 +47,7 @@ class TChannelRequestHandler(RequestHandler):
                 response.finish()
         else:
             # TODO error handling if endpoint is not found
-            raise NotImplementedError()
+            raise NotImplementedError(request.method)
 
     def route(self, rule, **opts):
         def decorator(handler):

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -4,12 +4,32 @@ import socket
 
 import pytest
 
-from tests.integration.server_manager import ServerManager
+from tests.integration.server_manager import TCPServerManager
+from tests.integration.server_manager import TChannelServerManager
 
 
 @pytest.yield_fixture
-def server_manager(random_open_port):
-    with ServerManager(random_open_port) as manager:
+def tcp_server(random_open_port):
+    with TCPServerManager(random_open_port) as manager:
+        yield manager
+
+
+@pytest.yield_fixture
+def tchannel_server(random_open_port):
+    with TChannelServerManager(random_open_port) as manager:
+        yield manager
+
+
+@pytest.yield_fixture(
+    params=[TCPServerManager, TChannelServerManager]
+)
+def server(request, random_open_port):
+    """Run a test against TChannel and TCP.
+
+    This only works in combination with `@pytest.mark.gen_test`.
+    """
+    manager_class = request.param
+    with manager_class(random_open_port) as manager:
         yield manager
 
 

--- a/python/tests/integration/server_manager.py
+++ b/python/tests/integration/server_manager.py
@@ -7,7 +7,11 @@ except ImportError:
     import socketserver as SocketServer
 from contextlib import contextmanager
 
-import tchannel.socket as tchannel
+import tornado
+
+from tchannel.handler import TChannelRequestHandler
+import tchannel.tornado.tchannel as tornado_tchannel
+import tchannel.socket as socket_tchannel
 import tchannel.messages as tmessage
 
 
@@ -23,6 +27,7 @@ class Expectation(object):
         # expectation.respond(context, connection) accepts the context and the
         # connection and writes output to the connection.
         self._respond = None
+        self.response = None
 
     @classmethod
     def messageType(cls, msg_typ):
@@ -39,39 +44,26 @@ class Expectation(object):
 
     def and_return(self, resp):
         """Write the given Message as a response."""
+        self.response = resp
+
         def respond(ctx, conn):
             return conn.frame_and_write(
                 resp,
                 message_id=ctx.message_id,
             )
+
         self._respond = respond
 
 
 class ServerManager(object):
-    """Provides a dynamically configurable TChannel server."""
     TIMEOUT = 0.15
 
     def __init__(self, port, timeout=None):
-        manager = self
         self.port = port
         self.timeout = timeout or self.TIMEOUT
 
-        class Handler(SocketServer.BaseRequestHandler):
-            def setup(self):
-                self.request.settimeout(manager.timeout)
-                self.tchan_conn = tchannel.SocketConnection(self.request)
-
-            def handle(self):
-                (host, port) = self.request.getsockname()
-                self.tchan_conn.await_handshake(headers={
-                    'host_port': '%s:%s' % (host, port),
-                    'process_name': 'tchannel_server-%s' % port
-                })
-                self.tchan_conn.handle_calls(manager.handle_call)
-
-        self.server = SocketServer.TCPServer(("", port), Handler)
-        self.thread = None
         self._expectations = []
+        self.thread = None
 
     def expect_ping(self):
         """Expect a Ping request.
@@ -103,29 +95,95 @@ class ServerManager(object):
             if exp.matches(context.message):
                 exp.respond(context, connection)
 
-    @contextmanager
-    def client_connection(self):
-        """Get an initiated Connection to this TChannel server."""
-        try:
-            conn = tchannel.SocketConnection.outgoing(
-                'localhost:%d' % self.port
-            )
-            yield conn
-        finally:
-            conn.close()
-
-    def start(self):
-        assert self.thread is None, 'server already started'
-        self.thread = threading.Thread(target=self.server.serve_forever)
-        self.thread.start()
-
-    def stop(self):
-        self.server.shutdown()
-        self.thread.join()
-
     def __enter__(self):
         self.start()
         return self
 
     def __exit__(self, *args):
         self.stop()
+
+    def start(self):
+        assert self.thread is None, 'server already started'
+        self.thread = threading.Thread(target=self.serve)
+        self.thread.start()
+
+    def stop(self):
+        self.shutdown()
+        self.thread.join()
+
+
+class TCPServerManager(ServerManager):
+    """Provides a dynamically configurable TChannel server."""
+
+    def __init__(self, port, timeout=None):
+        super(TCPServerManager, self).__init__(port, timeout)
+
+        manager = self
+
+        class Handler(SocketServer.BaseRequestHandler):
+            def setup(self):
+                self.request.settimeout(manager.timeout)
+                self.tchan_conn = socket_tchannel.SocketConnection(
+                    self.request,
+                )
+
+            def handle(self):
+                (host, port) = self.request.getsockname()
+                self.tchan_conn.await_handshake(headers={
+                    'host_port': '%s:%s' % (host, port),
+                    'process_name': 'tchannel_server-%s' % port
+                })
+                self.tchan_conn.handle_calls(manager.handle_call)
+
+        self.server = SocketServer.TCPServer(("", port), Handler)
+
+    @contextmanager
+    def client_connection(self):
+        """Get an initiated Connection to this TChannel server."""
+        try:
+            conn = socket_tchannel.SocketConnection.outgoing(
+                'localhost:%d' % self.port
+            )
+            yield conn
+        finally:
+            conn.close()
+
+    def serve(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.shutdown()
+
+
+class TChannelServerManager(ServerManager):
+
+    def __init__(self, port, timeout=None):
+        super(TChannelServerManager, self).__init__(port, timeout)
+
+        self.handler = TChannelRequestHandler()
+        self.tchannel = tornado_tchannel.TChannel()
+        self.server = self.tchannel.host(port, self.handler)
+
+    def serve(self):
+        self.server.listen()
+        tornado.ioloop.IOLoop.current().start()
+
+    def shutdown(self):
+        tornado.ioloop.IOLoop.current().stop()
+
+    def expect_ping_request(self):
+        raise NotImplementedError()
+
+    def expect_call_request(self, endpoint):
+        expectation = super(TChannelServerManager, self).expect_call_request(
+            endpoint,
+        )
+
+        # TODO: this should match `handle_call` above in the TCP case...
+        def handler(request, response, opts):
+            # TODO: just call `resp_msg` a `message`...
+            response.resp_msg = expectation.response
+
+        self.handler.register_handler(endpoint, handler)
+
+        return expectation

--- a/python/tests/integration/server_manager.py
+++ b/python/tests/integration/server_manager.py
@@ -64,6 +64,7 @@ class ServerManager(object):
 
         self._expectations = []
         self.thread = None
+        self.ready = False
 
     def expect_ping(self):
         """Expect a Ping request.
@@ -106,6 +107,8 @@ class ServerManager(object):
         assert self.thread is None, 'server already started'
         self.thread = threading.Thread(target=self.serve)
         self.thread.start()
+        while not self.ready:
+            pass
 
     def stop(self):
         self.shutdown()
@@ -149,6 +152,7 @@ class TCPServerManager(ServerManager):
             conn.close()
 
     def serve(self):
+        self.ready = True
         self.server.serve_forever()
 
     def shutdown(self):
@@ -166,6 +170,7 @@ class TChannelServerManager(ServerManager):
 
     def serve(self):
         self.server.listen()
+        self.ready = True
         tornado.ioloop.IOLoop.current().start()
 
     def shutdown(self):


### PR DESCRIPTION
This should hopefully prevent another bug where we totally kill our ability to make requests :)

This brings coverage from 81% up to 83% :[

@junchaowu `TCPServerManager` is still using its own request handler which makes things a little awkward.