### PR TITLE
Drop use of node core streams from socket -> handler -> socket path

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -685,9 +685,12 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
 TChannelConnection.prototype.setupHandler = function setupHandler() {
     var self = this;
 
+    self.handler.write = function write(buf, done) {
+        self.socket.write(buf, null, done);
+    };
+
     self.mach.emit = handleReadFrame;
 
-    self.handler.on('buffer', onHandlerBuffer);
     self.handler.on('error', onHandlerError);
     self.handler.on('call.incoming.request', onCallRequest);
     self.handler.on('call.incoming.response', onCallResponse);
@@ -713,10 +716,6 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     // stream = stream
     //     .pipe(self.socket)
     //     ;
-
-    function onHandlerBuffer(buf) {
-        self.socket.write(buf);
-    }
 
     function onHandlerError(err) {
         self.resetAll(err);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -84,7 +84,7 @@ TChannelV2Handler.prototype.pushFrame = function pushFrame(frame) {
     if (err) {
         if (!Buffer.isBuffer(err.buffer)) err.buffer = writeBuffer;
         if (typeof err.offset !== 'number') err.offset = res.offset;
-        self.emit('error', err);
+        self.emit('write.error', err);
     } else {
         var buf = writeBuffer.slice(0, res.offset);
         self.writeCopy(buf);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -64,6 +64,11 @@ function TChannelV2Handler(options) {
 
 util.inherits(TChannelV2Handler, EventEmitter);
 
+TChannelV2Handler.prototype.write = function write() {
+    var self = this;
+    self.emit('error', new Error('write not implemented'));
+};
+
 TChannelV2Handler.prototype.pushFrame = function pushFrame(frame) {
     var self = this;
     var tup = bufrw.toBufferTuple(v2.Frame.RW, frame);
@@ -72,7 +77,7 @@ TChannelV2Handler.prototype.pushFrame = function pushFrame(frame) {
     if (err) {
         self.emit('error', err);
     } else {
-        self.emit('buffer', buffer);
+        self.write(buffer);
     }
 };
 


### PR DESCRIPTION
This is between a 20% and 30% speedup on our synthetic benchmark.

At the cost of dropping `NODE_DEBUG=tchannel_dump` convenience for now.

cc @Raynos @kriskowal 