### PR TITLE
Better default for timeouts

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -37,6 +37,7 @@ var nullLogger = require('./null-logger.js');
 var Spy = require('./v2/spy');
 var EndpointHandler = require('./endpoint-handler.js');
 
+var DEFAULT_OUTGOING_REQ_TIMEOUT = 1000;
 var dumpEnabled = /\btchannel_dump\b/.test(process.env.NODE_DEBUG || '');
 
 var TChannelListenError = WrappedError({
@@ -801,7 +802,9 @@ TChannelConnection.prototype.request = function request(options) {
     // TODO: generate tracing if empty?
     // TODO: refactor callers
     options.checksumType = options.checksum;
-    options.ttl = options.timeout || 1; // TODO: better default, support for dynamic
+
+    // TODO: better default, support for dynamic
+    options.ttl = options.timeout || DEFAULT_OUTGOING_REQ_TIMEOUT;
     var req = self.handler.buildOutgoingRequest(options);
     var id = req.id;
     self.outOps[id] = new TChannelClientOp(req, self.channel.now());


### PR DESCRIPTION
The default timeout of 1ms makes req randomly timeout
since the default timeout is lower then the
`timeoutCheckInterval` of 1s.

This change setting the default to 2 seconds means that
timeouts will happen a lot more deterministically for
outgoing requests. (i.e. the timeout is actually between
2 and 3 seconds instead of 1ms and 1s).

r: @jcorbin @kriskowal