### PR TITLE
[node] Fix lost operation crash error

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -497,6 +497,15 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     self.handler.on('call.incoming.response', function onCallResponse(res) {
         var op = self.popOutOp(res.id);
+        if (!op) {
+            self.logger.warn('response received for unknown or lost operation', {
+                responseId: res.id,
+                remoteAddr: self.remoteAddr,
+                direction: self.direction,
+            });
+            return;
+        }
+
         op.req.emit('response', res);
     });
 


### PR DESCRIPTION
getOp returns undefined if the operation does not exist or was dropped.
This fixes a crash.

To reproduce the crash, start a service that registers over tchannel
before starting the tchannel service registry. When the service
discovery system comes up, the service will crash because op is
undefined.