### PR TITLE
Make streaming an optional mode

### DIFF
--- a/node/argstream.js
+++ b/node/argstream.js
@@ -81,6 +81,9 @@ function ArgStream() {
 inherits(ArgStream, EventEmitter);
 
 function InArgStream() {
+    if (!(this instanceof InArgStream)) {
+        return new InArgStream();
+    }
     var self = this;
     ArgStream.call(self);
     self.streams = [self.arg1, self.arg2, self.arg3];
@@ -132,6 +135,9 @@ InArgStream.prototype.handleFrame = function handleFrame(parts) {
 };
 
 function OutArgStream() {
+    if (!(this instanceof OutArgStream)) {
+        return new OutArgStream();
+    }
     var self = this;
     ArgStream.call(self);
     self._flushImmed = null;

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -65,7 +65,7 @@ TChannelEndpointHandler.prototype.register = function register(name, handler) {
     return handler;
 };
 
-TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, res) {
+TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, buildResponse) {
     var self = this;
     // TODO: waterfall
     req.arg1.onValueReady(function arg1Ready(err, arg1) {
@@ -87,7 +87,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
                 'no such endpoint service=%j endpoint=%j',
                 req.service, name));
         } else if (handler.canStream) {
-            handler(req, res);
+            handler(req, buildResponse);
         } else {
             parallel({
                 arg2: req.arg2.onValueReady,
@@ -107,11 +107,13 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
         }
 
         function compatHandle(handler, args) {
+            var res = buildResponse();
             handler(req, res, args.arg2, args.arg3);
         }
     }
 
     function sendError(code, mess) {
+        var res = buildResponse();
         res.sendError(code, mess);
     }
 };

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -86,10 +86,19 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
             parallel({
                 arg2: req.arg2.onValueReady,
                 arg3: req.arg3.onValueReady
-            }, function argsDone(err, args) {
-                if (err) throw err; // TODO: protocol error, respond with error frame
-                else handler(req, res, args.arg2, args.arg3);
-            });
+            }, argsDone);
+        }
+
+        function argsDone(err, args) {
+            if (err) {
+                throw err; // TODO: protocol error, respond with error frame
+            } else {
+                compatHandle(handler, args);
+            }
+        }
+
+        function compatHandle(handler, args) {
+            handler(req, res, args.arg2, args.arg3);
         }
     }
 };

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -69,8 +69,14 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
     var self = this;
     // TODO: waterfall
     req.arg1.onValueReady(function arg1Ready(err, arg1) {
-        if (err) throw err; // TODO: protocol error, respond with error frame
-        handleArg1(arg1);
+        if (err) {
+            // TODO: log error
+            sendError('UnexpectedError', util.format(
+                'error accumulating arg1: %s: %s',
+                err.constructor.name, err.message));
+        } else {
+            handleArg1(arg1);
+        }
     });
 
     function handleArg1(arg1) {
@@ -91,7 +97,10 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
 
         function argsDone(err, args) {
             if (err) {
-                throw err; // TODO: protocol error, respond with error frame
+                // TODO: log error
+                sendError('UnexpectedError', util.format(
+                    'error accumulating arg2/arg3: %s: %s',
+                    err.constructor.name, err.message));
             } else {
                 compatHandle(handler, args);
             }

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -77,7 +77,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
         var name = String(arg1);
         var handler = self.endpoints[name];
         if (!handler) {
-            res.sendError('BadRequest', util.format(
+            sendError('BadRequest', util.format(
                 'no such endpoint service=%j endpoint=%j',
                 req.service, name));
         } else if (handler.canStream) {
@@ -100,6 +100,10 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
         function compatHandle(handler, args) {
             handler(req, res, args.arg2, args.arg3);
         }
+    }
+
+    function sendError(code, mess) {
+        res.sendError(code, mess);
     }
 };
 

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -80,9 +80,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
             res.sendError('BadRequest', util.format(
                 'no such endpoint service=%j endpoint=%j',
                 req.service, name));
-            return;
-        }
-        if (handler.canStream) {
+        } else if (handler.canStream) {
             handler(req, res);
         } else {
             parallel({

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -70,6 +70,10 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
     // TODO: waterfall
     req.arg1.onValueReady(function arg1Ready(err, arg1) {
         if (err) throw err; // TODO: protocol error, respond with error frame
+        handleArg1(arg1);
+    });
+
+    function handleArg1(arg1) {
         var name = String(arg1);
         var handler = self.endpoints[name];
         if (!handler) {
@@ -89,7 +93,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, re
                 else handler(req, res, args.arg2, args.arg3);
             });
         }
-    });
+    }
 };
 
 module.exports = TChannelEndpointHandler;

