### PR TITLE
Examples should use 0.0.0.0 for portability

### DIFF
--- a/node/examples/example1.js
+++ b/node/examples/example1.js
@@ -46,12 +46,12 @@ var listening = ready(function (err) {
     }
 
     client
-        .request({host: '127.0.0.1:4040'})
+        .request({host: '0.0.0.0:4040'})
         .send('func 1', "arg 1", "arg 2", function (err, res) {
             console.log('normal res: ' + res.arg2.toString() + ' ' + res.arg3.toString());
         });
     client
-        .request({host: '127.0.0.1:4040'})
+        .request({host: '0.0.0.0:4040'})
         .send('func 2', "arg 1", "arg 2", function (err, res) {
             console.log('err res: ' + res.ok +
                 ' message: ' + String(res.arg3));
@@ -59,5 +59,5 @@ var listening = ready(function (err) {
 
 });
 
-server.listen(4040, '127.0.0.1', ready.signal);
-client.listen(4041, '127.0.0.1', ready.signal);
+server.listen(4040, '0.0.0.0', ready.signal);
+client.listen(4041, '0.0.0.0', ready.signal);

--- a/node/examples/example2.js
+++ b/node/examples/example2.js
@@ -51,7 +51,7 @@ var listening = ready(function (err) {
     async.series([
         function pingOne(done) {
             client
-                .request({host: '127.0.0.1:4040'})
+                .request({host: '0.0.0.0:4040'})
                 .send('ping', null, null, function (err, res) {
                     console.log('ping res from client: ' + res.arg2 + ' ' + res.arg3);
                     done();
@@ -60,7 +60,7 @@ var listening = ready(function (err) {
 
         function pingTwo(done) {
             server
-                .request({host: '127.0.0.1:4041'})
+                .request({host: '0.0.0.0:4041'})
                 .send('ping', null, null, function (err, res) {
                     console.log('ping res server: ' + res.arg2 + ' ' + res.arg3);
                     done();
@@ -70,5 +70,5 @@ var listening = ready(function (err) {
     ], function() {});
 });
 
-server.listen(4040, '127.0.0.1', ready.signal);
-client.listen(4041, '127.0.0.1', ready.signal);
+server.listen(4040, '0.0.0.0', ready.signal);
+client.listen(4041, '0.0.0.0', ready.signal);

--- a/node/examples/josh_test_client.js
+++ b/node/examples/josh_test_client.js
@@ -24,7 +24,7 @@ var RNGStream = require('../test/lib/rng_stream');
 var tchan = require('../index');
 var chan = tchan();
 var req = chan.request({
-    host: '127.0.0.1:4040',
+    host: '0.0.0.0:4040',
     timeout: 1000
 });
 req.on('response', onResponse);

--- a/node/examples/josh_test_server.js
+++ b/node/examples/josh_test_server.js
@@ -48,7 +48,7 @@ chan.handler.register('repl', repl);
 grepn.canStream = true;
 chan.handler.register('grepn', grepn);
 
-chan.listen(4040, '127.0.0.1');
+chan.listen(4040, '0.0.0.0');
 
 var spawn = require('child_pty').spawn;
 // var spawn = require('child_process').spawn;

--- a/node/examples/legacy_example.js
+++ b/node/examples/legacy_example.js
@@ -27,9 +27,9 @@ var TChannel = require('../index.js');
 
 var ready = CountedReadySignal(2);
 var server = new TChannel();
-server.listen(4040, '127.0.0.1', ready.signal);
+server.listen(4040, '0.0.0.0', ready.signal);
 var client = new TChannel();
-client.listen(4041, '127.0.0.1', ready.signal);
+client.listen(4041, '0.0.0.0', ready.signal);
 
 // normal response
 server.register('func 1', function func1(arg1, arg2, peerInfo, cb) {
@@ -45,7 +45,7 @@ server.register('func 2', function func2(arg1, arg2, peerInfo, cb) {
 
 ready(function onReady() {
     client.send({
-        host: '127.0.0.1:4040'
+        host: '0.0.0.0:4040'
     }, 'func 1', 'arg 1', 'arg 2', function onResp1(err, res1, res2) {
         if (err) {
             console.log('unexpected err: ' + err.message);
@@ -54,7 +54,7 @@ ready(function onReady() {
     });
 
     client.send({
-        host: '127.0.0.1:4040'
+        host: '0.0.0.0:4040'
     }, 'func 2', 'arg 1', 'arg 2', function onResp2(err, res1, res2) {
         console.log('err res: ' + err.message);
     });

--- a/node/examples/send_test.js
+++ b/node/examples/send_test.js
@@ -63,11 +63,11 @@ var ready = CountedReadySignal(3);
 var listening = ready(function (err) {
 
     client
-        .request({host: '127.0.0.1:4040'})
+        .request({host: '0.0.0.0:4040'})
         .send('ping', null, null, function (err, res) {
             console.log('ping res from client: ' + res.arg2 + ' ' + res.arg3);
             server
-                .request({host: '127.0.0.1:4041'})
+                .request({host: '0.0.0.0:4041'})
                 .send('ping', null, null, function (err, res) {
                     console.log('ping res server: ' + res.arg2 + ' ' + res.arg3);
                 });
@@ -75,33 +75,33 @@ var listening = ready(function (err) {
 
     // very aggressive settings. Not recommended for real life.
     client2
-        .request({host: '127.0.0.1:4040', timeout: 500})
+        .request({host: '0.0.0.0:4040', timeout: 500})
         .send('func 3', 'arg2', 'arg3', function (err, res) {
             console.log('2 slow res: ' + formatRes(err, res));
             client2
-                .request({host: '127.0.0.1:4040', timeout: 500})
+                .request({host: '0.0.0.0:4040', timeout: 500})
                 .send('func 3', 'arg2', 'arg3', function (err, res) {
                     console.log('3 slow res: ' + formatRes(err, res));
                 });
 
             client2
-                .request({host: '127.0.0.1:4040', timeout: 500})
+                .request({host: '0.0.0.0:4040', timeout: 500})
                 .send('func 3', 'arg2', 'arg3', function (err, res) {
                     console.log('4 slow res: ' + formatRes(err, res));
                 });
         });
 
     client2
-        .request({host: '127.0.0.1:4040', timeout: 500})
+        .request({host: '0.0.0.0:4040', timeout: 500})
         .send('func 1', 'arg2', 'arg3', function (err, res) {
             console.log('1 fast res: ' + formatRes(err, res));
         });
 
 });
 
-server.listen(4040, '127.0.0.1', ready.signal);
-client.listen(4041, '127.0.0.1', ready.signal);
-client2.listen(4042, '127.0.0.1', ready.signal);
+server.listen(4040, '0.0.0.0', ready.signal);
+client.listen(4041, '0.0.0.0', ready.signal);
+client2.listen(4042, '0.0.0.0', ready.signal);
 
 function formatRes(err, res) {
     var ret = [];

--- a/node/examples/term_client.js
+++ b/node/examples/term_client.js
@@ -27,7 +27,7 @@ startCommand(chan, process.argv.slice(2));
 
 function startCommand(chan, cmd) {
     var req = chan.request({
-        host: '127.0.0.1:4040',
+        host: '0.0.0.0:4040',
         timeout: 1000
     });
     req.on('response', onResponse);
@@ -80,7 +80,7 @@ function startCommand(chan, cmd) {
 
 function startControlChannel(chan, sessionId, callback) {
     var req = chan.request({
-        host: '127.0.0.1:4040',
+        host: '0.0.0.0:4040',
         timeout: 1000
     });
     req.on('response', onResponse);

--- a/node/examples/term_server.js
+++ b/node/examples/term_server.js
@@ -43,7 +43,7 @@ chan.handler.register('start', start);
 control.canStream = true;
 chan.handler.register('control', control);
 
-chan.listen(4040, '127.0.0.1');
+chan.listen(4040, '0.0.0.0');
 
 var Sessions = {};
 var SessionId = 0;

--- a/python/examples/options.py
+++ b/python/examples/options.py
@@ -9,6 +9,6 @@ def get_args():
     )
     parser.add_argument(
         "--host",
-        dest="host", default="localhost"
+        dest="host", default="0.0.0.0"
     )
     return parser.parse_args()


### PR DESCRIPTION
This change is needed for the tchannel-testbed I'm working on - the examples get installed into containers, which need to be accessible outside of themselves.