### PR TITLE
Gracefully handle redundant error responses.

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -489,7 +489,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     self.handler.on('call.incoming.response', function onCallResponse(res) {
         var op = self.popOutOp(res.id);
         if (!op) {
-            self.logger.warn('response received for unknown or lost operation', {
+            self.logger.info('response received for unknown or lost operation', {
                 responseId: res.id,
                 remoteAddr: self.remoteAddr,
                 direction: self.direction,
@@ -502,6 +502,11 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
 
     self.handler.on('call.incoming.error', function onCallError(err) {
         var op = self.popOutOp(err.originalId);
+        if (!op) {
+            self.logger.info('error received for unknown or lost operation', err);
+            return;
+        }
+
         op.req.emit('error', err);
     });
 


### PR DESCRIPTION
And downgrade redundant errors and responses to `info` log level since
these are expected in normal operation due to timeouts, retry,
speculative pretry, etc.

Fixes #254 

review: @jcorbin @Raynos 