### PR TITLE
Error framing should use tracing instead of original_message_id

### DIFF
--- a/python/tchannel/messages/error.py
+++ b/python/tchannel/messages/error.py
@@ -41,10 +41,10 @@ class ErrorMessage(BaseMessage):
         ErrorCode.fatal: 'fatal protocol error'
     }
 
-    def __init__(self, code=None, original_message_id=None, message=None):
-        self.original_message_id = original_message_id
+    def __init__(self, code=None, tracing=None, message=None):
         self.code = ErrorCode(code) if code else ErrorCode.unexpected
         self.message = message or ''
+        self.tracing = tracing or common.Tracing(0, 0, 0, 0)
 
     def error_name(self):
         """Get a friendly error message."""

--- a/python/tchannel/messages/error.py
+++ b/python/tchannel/messages/error.py
@@ -5,6 +5,7 @@ import enum
 from .. import rw
 from .base import BaseMessage
 from .types import Types
+from . import common
 
 
 @enum.unique
@@ -26,7 +27,7 @@ class ErrorMessage(BaseMessage):
 
     __slots__ = (
         'code',
-        'original_message_id',
+        'tracing',
         'message',
     )
 
@@ -53,6 +54,6 @@ class ErrorMessage(BaseMessage):
 error_rw = rw.instance(
     ErrorMessage,
     ('code', error_code_rw),                            # code:1
-    ('original_message_id', rw.number(4)),              # id:4
+    ('tracing', common.tracing_rw),                     # tracing:24
     ('message', rw.len_prefixed_string(rw.number(2)))   # message~2
 )

--- a/python/tests/test_messages.py
+++ b/python/tests/test_messages.py
@@ -101,7 +101,6 @@ def test_valid_ping_request():
     (messages.ErrorMessage, messages.error_rw, {
         'code': 1,
         'message': 'hi',
-        'original_message_id': 1,
     }),
     (messages.CallRequestMessage, messages.call_req_rw, {
         'flags': 0,
@@ -144,13 +143,14 @@ def test_roundtrip_message(message_class, message_rw, attrs):
 
 
 @pytest.mark.parametrize('message_rw, byte_stream', [
-    (messages.error_rw, bytearray([
-        0, 0, 0, 0, 1, 0, 2
-    ] + list('hi')))
+    (messages.error_rw, bytearray(
+        [1] + [0] * 25 + [0, 2] + list('hi')))
 ])
 def test_parse_message(message_rw, byte_stream):
     """Verify all messages parse properly."""
-    message_rw.read(BytesIO(byte_stream))
+    error = message_rw.read(BytesIO(byte_stream))
+    assert error.code == 1
+    assert error.message == u'hi'
 
 
 def test_error_message_name():


### PR DESCRIPTION
Will fix tests once I know the direction is sane.