### PR TITLE
Improve operational errors:

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -736,21 +736,25 @@ TChannelConnection.prototype.start = function start() {
     var self = this;
     if (self.direction === 'out') {
         self.handler.sendInitRequest();
-        self.handler.once('init.response', function onOutIdentified(init) {
-            self.remoteName = init.hostPort;
-            self.emit('identified', {
-                hostPort: init.hostPort,
-                processName: init.processName
-            });
-        });
+        self.handler.once('init.response', onOutIdentified);
     } else {
-        self.handler.once('init.request', function onInIdentified(init) {
-            self.remoteName = init.hostPort;
-            self.channel.peers.add(self.remoteName).addConnection(self);
-            self.emit('identified', {
-                hostPort: init.hostPort,
-                processName: init.processName
-            });
+        self.handler.once('init.request', onInIdentified);
+    }
+
+    function onOutIdentified(init) {
+        self.remoteName = init.hostPort;
+        self.emit('identified', {
+            hostPort: init.hostPort,
+            processName: init.processName
+        });
+    }
+
+    function onInIdentified(init) {
+        self.remoteName = init.hostPort;
+        self.channel.peers.add(self.remoteName).addConnection(self);
+        self.emit('identified', {
+            hostPort: init.hostPort,
+            processName: init.processName
         });
     }
 };

--- a/node/index.js
+++ b/node/index.js
@@ -511,6 +511,9 @@ TChannelConnectionBase.prototype.onReqTimeout = function onReqTimeout(op) {
 // stumbles across this object in a core dump.
 TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     var self = this;
+
+    self.clearTimeoutTimer();
+
     if (self.closing) return;
     self.closing = true;
 
@@ -526,8 +529,6 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
         inPending: self.inPending,
         outPending: self.outPending
     });
-
-    self.clearTimeoutTimer();
 
     self.emit('error', err);
 

--- a/node/index.js
+++ b/node/index.js
@@ -525,6 +525,10 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     var inOpKeys = Object.keys(self.inOps);
     var outOpKeys = Object.keys(self.outOps);
 
+    if (!err) {
+        err = new Error('unknown connection reset'); // TODO typed error
+    }
+
     self.logger[err ? 'warn' : 'info']('resetting connection', {
         error: err,
         remoteName: self.remoteName,

--- a/node/index.js
+++ b/node/index.js
@@ -676,7 +676,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         self.onSocketErr(err);
     });
     self.socket.on('close', function onSocketClose() {
-        self.onSocketErr(new Error('socket closed')); // TODO typed error
+        self.resetAll(new Error('socket closed')); // TODO typed error
         if (self.remoteName === '0.0.0.0:0') {
             self.channel.peers.delete(self.remoteAddr);
         }

--- a/node/index.js
+++ b/node/index.js
@@ -680,7 +680,6 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         if (self.remoteName === '0.0.0.0:0') {
             self.channel.peers.delete(self.remoteAddr);
         }
-        self.clearTimeoutTimer(); // TODO probably not needed, both resetAll and close call it
     });
 
     self.reader.on('data', function onReaderFrame(frame) {

--- a/node/index.js
+++ b/node/index.js
@@ -699,26 +699,6 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         self.socket.destroy();
     });
 
-    if (direction === 'out') {
-        self.handler.sendInitRequest();
-        self.handler.once('init.response', function onOutIdentified(init) {
-            self.remoteName = init.hostPort;
-            self.emit('identified', {
-                hostPort: init.hostPort,
-                processName: init.processName
-            });
-        });
-    } else {
-        self.handler.once('init.request', function onInIdentified(init) {
-            self.remoteName = init.hostPort;
-            self.channel.peers.add(self.remoteName).addConnection(self);
-            self.emit('identified', {
-                hostPort: init.hostPort,
-                processName: init.processName
-            });
-        });
-    }
-
     var stream = self.socket;
 
     if (dumpEnabled) {
@@ -747,8 +727,33 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         self.logger.warn(self.channel.hostPort + ' destroying socket from timeouts');
         self.socket.destroy();
     });
+
+    self.start();
 }
 inherits(TChannelConnection, TChannelConnectionBase);
+
+TChannelConnection.prototype.start = function start() {
+    var self = this;
+    if (self.direction === 'out') {
+        self.handler.sendInitRequest();
+        self.handler.once('init.response', function onOutIdentified(init) {
+            self.remoteName = init.hostPort;
+            self.emit('identified', {
+                hostPort: init.hostPort,
+                processName: init.processName
+            });
+        });
+    } else {
+        self.handler.once('init.request', function onInIdentified(init) {
+            self.remoteName = init.hostPort;
+            self.channel.peers.add(self.remoteName).addConnection(self);
+            self.emit('identified', {
+                hostPort: init.hostPort,
+                processName: init.processName
+            });
+        });
+    }
+};
 
 TChannelConnection.prototype.close = function close(callback) {
     var self = this;

--- a/node/index.js
+++ b/node/index.js
@@ -180,9 +180,6 @@ TChannel.prototype.getServer = function getServer() {
         });
         self.emit('error', err);
     });
-    self.serverSocket.on('close', function onServerSocketClose() {
-        self.logger.warn('server socket close');
-    });
     return self.serverSocket;
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -702,8 +702,10 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
         .pipe(self.socket)
         ;
 
