### PR TITLE
Peering hosts

### DIFF
--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -27,10 +27,6 @@ server.listen(4040, '127.0.0.1');
 
 var keys = {};
 
-server.on('socketClose', function (conn, err) {
-	// console.log('socket close: ' + conn.remoteName + ' ' + err);
-});
-
 server.handler.register('ping', function onPing(req, res) {
 	res.sendOk('pong', null);
 });

--- a/node/docs.jsig
+++ b/node/docs.jsig
@@ -16,11 +16,6 @@ type HostInfo : String
 type TChannelValue :
     Buffer | String | null | undefined
 
-type TChannelConnection : {
-    direction: "in" | "out",
-    remoteAddr: HostInfo
-}
-
 type TChannelIncomingResponse : {
     id: Number,
     ok: Boolean,
@@ -88,10 +83,6 @@ type TChannel : {
     ) => void,
     address: () => ?{port, family, address}
     close: (Callback<Error>) => void,
-
-    getPeer: (hostPort: HostInfo) => TChannelConnection,
-    getPeers: () => Array<TChannelConnection>,
-
     hostPort: HostInfo
 }
 

--- a/node/index.js
+++ b/node/index.js
@@ -865,6 +865,7 @@ TChannelPeers.prototype.choosePeer = function choosePeer(options, op, n) {
     if (n > 1) throw new Error('not implemented'); // TODO heap select n
     var self = this;
 
+    if (!options) options = {};
     var hosts = null;
     if (options.host) {
         hosts = [options.host];

--- a/node/index.js
+++ b/node/index.js
@@ -696,6 +696,8 @@ TChannelConnection.prototype.popOutOp = function popOutOp(id) {
 // create a request
 TChannelConnection.prototype.request = function request(options) {
     var self = this;
+    if (!options) options = {};
+
     // TODO: use this to protect against >4Mi outstanding messages edge case
     // (e.g. zombie operation bug, incredible throughput, or simply very long
     // timeout

--- a/node/index.js
+++ b/node/index.js
@@ -114,9 +114,10 @@ function TChannel(options) {
     self.handler = self.options.handler || noHandlerHandler;
 
     // populated by:
-    // - manually api (.addPeer etc)
+    // - manually api (.peers.add etc)
     // - incoming connections on any listening socket
-    self.peers = Object.create(null);
+    self.peers = TChannelPeers(self, self.options);
+    self._hookupPeers();
 
     // TChannel advances through the following states.
     self.listened = false;
@@ -169,6 +170,40 @@ TChannel.prototype.getServer = function getServer() {
         self.logger.warn('server socket close');
     });
     return self.serverSocket;
+};
+
+TChannel.prototype._hookupPeers = function _hookupPeers() {
+    var self = this;
+    self.peers.on('allocPeer', function(peer) {
+        self._hookupPeer(peer);
+    });
+};
+
+TChannel.prototype._hookupPeer = function _hookupPeer(peer) {
+    var self = this;
+
+    self.logger.debug('alloc peer', {
+        chanHostPort: self.hostPort,
+        peerHostPort: peer.hostPort,
+        initialState: peer.state.name
+    });
+
+    peer.on('stateChanged', function(oldState, newState) {
+        self.logger.debug('peer state changed', {
+            chanHostPort: self.hostPort,
+            peerHostPort: peer.hostPort,
+            oldState: oldState.name,
+            newState: newState.name
+        });
+    });
+
+    peer.on('allocConnection', function(conn) {
+        self.logger.debug('alloc peer connection', {
+            direction: conn.direction,
+            chanHostPort: self.hostPort,
+            peerHostPort: peer.hostPort
+        });
+    });
 };
 
 // Decoulping config and creation from the constructor.
@@ -241,102 +276,6 @@ TChannel.prototype.address = function address() {
     return self.serverSocket && self.serverSocket.address();
 };
 
-// not public, used by addPeer
-TChannel.prototype.setPeer = function setPeer(hostPort, conn) {
-    var self = this;
-    if (hostPort === self.hostPort) {
-        throw new Error('refusing to set self peer'); // TODO typed error
-    }
-
-    var list = self.peers[hostPort];
-    if (!list) {
-        list = self.peers[hostPort] = [];
-    }
-
-    if (conn.direction === 'out') {
-        list.unshift(conn);
-    } else {
-        list.push(conn);
-    }
-    return conn;
-};
-
-TChannel.prototype.getPeer = function getPeer(hostPort) {
-    var self = this;
-    var list = self.peers[hostPort];
-    return list && list[0] ? list[0] : null;
-};
-
-TChannel.prototype.removePeer = function removePeer(hostPort, conn) {
-    var self = this;
-    var list = self.peers[hostPort];
-    var index = list ? list.indexOf(conn) : -1;
-
-    if (index === -1) {
-        return;
-    }
-
-    // TODO: run (don't walk) away from "arrays" as peers, get to actual peer
-    // objects... note how these current semantics can implicitly convert
-    // an in socket to an out socket
-    list.splice(index, 1);
-    if (!list.length) {
-        delete self.peers[hostPort];
-    }
-};
-
-TChannel.prototype.getPeers = function getPeers() {
-    var self = this;
-    var keys = Object.keys(self.peers);
-
-    var peers = [];
-    for (var i = 0; i < keys.length; i++) {
-        var list = self.peers[keys[i]];
-
-        for (var j = 0; j < list.length; j++) {
-            peers.push(list[j]);
-        }
-    }
-
-    return peers;
-};
-
-TChannel.prototype.addPeer = function addPeer(hostPort, connection) {
-    var self = this;
-
-    if (hostPort === self.hostPort) {
-        throw new Error('refusing to add self peer'); // TODO typed error
-    }
-
-    if (!connection) {
-        connection = self.makeOutConnection(hostPort);
-    }
-
-    var existingPeer = self.getPeer(hostPort);
-    if (existingPeer !== null && existingPeer !== connection) { // TODO: how about === undefined?
-        self.logger.warn('allocated a connection twice', {
-            hostPort: hostPort,
-            direction: connection.direction
-            // TODO: more log context
-        });
-    }
-
-    self.logger.debug('alloc peer', {
-        source: self.hostPort,
-        destination: hostPort,
-        direction: connection.direction
-        // TODO: more log context
-    });
-    connection.once('reset', function onConnectionReset(/* err */) {
-        // TODO: log?
-        self.removePeer(hostPort, connection);
-    });
-    connection.once('socketClose', function onConnectionSocketClose(conn, err) {
-        self.emit('socketClose', conn, err);
-    });
-    return self.setPeer(hostPort, connection);
-};
-
 /* jshint maxparams:5 */
 // TODO: deprecated, callers should use .request directly
 TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
@@ -364,45 +303,9 @@ TChannel.prototype.request = function request(options) {
     var self = this;
     if (self.destroyed) {
         throw new Error('cannot request() to destroyed tchannel'); // TODO typed error
+    } else {
+        return self.peers.request(options);
     }
-
-    var dest = options.host;
-    if (!dest) {
-        throw new Error('cannot request() without options.host'); // TODO typed error
-    }
-
-    var peer = self.getOutConnection(dest);
-    return peer.request(options);
-};
-
-TChannel.prototype.getOutConnection = function getOutConnection(dest) {
-    var self = this;
-    var peer = self.getPeer(dest);
-    if (!peer) {
-        peer = self.addPeer(dest);
-    }
-    return peer;
-};
-
-TChannel.prototype.makeSocket = function makeSocket(dest) {
-    var parts = dest.split(':');
-    if (parts.length !== 2) {
-        throw new Error('invalid destination'); // TODO typed error
-    }
-    var host = parts[0];
-    var port = parts[1];
-    if (host === '0.0.0.0' || port === '0') {
-        throw new Error('cannot make out connection to ephemeral peer'); // TODO typed error
-    }
-    var socket = net.createConnection({host: host, port: port});
-    return socket;
-};
-
-TChannel.prototype.makeOutConnection = function makeOutConnection(dest) {
-    var self = this;
-    var socket = self.makeSocket(dest);
-    var connection = new TChannelConnection(self, socket, 'out', dest);
-    return connection;
 };
 
 TChannel.prototype.quit = // to provide backward compatibility.
@@ -414,27 +317,14 @@ TChannel.prototype.close = function close(callback) {
     }
 
     self.destroyed = true;
-    var peers = self.getPeers();
-    var counter = peers.length + 1;
-
     self.logger.debug('quitting tchannel', {
         hostPort: self.hostPort
     });
 
-    peers.forEach(function eachPeer(conn) {
-        var sock = conn.socket;
-        sock.once('close', onClose);
-
-        conn.clearTimeoutTimer();
-
-        self.logger.debug('destroy channel for', {
-            direction: conn.direction,
-            peerRemoteAddr: conn.remoteAddr,
-            peerRemoteName: conn.remoteName,
-            fromAddress: sock.address()
-        });
-        conn.resetAll(new Error('shutdown from quit')); // TODO typed error
-        sock.destroy();
+    var peers = self.peers.values();
+    var counter = peers.length + 1;
+    peers.forEach(function eachPeer(peer) {
+        peer.close(onClose);
     });
 
     if (self.serverSocket) {
@@ -533,7 +423,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     self.socket.on('close', function onSocketClose() {
         self.onSocketErr(new Error('socket closed')); // TODO typed error
         if (self.remoteName === '0.0.0.0:0') {
-            self.channel.removePeer(self.remoteAddr, self);
+            self.channel.peers.delete(self.remoteAddr);
         }
     });
 
@@ -562,7 +452,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
     } else {
         self.handler.once('init.request', function onInIdentified(init) {
             self.remoteName = init.hostPort;
-            self.channel.addPeer(init.hostPort, self);
+            self.channel.peers.add(self.remoteName).addConnection(self);
             self.channel.emit('identified', {
                 hostPort: init.hostPort,
                 processName: init.processName
@@ -876,5 +766,211 @@ function TChannelClientOp(req, start) {
     self.start = start;
     self.timedOut = false;
 }
+
+function TChannelPeers(channel, options) {
+    if (!(this instanceof TChannelPeers)) {
+        return new TChannelPeers(channel, options);
+    }
+    var self = this;
+    EventEmitter.call(self);
+    self.channel = channel;
+    self.logger = self.channel.logger;
+    self.options = options || {};
+    self._map = Object.create(null);
+}
+
+inherits(TChannelPeers, EventEmitter);
+
+TChannelPeers.prototype.get = function get(hostPort) {
+    var self = this;
+    return self._map[hostPort] || null;
+};
+
+TChannelPeers.prototype.add = function add(hostPort) {
+    var self = this;
+    var peer = self._map[hostPort];
+    if (!peer) {
+        if (hostPort === self.channel.hostPort) {
+            throw new Error('refusing to add self peer'); // TODO typed error
+        }
+        peer = TChannelPeer(self.channel, hostPort);
+        self.emit('allocPeer', peer);
+        self._map[hostPort] = peer;
+    }
+    return peer;
+};
+
+TChannelPeers.prototype.addPeer = function addPeer(peer) {
+    var self = this;
+    if (!peer instanceof TChannelPeer) {
+        throw new Error('invalid peer'); // TODO typed error
+    }
+    if (self._map[peer.hostPort]) {
+        throw new Error('peer already defined'); // TODO typed error
+    }
+    self._map[peer.hostPort] = peer;
+};
+
+TChannelPeers.prototype.keys = function keys() {
+    var self = this;
+    var ks = Object.keys(self._map);
+    var ret = new Array(ks.length);
+    for (var i = 0; i < ks.length; i++) {
+        ret[i] = ks[i];
+    }
+    return ret;
+};
+
+TChannelPeers.prototype.values = function values() {
+    var self = this;
+    var keys = Object.keys(self._map);
+    var ret = new Array(keys.length);
+    for (var i = 0; i < keys.length; i++) {
+        ret[i] = self._map[keys[i]];
+    }
+    return ret;
+};
+
+TChannelPeers.prototype.entries = function entries() {
+    var self = this;
+    var keys = Object.keys(self._map);
+    var ret = new Array(keys.length);
+    for (var i = 0; i < keys.length; i++) {
+        ret[i] = [keys[i], self._map[keys[i]]];
+    }
+    return ret;
+};
+
+TChannelPeers.prototype.delete = function del(hostPort) {
+    var self = this;
+    var peer = self._map[hostPort];
+    delete self._map[hostPort];
+    return peer;
+};
+
+TChannelPeers.prototype.request = function request(options) {
+    var self = this;
+    var dest = options.host;
+    if (!dest) {
+        throw new Error('cannot request() without options.host'); // TODO typed error
+    }
+    var peer = self.add(dest);
+    return peer.request(options);
+};
+
+function TChannelPeer(channel, hostPort, options) {
+    if (!(this instanceof TChannelPeer)) {
+        return new TChannelPeer(channel, hostPort, options);
+    }
+    var self = this;
+    EventEmitter.call(self);
+    self.channel = channel;
+    self.logger = self.channel.logger;
+    self.options = options || {};
+    self.hostPort = hostPort;
+    self.isEphemeral = self.hostPort === '0.0.0.0:0';
+    self.connections = [];
+}
+
+inherits(TChannelPeer, EventEmitter);
+
+TChannelPeer.prototype.close = function close(callback) {
+    var self = this;
+    var counter = self.connections.length;
+    if (!counter) {
+        callback();
+    }
+    self.connections.forEach(function eachConn(conn) {
+        var sock = conn.socket;
+        sock.once('close', onClose);
+        conn.clearTimeoutTimer();
+        self.logger.debug('destroy channel for', {
+            direction: conn.direction,
+            peerRemoteAddr: conn.remoteAddr,
+            peerRemoteName: conn.remoteName,
+            fromAddress: sock.address()
+        });
+        conn.resetAll(new Error('shutdown from quit')); // TODO typed error
+        sock.destroy();
+    });
+    function onClose() {
+        if (--counter <= 0) {
+            if (counter < 0) {
+                self.logger.error('closed more sockets than expected', {
+                    counter: counter
+                });
+            }
+            callback();
+        }
+    }
+};
+
+TChannelPeer.prototype.connect = function connect() {
+    var self = this;
+    var conn = self.connections[self.connections.length - 1];
+    if (!conn) {
+        var socket = self.makeOutSocket();
+        conn = self.makeOutConnection(socket);
+        self.addConnection(conn);
+    }
+    return conn;
+};
+
+TChannelPeer.prototype.request = function request(options) {
+    var self = this;
+    return self.connect().request(options);
+};
+
+TChannelPeer.prototype.addConnection = function addConnection(conn) {
+    var self = this;
+    // TODO: first approx alert for self.connections.length > 2
+    // TODO: second approx support pruning
+    if (conn.direction === 'out') {
+        self.connections.push(conn);
+    } else {
+        self.connections.unshift(conn);
+    }
+    return conn;
+};
+
+TChannelPeer.prototype.removeConnection = function removeConnection(conn) {
+    var self = this;
+    var list = self.connections;
+    var index = list ? list.indexOf(conn) : -1;
+    if (index !== -1) {
+        return list.splice(index, 1)[0];
+    } else {
+        return null;
+    }
+};
+
+TChannelPeer.prototype.makeOutSocket = function makeOutSocket() {
+    var self = this;
+    var parts = self.hostPort.split(':');
+    if (parts.length !== 2) {
+        throw new Error('invalid destination'); // TODO typed error
+    }
+    var host = parts[0];
+    var port = parts[1];
+    if (host === '0.0.0.0' || port === '0') {
+        throw new Error('cannot make out connection to ephemeral peer'); // TODO typed error
+    }
+    var socket = net.createConnection({host: host, port: port});
+    return socket;
+};
+
+TChannelPeer.prototype.makeOutConnection = function makeOutConnection(socket) {
+    var self = this;
+    var chan = self.channel;
+    var conn = new TChannelConnection(chan, socket, 'out', self.hostPort);
+    conn.once('reset', onConnectionReset);
+    self.emit('allocConnection', conn);
+    return conn;
+
+    function onConnectionReset(/* err */) {
+        // TODO: log?
+        self.removeConnection(conn);
+    }
+};
 
 module.exports = TChannel;

--- a/node/test/identify.js
+++ b/node/test/identify.js
@@ -29,35 +29,33 @@ allocCluster.test('identify', 2, function t(cluster, assert) {
     var hostOne = cluster.hosts[0];
     var hostTwo = cluster.hosts[1];
 
-    assert.equal(one.getPeer(hostTwo), null, 'one has no peer two');
-    assert.equal(two.getPeer(hostOne), null, 'two has no peer one');
+    assert.equal(one.peers.get(hostTwo), null, 'one has no peer two');
+    assert.equal(two.peers.get(hostOne), null, 'two has no peer one');
 
     var idBar = barrier.keyed(2, function(idents, done) {
         assert.equal(idents.one.hostPort, hostTwo, 'one identified two');
         assert.equal(idents.two.hostPort, hostOne, 'two identified one');
 
-        var peersOne = one.getPeers();
-        var peersTwo = two.getPeers();
-
-        assert.equal(peersOne.length, 1, 'one should have 1 peer');
-        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-
-        var outPeer = one.getPeer(hostTwo);
-        if (outPeer) {
-            assert.equal(outPeer.direction, 'out', 'outPeer is out');
-            assert.equal(outPeer.remoteName, hostTwo, 'outgoing connection name filled in');
-        }
-
-        var inPeer = two.getPeer(hostOne);
-        if (inPeer) {
-            assert.equal(inPeer.direction, 'in', 'inPeer is in');
-            assert.equal(inPeer.remoteName, hostOne, 'incoming connection name filled in');
-        }
+        cluster.assertCleanState(assert, {
+            channels: [{
+                peers: [{
+                    connections: [{
+                        remoteName: hostTwo
+                    }]
+                }]
+            }, {
+                peers: [{
+                    connections: [{
+                        remoteName: hostOne
+                    }]
+                }]
+            }]
+        });
 
         done();
     }, assert.end);
 
     one.once('identified', idBar('one'));
     two.once('identified', idBar('two'));
-    one.addPeer(hostTwo);
+    one.peers.add(hostTwo).connect();
 });

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -34,6 +34,7 @@ allocCluster.test('does not leak inOps', 2, {
 
     one.handler.register('/timeout', timeout);
 
+    two.timeoutCheckInterval = 99999;
     two
         .request({
             host: cluster.hosts[0],
@@ -42,30 +43,23 @@ allocCluster.test('does not leak inOps', 2, {
         .send('/timeout', 'h', 'b', onTimeout);
 
     function onTimeout(err) {
-        two.timeoutCheckInterval = 99999;
         assert.equal(err && err.message, 'timed out', 'should have a timeout error');
-
-        var peersOne = one.getPeers();
-        var peersTwo = two.getPeers();
-
-        assert.equal(peersOne.length, 1, 'one should have 1 peer');
-        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-
-        var inPeer = peersOne[0];
-        if (inPeer) {
-            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
-            inPeer.onTimeoutCheck();
-            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
-            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
-        }
-
-        var outPeer = peersTwo[0];
-        if (outPeer) {
-            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
-            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
-            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
-        }
-
+        one.peers.get(two.hostPort).connections[0].onTimeoutCheck();
+        cluster.assertCleanState(assert, {
+            channels: [{
+                peers: [{
+                    connections: [
+                        {direction: 'in', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }, {
+                peers: [{
+                    connections: [
+                        {direction: 'out', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }]
+        });
         assert.end();
     }
 

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -23,9 +23,12 @@
 var allocCluster = require('./lib/alloc-cluster.js');
 var EndpointHandler = require('../endpoint-handler');
 
-allocCluster.test('does not leak inOps', 2, {
-    timeoutCheckInterval: 100,
-    serverTimeoutDefault: 100
+allocCluster.test('does not leak inOps', {
+    numPeers: 2,
+    channelOptions: {
+        timeoutCheckInterval: 100,
+        serverTimeoutDefault: 100
+    }
 }, function t(cluster, assert) {
     var one = cluster.channels[0];
     var two = cluster.channels[1];

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -159,27 +159,21 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
         return sendTest(testCase, assert);
     }), function onResults(err) {
         assert.ifError(err, 'no errors from sending');
-
-        var peersOne = one.getPeers();
-        var peersTwo = two.getPeers();
-
-        assert.equal(peersOne.length, 1, 'one should have 1 peer');
-        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-
-        var inPeer = peersOne[0];
-        if (inPeer) {
-            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
-            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
-            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
-        }
-
-        var outPeer = peersTwo[0];
-        if (outPeer) {
-            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
-            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
-            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
-        }
-
+        cluster.assertCleanState(assert, {
+            channels: [{
+                peers: [{
+                    connections: [
+                        {direction: 'in', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }, {
+                peers: [{
+                    connections: [
+                        {direction: 'out', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }]
+        });
         assert.end();
     });
 });

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -26,118 +26,6 @@ var extend = require('xtend');
 var allocCluster = require('./lib/alloc-cluster.js');
 var EndpointHandler = require('../endpoint-handler');
 
-var Cases = [
-
-    {
-        name: 'bufferOp',
-        op: Buffer('foo'),
-        reqHead: null,
-        reqBody: null,
-        resHead: '',
-        resBody: ''
-    },
-
-    {
-        name: 'stringOp',
-        op: 'foo',
-        reqHead: null,
-        reqBody: null,
-        resHead: '',
-        resBody: ''
-    },
-
-    {
-        name: 'bufferHead',
-        op: 'foo',
-        reqHead: Buffer('abc'),
-        reqBody: null,
-        resHead: 'abc',
-        resBody: ''
-    },
-
-    {
-        name: 'stringHead',
-        op: 'foo',
-        reqHead: 'abc',
-        reqBody: null,
-        resHead: 'abc',
-        resBody: ''
-    },
-
-    {
-        name: 'objectHead',
-        op: 'foo',
-        reqHead: JSON.stringify({value: 'abc'}),
-        reqBody: null,
-        resHead: '{"value":"abc"}',
-        resBody: ''
-    },
-
-    {
-        name: 'nullHead',
-        op: 'foo',
-        reqHead: null,
-        reqBody: null,
-        resHead: '',
-        resBody: ''
-    },
-
-    {
-        name: 'undefinedHead',
-        op: 'foo',
-        reqHead: undefined,
-        reqBody: null,
-        resHead: '',
-        resBody: ''
-    },
-
-    {
-        name: 'bufferBody',
-        op: 'foo',
-        reqHead: null,
-        reqBody: Buffer('abc'),
-        resHead: '',
-        resBody: 'abc'
-    },
-
-    {
-        name: 'stringBody',
-        op: 'foo',
-        reqHead: null,
-        reqBody: 'abc',
-        resHead: '',
-        resBody: 'abc'
-    },
-
-    {
-        name: 'objectBody',
-        op: 'foo',
-        reqHead: null,
-        reqBody: JSON.stringify({value: 'abc'}),
-        resHead: '',
-        resBody: '{"value":"abc"}'
-    },
-
-    {
-        name: 'nullBody',
-        op: 'foo',
-        reqHead: null,
-        reqBody: null,
-        resHead: '',
-        resBody: ''
-    },
-
-    {
-        name: 'undefinedBody',
-        op: 'foo',
-        reqHead: null,
-        reqBody: undefined,
-        resHead: '',
-        resBody: ''
-    },
-
-];
-
 allocCluster.test('request().send() to a server', 2, function t(cluster, assert) {
     var one = cluster.channels[0];
     var two = cluster.channels[1];
@@ -151,7 +39,117 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
         res.sendOk(arg2, arg3);
     });
 
-    parallel(Cases.map(function eachTestCase(testCase) {
+    parallel([
+
+        {
+            name: 'bufferOp',
+            op: Buffer('foo'),
+            reqHead: null,
+            reqBody: null,
+            resHead: '',
+            resBody: ''
+        },
+
+        {
+            name: 'stringOp',
+            op: 'foo',
+            reqHead: null,
+            reqBody: null,
+            resHead: '',
+            resBody: ''
+        },
+
+        {
+            name: 'bufferHead',
+            op: 'foo',
+            reqHead: Buffer('abc'),
+            reqBody: null,
+            resHead: 'abc',
+            resBody: ''
+        },
+
+        {
+            name: 'stringHead',
+            op: 'foo',
+            reqHead: 'abc',
+            reqBody: null,
+            resHead: 'abc',
+            resBody: ''
+        },
+
+        {
+            name: 'objectHead',
+            op: 'foo',
+            reqHead: JSON.stringify({value: 'abc'}),
+            reqBody: null,
+            resHead: '{"value":"abc"}',
+            resBody: ''
+        },
+
+        {
+            name: 'nullHead',
+            op: 'foo',
+            reqHead: null,
+            reqBody: null,
+            resHead: '',
+            resBody: ''
+        },
+
+        {
+            name: 'undefinedHead',
+            op: 'foo',
+            reqHead: undefined,
+            reqBody: null,
+            resHead: '',
+            resBody: ''
+        },
+
+        {
+            name: 'bufferBody',
+            op: 'foo',
+            reqHead: null,
+            reqBody: Buffer('abc'),
+            resHead: '',
+            resBody: 'abc'
+        },
+
+        {
+            name: 'stringBody',
+            op: 'foo',
+            reqHead: null,
+            reqBody: 'abc',
+            resHead: '',
+            resBody: 'abc'
+        },
+
+        {
+            name: 'objectBody',
+            op: 'foo',
+            reqHead: null,
+            reqBody: JSON.stringify({value: 'abc'}),
+            resHead: '',
+            resBody: '{"value":"abc"}'
+        },
+
+        {
+            name: 'nullBody',
+            op: 'foo',
+            reqHead: null,
+            reqBody: null,
+            resHead: '',
+            resBody: ''
+        },
+
+        {
+            name: 'undefinedBody',
+            op: 'foo',
+            reqHead: null,
+            reqBody: undefined,
+            resHead: '',
+            resBody: ''
+        },
+
+    ].map(function eachTestCase(testCase) {
         testCase = extend({
             channel: two,
             opts: {host: hostOne},

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -74,24 +74,21 @@ allocCluster.test('streaming echo w/ streaming callback', 2, function t(cluster,
         return partsTest(testCase, assert);
     }), function onResults(err) {
         assert.ifError(err, 'no errors from sending');
-        var one = cluster.channels[0];
-        var two = cluster.channels[1];
-        var peersOne = one.getPeers();
-        var peersTwo = two.getPeers();
-        assert.equal(peersOne.length, 1, 'one should have 1 peer');
-        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-        var inPeer = peersOne[0];
-        if (inPeer) {
-            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
-            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
-            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
-        }
-        var outPeer = peersTwo[0];
-        if (outPeer) {
-            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
-            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
-            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
-        }
+        cluster.assertCleanState(assert, {
+            channels: [{
+                peers: [{
+                    connections: [
+                        {direction: 'in', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }, {
+                peers: [{
+                    connections: [
+                        {direction: 'out', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }]
+        });
         cluster.destroy(assert.end);
     });
 });

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -216,7 +216,9 @@ TestStreamSearch.prototype.init = function init() {
 TestStreamSearch.prototype.test = function test(state, assert) {
     var options = state.test;
     var name = describe(options);
-    var cluster = allocCluster(2);
+    var cluster = allocCluster({
+        numPeers: 2
+    });
     cluster.ready(function clusterReady() {
         for (var i = 0; i < cluster.hosts.length; i++) {
             assert.comment(util.format(

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -237,24 +237,21 @@ TestStreamSearch.prototype.test = function test(state, assert) {
             headStream: CountStream({limit: options.hSize}),
             bodyStream: CountStream({limit: options.bSize})
         }, assert, function streamingTestDone() {
-            var one = cluster.channels[0];
-            var two = cluster.channels[1];
-            var peersOne = one.getPeers();
-            var peersTwo = two.getPeers();
-            assert.equal(peersOne.length, 1, 'one should have 1 peer');
-            assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-            var inPeer = peersOne[0];
-            if (inPeer) {
-                assert.equal(inPeer.direction, 'in', 'inPeer should be in');
-                assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
-                assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
-            }
-            var outPeer = peersTwo[0];
-            if (outPeer) {
-                assert.equal(outPeer.direction, 'out', 'outPeer should be out');
-                assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
-                assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
-            }
+            cluster.assertCleanState(assert, {
+                channels: [{
+                    peers: [{
+                        connections: [
+                            {direction: 'in', inOps: 0, outOps: 0}
+                        ]
+                    }]
+                }, {
+                    peers: [{
+                        connections: [
+                            {direction: 'out', inOps: 0, outOps: 0}
+                        ]
+                    }]
+                }]
+            });
             cluster.destroy(assert.end);
         });
     });

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -26,8 +26,11 @@ var timers = TimeMock(Date.now());
 
 var EndpointHandler = require('../endpoint-handler');
 
-allocCluster.test('requests will timeout', 2, {
-    timers: timers
+allocCluster.test('requests will timeout', {
+    numPeers: 2,
+    channelOptions: {
+        timers: timers
+    }
 }, function t(cluster, assert) {
     var one = cluster.channels[0];
     var two = cluster.channels[1];

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -63,28 +63,22 @@ allocCluster.test('requests will timeout', 2, {
 
     function onTimeout(err) {
         assert.equal(err && err.message, 'timed out', 'expected timeout error');
-
-        var peersOne = one.getPeers();
-        var peersTwo = two.getPeers();
-
-        assert.equal(peersOne.length, 1, 'one should have 1 peer');
-        assert.equal(peersTwo.length, 1, 'two should have 1 peer');
-
-        var inPeer = peersOne[0];
-        if (inPeer) {
-            assert.equal(inPeer.direction, 'in', 'inPeer should be in');
-            inPeer.onTimeoutCheck();
-            assert.equal(Object.keys(inPeer.inOps).length, 0, 'inPeer should have no inOps');
-            assert.equal(Object.keys(inPeer.outOps).length, 0, 'inPeer should have no outOps');
-        }
-
-        var outPeer = peersTwo[0];
-        if (outPeer) {
-            assert.equal(outPeer.direction, 'out', 'outPeer should be out');
-            assert.equal(Object.keys(outPeer.inOps).length, 0, 'outPeer should have no inOps');
-            assert.equal(Object.keys(outPeer.outOps).length, 0, 'outPeer should have no outOps');
-        }
-
+        one.peers.get(two.hostPort).connections[0].onTimeoutCheck();
+        cluster.assertCleanState(assert, {
+            channels: [{
+                peers: [{
+                    connections: [
+                        {direction: 'in', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }, {
+                peers: [{
+                    connections: [
+                        {direction: 'out', inOps: 0, outOps: 0}
+                    ]
+                }]
+            }]
+        });
         assert.end();
     }
 


### PR DESCRIPTION
First steps towards peering changes:
- refactors the channel peering structure to:
  - by an explicit map-like
  - have explicit peer objects
- adds skeleton peer state objects, only used for selection in static ways presently
- adds support for hosts option
  - [ ] TODO document
  - [x] TODO tests
  - [ ] TODO example usage

reviewers: @kriskowal @Raynos 