### PR TITLE
better parity between tcp/tchannel request handling

### DIFF
--- a/python/examples/tchannel_server.py
+++ b/python/examples/tchannel_server.py
@@ -2,17 +2,10 @@ from __future__ import absolute_import
 
 import tornado.ioloop
 
-from options import get_args
 from tchannel.tornado import TChannel
-from tchannel.handler import TChannelRequestHandler
 
-
-def handler1(request, response, opts):
-    response.write("handler1 says hi")
-
-
-def handler2(request, response, opts):
-    response.write("handler2 says ok")
+from options import get_args
+from handler import get_example_handler
 
 
 def main():  # pragma: no cover
@@ -20,17 +13,7 @@ def main():  # pragma: no cover
 
     client = TChannel()
 
-    handler = TChannelRequestHandler()
-    handler.register_handler(
-        r"/hi", handler1
-    )
-    handler.register_handler(
-        r"/ok", handler2
-    )
-
-    @handler.route("/bye")
-    def handler3(request, response, opts):
-        response.write("handler3 says bye")
+    handler = get_example_handler()
 
     server = client.host(args.port, handler)
     server.listen()

--- a/python/examples/tcp_server.py
+++ b/python/examples/tcp_server.py
@@ -8,37 +8,31 @@ except ImportError:
 
 import sys
 
-from options import get_args
 from tchannel.socket import SocketConnection
+
+from handler import get_example_handler
+from options import get_args
 
 
 class MyHandler(SocketServer.BaseRequestHandler):
+
     def handle(self):
         """Implement the BaseRequestHandler interface.
 
         ``self.request`` is the TCP socket connected to the client.
         """
         self.request.settimeout(1.0)
-        tchannel_connection = SocketConnection(connection=self.request)
-        print("Received request from %s:%d" % self.client_address)
 
-        print("Waiting for TChannel handshake...")
+        tchannel_connection = SocketConnection(connection=self.request)
+
         tchannel_connection.await_handshake(headers={
             'host_port': '%s:%s' % self.request.getsockname(),
             'process_name': sys.argv[0],
         })
-        print("Successfully completed handshake")
 
-        # This call synchronously dispatches RPC requests to
-        # ``self.handle_call``
-        tchannel_connection.handle_calls(self.handle_call)
+        handler = get_example_handler()
 
-        # Connection is automatically closed when this function returns
-        print("Closing connection to %s:%d" % self.client_address)
-
-    def handle_call(self, context, connection):
-        """Handle a TChannel CALL_REQ message."""
-        print("Received message: %s" % context.message)
+        tchannel_connection.handle_calls(handler)
 
 
 if __name__ == '__main__':

--- a/python/tchannel/socket.py
+++ b/python/tchannel/socket.py
@@ -62,8 +62,8 @@ class SocketConnection(object):
         self._id_sequence = 0
 
     def handle_calls(self, handler):
-        for call in self.reader:
-            handler(call, connection=self)
+        for context in self.reader:
+            handler.handle_request(context, self)
 
     def await(self):
         """Decode a full message and return"""
@@ -187,3 +187,7 @@ class SocketConnection(object):
 
         self.extract_handshake_headers(message)
         return message
+
+    def finish(self, response):
+        """write response"""
+        self.frame_and_write(response.resp_msg, response.id)

--- a/python/tchannel/tcurl.py
+++ b/python/tchannel/tcurl.py
@@ -193,7 +193,7 @@ def tcurl(tchannel, hostport, headers, body, quiet=False):
             headers,
             body,
         )
-    except:
+    except Exception:
         log.debug("X Msg: %s" % request.message_id)
         return
 

--- a/python/tests/integration/test_client_server.py
+++ b/python/tests/integration/test_client_server.py
@@ -19,7 +19,6 @@ def call_response():
 def test_serial_ping_pong(tcp_server):
     with tcp_server.client_connection() as conn:
         resp = tmessage.PingResponseMessage()
-        tcp_server.expect_ping().and_return(resp)
 
         for i in range(1000):
             conn.ping()
@@ -128,7 +127,11 @@ def test_tcurl(server, call_response):
         server.port, endpoint.decode('ascii')
     )
 
-    [response] = yield tcurl.main(['--host', hostport])
+    responses = yield tcurl.main(['--host', hostport, '-d', ''])
 
-    assert response.arg_1 == call_response.arg_1
-    assert response.arg_3 == call_response.arg_3
+    # TODO: get multiple requests working here
+    assert len(responses) == 1
+
+    for response in responses:
+        assert response.arg_1 == call_response.arg_1
+        assert response.arg_3 == call_response.arg_3

--- a/python/tests/test_socket.py
+++ b/python/tests/test_socket.py
@@ -3,8 +3,9 @@ import socket
 
 import pytest
 
-from tchannel.socket import SocketConnection
 from tchannel.exceptions import InvalidMessageException
+from tchannel.handler import TChannelRequestHandler
+from tchannel.socket import SocketConnection
 
 
 @pytest.yield_fixture
@@ -92,13 +93,15 @@ def test_handle_calls(tchannel_pair):
     class _MyException(Exception):
         pass
 
-    def my_handler(context, connection):
-        raise _MyException()
+    class MyHandler(TChannelRequestHandler):
+        def handle_request(*args, **kwargs):
+            raise _MyException()
 
     server, client = tchannel_pair
     client.ping()
+
     with pytest.raises(_MyException):
-        server.handle_calls(my_handler)
+        server.handle_calls(MyHandler())
 
 
 def test_finish_connection(tchannel_pair):
@@ -107,6 +110,8 @@ def test_finish_connection(tchannel_pair):
     client.ping()
     client.connection.close()
 
-    def _handle(data, connection):
-        pass
-    server.handle_calls(_handle)
+    class MyHandler(TChannelRequestHandler):
+        def handle_request(*args, **kwargs):
+            pass
+
+    server.handle_calls(MyHandler())


### PR DESCRIPTION
This makes our TCP server share `TChannelRequestHandler` logic with tornado.

This also fixes a long-standing issue where the TCP example couldn't respond to multiple call requests, but the `tcurl` test still fails with multiple requests and I still need to fix that.