### PR TITLE
v2/error_response: correct id => tracing

### DIFF
--- a/node/test/v2/error_response.js
+++ b/node/test/v2/error_response.js
@@ -23,6 +23,14 @@
 var test = require('tape');
 var ErrorResponse = require('../../v2/error_response.js');
 var testRW = require('bufrw/test_rw');
+var Tracing = require('../../v2/tracing.js');
+
+var testTracing = Tracing(
+    new Buffer([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+    new Buffer([0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]),
+    new Buffer([0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17]),
+    24
+);
 
 test('ErrorResponse.RW: read/write payload', testRW.cases(ErrorResponse.RW, [
 
@@ -30,11 +38,17 @@ test('ErrorResponse.RW: read/write payload', testRW.cases(ErrorResponse.RW, [
     [
         ErrorResponse(
             ErrorResponse.Codes.ProtocolError,
-            0x01020304,
+            testTracing,
             'too bad.'
         ), [
             ErrorResponse.Codes.ProtocolError, // code:1
-            0x01, 0x02, 0x03, 0x04,            // id:4
+            0x00, 0x01, 0x02, 0x03,            // tracing:24
+            0x04, 0x05, 0x06, 0x07,            // ...
+            0x08, 0x09, 0x0a, 0x0b,            // ...
+            0x0c, 0x0d, 0x0e, 0x0f,            // ...
+            0x10, 0x11, 0x12, 0x13,            // ...
+            0x14, 0x15, 0x16, 0x17,            // ...
+            0x18,                              // traceflags:1
             0x00, 0x08, 0x74, 0x6f,            // message~2
             0x6f, 0x20, 0x62, 0x61,            // ...
             0x64, 0x2e                         // ...

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -320,7 +320,7 @@ TChannelV2Handler.prototype.sendErrorFrame = function sendErrorFrame(req, codeSt
         });
     }
 
-    var errBody = v2.ErrorResponse(code, req.id, message);
+    var errBody = v2.ErrorResponse(code, req.tracing, message);
     var errFrame = v2.Frame(req.id, errBody);
     self.push(errFrame);
 };


### PR DESCRIPTION
We changed this protocol slightly in #167 out of #166 late in the game, but never updated any implementations yet.

There aren't any claim/cancel implementations to update in node yet, so this PR is error frame only.

cc: @mmihic @abhinav @Raynos @kriskowal 