--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -79,7 +79,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, bu
             }
         });
     } else {
-        throw new Error('not implemented');
+        handleArg1(req.arg1);
     }
 
     function handleArg1(arg1) {
@@ -97,7 +97,7 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, bu
                 arg3: req.arg3.onValueReady
             }, argsDone);
         } else {
-            throw new Error('not implemented');
+            compatHandle(handler, req);
         }
 
         function argsDone(err, args) {
@@ -112,13 +112,13 @@ TChannelEndpointHandler.prototype.handleRequest = function handleRequest(req, bu
         }
 
         function compatHandle(handler, args) {
-            var res = buildResponse();
+            var res = buildResponse({streamed: false});
             handler(req, res, args.arg2, args.arg3);
         }
     }
 
     function sendError(code, mess) {
-        var res = buildResponse();
+        var res = buildResponse({streamed: false});
         res.sendError(code, mess);
     }
 };

--- a/node/examples/josh_test_client.js
+++ b/node/examples/josh_test_client.js
@@ -25,7 +25,8 @@ var tchan = require('../index');
 var chan = tchan();
 var req = chan.request({
     host: '127.0.0.1:4040',
-    timeout: 1000
+    timeout: 1000,
+    streamed: true
 });
 req.on('response', onResponse);
 req.arg1.end(argv._[0]);
@@ -42,8 +43,4 @@ function onResponse(res) {
     res.arg3.on('end', function() {
         chan.quit();
     });
-}
-
-function onError(err) {
-    console.error(err);
 }

--- a/node/examples/josh_test_server.js
+++ b/node/examples/josh_test_server.js
@@ -53,9 +53,11 @@ chan.listen(4040, '127.0.0.1');
 var spawn = require('child_pty').spawn;
 // var spawn = require('child_process').spawn;
 