-    function onReaderFrame(frame) {
-        self.onFrame(frame);
+    function onReaderFrame() {
+        if (!self.closing) {
+            self.lastTimeoutTime = 0;
+        }
     }
 
     function onReaderError(err) {
@@ -802,13 +804,6 @@ TChannelConnection.prototype.onSocketErr = function onSocketErr(err) {
     var self = this;
     if (!self.closing) {
         self.resetAll(err);
-    }
-};
-
-TChannelConnection.prototype.onFrame = function onFrame(/* frame */) {
-    var self = this;
-    if (!self.closing) {
-        self.lastTimeoutTime = 0;
     }
 };
 

--- a/node/index.js
+++ b/node/index.js
@@ -550,8 +550,6 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
 
     self.inPending = 0;
     self.outPending = 0;
-
-    self.emit('socketClose', self, err);
 };
 
 TChannelConnectionBase.prototype.popOutOp = function popOutOp(id) {

--- a/node/index.js
+++ b/node/index.js
@@ -529,7 +529,8 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
         err = new Error('unknown connection reset'); // TODO typed error
     }
 
-    self.logger[err ? 'warn' : 'info']('resetting connection', {
+    var isError = err.type !== 'tchannel.socket-closed';
+    self.logger[isError ? 'warn' : 'info']('resetting connection', {
         error: err,
         remoteName: self.remoteName,
         localName: self.channel.hostPort,
@@ -539,7 +540,9 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
         outPending: self.outPending
     });
 
-    self.emit('error', err);
+    if (isError) {
+        self.emit('error', err);
+    }
 
     // requests that we've received we can delete, but these reqs may have started their
     //   own outgoing work, which is hard to cancel. By setting this.closing, we make sure

--- a/node/index.js
+++ b/node/index.js
@@ -398,11 +398,6 @@ inherits(TChannelConnectionBase, EventEmitter);
 
 TChannelConnectionBase.prototype.close = function close(callback) {
     var self = this;
-    self.logger.debug('destroy channel for', {
-        direction: self.direction,
-        peerRemoteAddr: self.remoteAddr,
-        peerRemoteName: self.remoteName
-    });
     self.resetAll(SocketClosedError({reason: 'local close'}));
     process.nextTick(callback);
 };
@@ -761,12 +756,6 @@ inherits(TChannelConnection, TChannelConnectionBase);
 TChannelConnection.prototype.close = function close(callback) {
     var self = this;
     self.socket.once('close', callback);
-    self.logger.debug('destroy channel for', {
-        direction: self.direction,
-        peerRemoteAddr: self.remoteAddr,
-        peerRemoteName: self.remoteName,
-        fromAddress: self.socket.address()
-    });
     self.resetAll(SocketClosedError({reason: 'local close'}));
     self.socket.destroy();
 };

--- a/node/index.js
+++ b/node/index.js
@@ -748,17 +748,16 @@ inherits(TChannelConnection, TChannelConnectionBase);
 
 TChannelConnection.prototype.close = function close(callback) {
     var self = this;
-    var sock = self.socket;
-    sock.once('close', callback);
+    self.socket.once('close', callback);
     self.clearTimeoutTimer();
     self.logger.debug('destroy channel for', {
         direction: self.direction,
         peerRemoteAddr: self.remoteAddr,
         peerRemoteName: self.remoteName,
-        fromAddress: sock.address()
+        fromAddress: self.socket.address()
     });
     self.resetAll(new Error('shutdown from quit')); // TODO typed error
-    sock.destroy();
+    self.socket.destroy();
 };
 
 TChannelConnection.prototype.onReaderError = function onReaderError(err) {

--- a/node/index.js
+++ b/node/index.js
@@ -392,7 +392,6 @@ inherits(TChannelConnectionBase, EventEmitter);
 
 TChannelConnectionBase.prototype.close = function close(callback) {
     var self = this;
-    self.clearTimeoutTimer();
     self.logger.debug('destroy channel for', {
         direction: self.direction,
         peerRemoteAddr: self.remoteAddr,
@@ -749,7 +748,6 @@ inherits(TChannelConnection, TChannelConnectionBase);
 TChannelConnection.prototype.close = function close(callback) {
     var self = this;
     self.socket.once('close', callback);
-    self.clearTimeoutTimer();
     self.logger.debug('destroy channel for', {
         direction: self.direction,
         peerRemoteAddr: self.remoteAddr,

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -27,6 +27,7 @@ var util = require('util');
 var TChannel = require('../../index.js');
 var parallel = require('run-parallel');
 var debugLogtron = require('debug-logtron');
+var LEVELS = require('debug-logtron/levels');
 
 module.exports = allocCluster;
 
@@ -35,6 +36,21 @@ function allocCluster(opts) {
 
     var host = 'localhost';
     var logger = debugLogtron('tchannel');
+
+    // TODO: debugLogtron should do this by default imo
+    var orig = logger._log;
+    logger._log = function _log(level, msg, meta, cb) {
+        if (level >= LEVELS.warn) {
+            var mess = msg;
+            if (meta && meta.error) {
+                mess += ' - ' + meta.error.message;
+            }
+            var levelName = LEVELS.LEVELS_BY_VALUE[level];
+            console.error('%s: %s ~', levelName, mess, meta);
+        }
+        orig.call(logger, level, msg, meta, cb);
+    };
+
     var cluster = {
         logger: logger,
         hosts: new Array(opts.numPeers),


### PR DESCRIPTION
- don't create error objects or warn log for non-error conditions
- hack observability into debug logtron so that test failures are clearer

Because of the way resetAll works, a frequent test failure mode is a hang/timeout with a (previously silenced) warn log.  This certainly is what we want in production: connection errors get logged, and we move on.

However until we figure out someway to make such errors a hard failure in a test (say by registering some re-throwing error handlers) this provides us better visibility.  IMO we want this sort of visibility anyhow... maybe better done by hooking it up to arbitrary sink, such as `assert.comment` rather than `console.error`, but this works for now.