### PR TITLE
Update SelfPeer to preserve response semantics

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -1149,6 +1149,8 @@ TChannelSelfConnection.prototype.buildOutgoingResponse = function buildOutgoingR
         inres.handleFrame(args);
         if (isLast) inres.handleFrame(null);
         if (first) {
+            inres.code = outres.code;
+            inres.ok = outres.ok;
             first = false;
             req.emit('response', inres);
         }
@@ -1156,8 +1158,11 @@ TChannelSelfConnection.prototype.buildOutgoingResponse = function buildOutgoingR
     }
 
     function passError(codeString, message) {
-        var err = new Error(format('%s: %s', codeString, message));
-        // TODO: proper error classes... requires coupling to v2?
+        var code = v2.ErrorResponse.Codes[codeString];
+        var err = v2.ErrorResponse.CodeErrors[code]({
+            originalId: req.id,
+            message: message
+        });
         req.emit('error', err);
         // TODO: should terminate corresponding inc res
         if (!self.closing) self.lastTimeoutTime = 0;


### PR DESCRIPTION
This updates the newly added SelfPeer with more tests
for not ok call responses and error frames.

It also updates the implementation to preserve the
behaviour of the other Peer.

r: @kriskowal @jcorbin