-function exec(req, res) {
+function exec(req, buildRes) {
     req.arg2.onValueReady(function(err, cmd) {
-        if (err) return res.sendError('ProtocolError');
+        if (err) return buildRes().sendError('ProtocolError');
+
+        var res = buildRes({streamed: true});
         cmd = String(cmd);
         // TODO shlex
         var parts = cmd.split(/ +/);
@@ -69,12 +71,13 @@ function exec(req, res) {
     });
 }
 
-function grepn(req, res) {
+function grepn(req, buildRes) {
     var split2 = require('split2');
     var through2 = require('through2');
     req.arg2.onValueReady(function(err, needle) {
-        if (err) return res.sendError('ProtocolError');
+        if (err) return buildRes().sendError('ProtocolError');
 
+        var res = buildRes({streamed: true});
         var pat = new RegExp(needle);
         console.log('GREPN', pat);
 
@@ -90,12 +93,12 @@ function grepn(req, res) {
     });
 }
 
-function repl(req, res) {
-    var repl = require('repl');
+function repl(req, buildRes) {
     console.log('repl', req.id);
+    var res = buildRes({streamed: true});
     res.setOk(true);
     req.arg2.end();
-    repl.start({
+    require('repl').start({
         prompt: '> ',
         input: req.arg3,
         output: res.arg3,
@@ -103,7 +106,8 @@ function repl(req, res) {
     });
 }
 
-function echo(req, res) {
+function echo(req, buildRes) {
+    var res = buildRes({streamed: true});
     res.setOk(true);
     console.log('echo', req.id);
     req.arg2.pipe(res.arg2);

--- a/node/examples/term_client.js
+++ b/node/examples/term_client.js
@@ -28,7 +28,8 @@ startCommand(chan, process.argv.slice(2));
 function startCommand(chan, cmd) {
     var req = chan.request({
         host: '127.0.0.1:4040',
-        timeout: 1000
+        timeout: 1000,
+        streamed: true
     });
     req.on('response', onResponse);
     req.on('error', onError);
@@ -81,7 +82,8 @@ function startCommand(chan, cmd) {
 function startControlChannel(chan, sessionId, callback) {
     var req = chan.request({
         host: '127.0.0.1:4040',
-        timeout: 1000
+        timeout: 1000,
+        streamed: true
     });
     req.on('response', onResponse);
     req.on('error', onError);

--- a/node/index.js
+++ b/node/index.js
@@ -825,11 +825,11 @@ TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req)
         self.channel.handler.handleRequest(req, buildResponse);
     }
 
-    function buildResponse() {
+    function buildResponse(options) {
         if (op.res && op.res.state !== reqres.States.Initial) {
             throw new Error('response already built and started'); // TODO: typed error
         }
-        op.res = self.handler.buildOutgoingResponse(req);
+        op.res = self.handler.buildOutgoingResponse(req, options);
         op.res.once('finish', opDone);
         return op.res;
     }

--- a/node/index.js
+++ b/node/index.js
@@ -31,6 +31,7 @@ var WrappedError = require('error/wrapped');
 var bufrw = require('bufrw');
 var ChunkReader = require('bufrw/stream/chunk_reader');
 var ChunkWriter = require('bufrw/stream/chunk_writer');
+var reqres = require('./reqres');
 
 var v2 = require('./v2');
 var nullLogger = require('./null-logger.js');
@@ -815,15 +816,23 @@ TChannelConnection.prototype.request = function request(options) {
 TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req) {
     var self = this;
     req.remoteAddr = self.remoteName;
-    var res = self.handler.buildOutgoingResponse(req);
     var id = req.id;
     self.inPending++;
-    var op = self.inOps[id] = new TChannelServerOp(self, self.channel.now(), req, res);
-    res.once('finish', opDone);
+    var op = self.inOps[id] = new TChannelServerOp(self, self.channel.now(), req);
     process.nextTick(runHandler);
 
     function runHandler() {
+        var res = buildResponse();
         self.channel.handler.handleRequest(req, res);
+    }
+
+    function buildResponse() {
+        if (op.res && op.res.state !== reqres.States.Initial) {
+            throw new Error('response already built and started'); // TODO: typed error
+        }
+        op.res = self.handler.buildOutgoingResponse(req);
+        op.res.once('finish', opDone);
+        return op.res;
     }
 
     function opDone() {
@@ -842,7 +851,7 @@ TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req)
 function TChannelServerOp(connection, start, req, res) {
     var self = this;
     self.req = req;
-    self.res = res;
+    self.res = res || null;
     self.connection = connection;
     self.logger = connection.logger;
     self.timedOut = false;

--- a/node/index.js
+++ b/node/index.js
@@ -822,8 +822,7 @@ TChannelConnection.prototype.handleCallRequest = function handleCallRequest(req)
     process.nextTick(runHandler);
 
     function runHandler() {
-        var res = buildResponse();
-        self.channel.handler.handleRequest(req, res);
+        self.channel.handler.handleRequest(req, buildResponse);
     }
 
     function buildResponse() {

--- a/node/reqres.js
+++ b/node/reqres.js
@@ -49,6 +49,7 @@ function TChannelIncomingRequest(id, options) {
     self.headers = options.headers || {};
     self.checksum = options.checksum || null;
     if (true) {
+        self.streamed = true;
         self._argstream = InArgStream();
         self.arg1 = self._argstream.arg1;
         self.arg2 = self._argstream.arg2;
@@ -69,8 +70,10 @@ inherits(TChannelIncomingRequest, EventEmitter);
 
 TChannelIncomingRequest.prototype.handleFrame = function handleFrame(parts) {
     var self = this;
-    if (true) {
+    if (self.streamed) {
         self._argstream.handleFrame(parts);
+    } else {
+        throw new Error('not implemented');
     }
 };
 
@@ -96,6 +99,7 @@ function TChannelIncomingResponse(id, options) {
     self.checksum = options.checksum || null;
     self.ok = self.code === 0; // TODO: probably okay, but a bit jank
     if (true) {
+        self.streamed = true;
         self._argstream = InArgStream();
         self.arg1 = self._argstream.arg1;
         self.arg2 = self._argstream.arg2;
@@ -116,8 +120,10 @@ inherits(TChannelIncomingResponse, EventEmitter);
 
 TChannelIncomingResponse.prototype.handleFrame = function handleFrame(parts) {
     var self = this;
-    if (true) {
+    if (self.streamed) {
         self._argstream.handleFrame(parts);
+    } else {
+        throw new Error('not implemented');
     }
 };
 
@@ -150,6 +156,7 @@ function TChannelOutgoingRequest(id, options) {
     self.checksum = options.checksum || null;
     self.sendFrame = options.sendFrame;
     if (true) {
+        self.streamed = true;
         self._argstream = OutArgStream();
         self.arg1 = self._argstream.arg1;
         self.arg2 = self._argstream.arg2;
@@ -219,10 +226,12 @@ TChannelOutgoingRequest.prototype.sendCallRequestContFrame = function sendCallRe
 TChannelOutgoingRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     var self = this;
     if (callback) self.hookupCallback(callback);
-    if (true) {
+    if (self.streamed) {
         self.arg1.end(arg1);
         self.arg2.end(arg2);
         self.arg3.end(arg3);
+    } else {
+        throw new Error('not implemented');
     }
     return self;
 };
@@ -240,11 +249,13 @@ TChannelOutgoingRequest.prototype.hookupCallback = function hookupCallback(callb
         self.removeListener('error', onError);
         if (callback.canStream) {
             callback(null, res);
-        } else {
+        } else if (res.streamed) {
             parallel({
                 arg2: res.arg2.onValueReady,
                 arg3: res.arg3.onValueReady
             }, compatCall);
+        } else {
+            throw new Error('not implemented');
         }
 
         function compatCall(err, args) {
@@ -274,6 +285,7 @@ function TChannelOutgoingResponse(id, options) {
     self.ok = true;
     self.sendFrame = options.sendFrame;
     if (true) {
+        self.streamed = true;
         self._argstream = OutArgStream();
         self.arg1 = self._argstream.arg1;
         self.arg2 = self._argstream.arg2;
@@ -287,6 +299,8 @@ function TChannelOutgoingResponse(id, options) {
         self._argstream.on('finish', function onFinish() {
             self.emit('finish');
         });
+    } else {
+        throw new Error('not implemented');
     }
 }
 
@@ -346,7 +360,7 @@ TChannelOutgoingResponse.prototype.sendError = function sendError(codeString, me
         throw new Error('response already done'); // TODO: typed error
     } else {
         self.state = States.Error;
-        if (true) {
+        if (self.streamed) {
             // TODO: we could decide to flush any parts in a (first?) call res frame
             self._argstream.finished = true;
             self.arg1.end();
@@ -364,7 +378,7 @@ TChannelOutgoingResponse.prototype.setOk = function setOk(ok) {
     }
     self.ok = ok;
     self.code = ok ? 0 : 1; // TODO: too coupled to v2 specifics?
-    if (true) {
+    if (self.streamed) {
         self.arg1.end();
     }
 };
@@ -372,18 +386,22 @@ TChannelOutgoingResponse.prototype.setOk = function setOk(ok) {
 TChannelOutgoingResponse.prototype.sendOk = function sendOk(res1, res2) {
     var self = this;
     self.setOk(true);
-    if (true) {
+    if (self.streamed) {
         self.arg2.end(res1);
         self.arg3.end(res2);
+    } else {
+        throw new Error('not implemented');
     }
 };
 
 TChannelOutgoingResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
     var self = this;
     self.setOk(false);
-    if (true) {
+    if (self.streamed) {
         self.arg2.end(res1);
         self.arg3.end(res2);
+    } else {
+        throw new Error('not implemented');
     }
 };
 

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -98,7 +98,9 @@ allocCluster.test('streaming echo w/ streaming callback', 2, function t(cluster,
 
 function partsTest(testCase, assert) {
     return function runSendTest(callback) {
-        var req = testCase.channel.request(testCase.opts);
+        var req = testCase.channel.request(extend({
+            streamed: true
+        }, testCase.opts));
         var resultReady = Ready();
         req.hookupCallback(resultReady.signal);
         req.arg1.end(testCase.op);
@@ -145,7 +147,7 @@ function partsTest(testCase, assert) {
 function echoHandler() {
     var handler = EndpointHandler();
     function foo(req, buildRes) {
-        var res = buildRes();
+        var res = buildRes({streamed: true});
         res.setOk(true);
 
         req.arg2.on('data', function onArg2Data(chunk) {

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -128,10 +128,10 @@ function partsTest(testCase, assert) {
 
         function onResult(err, result) {
             // var res = result.result[0];
-            var head = result.result[1];
-            var body = result.result[2];
             assert.ifError(err, testCase.name + ': no result error');
             if (!err) {
+                var head = result.result[1];
+                var body = result.result[2];
                 assert.ok(Buffer.isBuffer(head), testCase.name + ': got head buffer');
                 assert.ok(Buffer.isBuffer(body), testCase.name + ': got body buffer');
                 assert.equal(head ? String(head) : head, testCase.resHead, testCase.name + ': expected head content');

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -144,8 +144,10 @@ function partsTest(testCase, assert) {
 
 function echoHandler() {
     var handler = EndpointHandler();
-    function foo(req, res) {
+    function foo(req, buildRes) {
+        var res = buildRes();
         res.setOk(true);
+
         req.arg2.on('data', function onArg2Data(chunk) {
             res.arg2.write(chunk);
         });

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -369,7 +369,8 @@ function describe(params) {
 
 function echoHandler() {
     var handler = EndpointHandler();
-    function foo(req, res) {
+    function foo(req, buildRes) {
+        var res = buildRes();
         res.setOk(true);
         req.arg2.on('data', function onArg2Data(chunk) {
             res.arg2.write(chunk);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -389,13 +389,15 @@ TChannelV2Handler.prototype.buildIncomingRequest = function buildIncomingRequest
         tracing: reqFrame.body.tracing,
         service: reqFrame.body.service,
         headers: reqFrame.body.headers,
-        checksum: v2.Checksum(reqFrame.body.csum.type)
+        checksum: v2.Checksum(reqFrame.body.csum.type),
+        streamed: reqFrame.body.flags & v2.CallRequest.Flags.Fragment
     });
 };
 
 TChannelV2Handler.prototype.buildIncomingResponse = function buildIncomingResponse(resFrame) {
     return TChannelIncomingResponse(resFrame.id, {
         code: resFrame.body.code,
-        checksum: v2.Checksum(resFrame.body.csum.type)
+        checksum: v2.Checksum(resFrame.body.csum.type),
+        streamed: resFrame.body.flags & v2.CallRequest.Flags.Fragment
     });
 };

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -352,19 +352,18 @@ TChannelV2Handler.prototype.buildOutgoingRequest = function buildOutgoingRequest
     }
 };
 
-TChannelV2Handler.prototype.buildOutgoingResponse = function buildOutgoingResponse(req) {
+TChannelV2Handler.prototype.buildOutgoingResponse = function buildOutgoingResponse(req, options) {
     var self = this;
-    var res = TChannelOutgoingResponse(req.id, {
-        tracing: req.tracing,
-        headers: {},
-        checksumType: req.checksum.type,
-        checksum: v2.Checksum(req.checksum.type),
-        sendFrame: {
-            callResponse: sendCallResponseFrame,
-            callResponseCont: sendCallResponseContFrame,
-            error: sendErrorFrame
-        }
-    });
+    if (!options) options = {};
+    options.tracing = req.tracing;
+    options.checksumType = req.checksum.type;
+    options.checksum = v2.Checksum(req.checksum.type);
+    options.sendFrame = {
+        callResponse: sendCallResponseFrame,
+        callResponseCont: sendCallResponseContFrame,
+        error: sendErrorFrame
+    };
+    var res = TChannelOutgoingResponse(req.id, options);
     return res;
 
     function sendCallResponseFrame(args, isLast) {


### PR DESCRIPTION
What this does:
- unbreaks the benchmark
- restores unstreamed mode:
  - you now only need to use streaming if you don't know how much or have all of the data on hand
  - otherwise the old .send(...) path will send a call frame and 0 or more fragmented cont frames; l/w with res.send(Not)Ok
- points the way forward for even more efficient forwarding in TRouter:
  - either a new mode other than streamed (or not)
  - or a minor API pivot to the current unstreamed mode to provide per-frame semantics

How:
- restores old pre-streaming req/res semantics under a flag
- exposes streamed flag through req/res builders
- delay and delegate res building to the handler
- when we get an incoming message that's not fragmented, turn off streaming mode

cc: @Raynos @kriskowal 