### PR TITLE
xtend should be a non-dev dependency

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,8 @@
     "hexer": "^1.2.0",
     "readable-stream": "1.0.33",
     "ready-signal": "^1.1.1",
-    "run-parallel": "^1.1.0"
+    "run-parallel": "^1.1.0",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "ansi-color": "^0.2.1",
@@ -45,8 +46,7 @@
     "tape": "^3.0.3",
     "through2": "^0.6.3",
     "time-mock": "^0.1.2",
-    "uber-licence": "^1.1.0",
-    "xtend": "^4.0.0"
+    "uber-licence": "^1.1.0"
   },
   "pre-commit": [],
   "pre-commit.silent": true


### PR DESCRIPTION
We are now using it in `index.js`

As an aside; There might be value in have all library
devDependencies be in depenendencies and using
`devDependencies` for things like istanbul and tape.

r: @kriskowal @jcorbin