### PR TITLE
Refactor args fragmenting

### DIFF
--- a/node/test/v2/args.js
+++ b/node/test/v2/args.js
@@ -22,6 +22,7 @@
 
 var test = require('tape');
 var bufrw = require('bufrw');
+var crc32 = require('crc').crc32;
 var testRW = require('bufrw/test_rw');
 var Checksum = require('../../v2/checksum.js');
 var ArgsRW = require('../../v2/args.js');
@@ -65,6 +66,69 @@ test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
     [
         TestBody(null, [Buffer('on'), Buffer('to'), Buffer('te')]), [
             0x00,                   // csumtype:1
+            0x00, 0x02, 0x6f, 0x6e, // arg1~2
+            0x00, 0x02, 0x74, 0x6f, // arg2~2
+            0x00, 0x02, 0x74, 0x65  // arg3~2
+        ]
+    ],
+
+    [
+        TestBody(Checksum.Types.CRC32, [Buffer('on')]), [
+            0x01,                   // csumtype:1
+            0x09, 0xb6, 0x29, 0xc8, // csum:4
+            0x00, 0x02, 0x6f, 0x6e  // arg1~2
+        ]
+    ],
+
+    [
+        TestBody(Checksum.Types.CRC32, [Buffer('on'), Buffer('to')]), [
+            0x01,                   // csumtype:1
+            0x96, 0x16, 0x1e, 0x58, // csum:4
+            0x00, 0x02, 0x6f, 0x6e, // arg1~2
+            0x00, 0x02, 0x74, 0x6f  // arg2~2
+        ]
+    ],
+
+    [
+        TestBody(Checksum.Types.CRC32, [Buffer('on'), Buffer('to'), Buffer('te')]), [
+            0x01,                   // csumtype:1
+            0xbf, 0x3f, 0x47, 0xf3, // csum:4
+            0x00, 0x02, 0x6f, 0x6e, // arg1~2
+            0x00, 0x02, 0x74, 0x6f, // arg2~2
+            0x00, 0x02, 0x74, 0x65  // arg3~2
+        ]
+    ],
+
+    [
+        TestBody(
+            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            [Buffer('on')]
+        ), [
+            0x01,                   // csumtype:1
+            0xdf, 0x93, 0xd6, 0xff, // csum:4
+            0x00, 0x02, 0x6f, 0x6e  // arg1~2
+        ]
+    ],
+
+    [
+        TestBody(
+            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            [Buffer('on'), Buffer('to')]
+        ), [
+            0x01,                   // csumtype:1
+            0x2b, 0x13, 0x87, 0xc4, // csum:4
+            0x00, 0x02, 0x6f, 0x6e, // arg1~2
+            0x00, 0x02, 0x74, 0x6f  // arg2~2
+        ]
+    ],
+
+    [
+        TestBody(
+            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            [Buffer('on'), Buffer('to'), Buffer('te')]
+        ), [
+            0x01,                   // csumtype:1
+            0xeb, 0x18, 0x14, 0x00, // csum:4
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f, // arg2~2
             0x00, 0x02, 0x74, 0x65  // arg3~2

--- a/node/test/v2/args.js
+++ b/node/test/v2/args.js
@@ -23,13 +23,15 @@
 var test = require('tape');
 var bufrw = require('bufrw');
 var testRW = require('bufrw/test_rw');
+var Checksum = require('../../v2/checksum.js');
 var ArgsRW = require('../../v2/args.js');
 
-function TestBody(args) {
+function TestBody(csum, args) {
     if (!(this instanceof TestBody)) {
-        return new TestBody(args);
+        return new TestBody(csum, args);
     }
     var self = this;
+    self.csum = Checksum.objOrType(csum);
     self.args = args || [];
 }
 
@@ -40,25 +42,29 @@ TestBody.RW = bufrw.Struct(TestBody, [
 test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
 
     [
-        TestBody([]), [
+        TestBody(null, []), [
+            0x00 // csumtype:1
         ]
     ],
 
     [
-        TestBody([Buffer('on')]), [
-            0x00, 0x02, 0x6f, 0x6e  // arg1~2
+        TestBody(null, [Buffer('on')]), [
+            0x00,                  // csumtype:1
+            0x00, 0x02, 0x6f, 0x6e // arg1~2
         ]
     ],
 
     [
-        TestBody([Buffer('on'), Buffer('to')]), [
+        TestBody(null, [Buffer('on'), Buffer('to')]), [
+            0x00,                   // csumtype:1
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f  // arg2~2
         ]
     ],
 
     [
-        TestBody([Buffer('on'), Buffer('to'), Buffer('te')]), [
+        TestBody(null, [Buffer('on'), Buffer('to'), Buffer('te')]), [
+            0x00,                   // csumtype:1
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f, // arg2~2
             0x00, 0x02, 0x74, 0x65  // arg3~2

--- a/node/test/v2/args.js
+++ b/node/test/v2/args.js
@@ -25,25 +25,40 @@ var bufrw = require('bufrw');
 var testRW = require('bufrw/test_rw');
 var ArgsRW = require('../../v2/args.js');
 
-test('ArgsRW: read/write payload', testRW.cases(ArgsRW(bufrw.buf2), [
+function TestBody(args) {
+    if (!(this instanceof TestBody)) {
+        return new TestBody(args);
+    }
+    var self = this;
+    self.args = args || [];
+}
 
-    [[], []],
+TestBody.RW = bufrw.Struct(TestBody, [
+    {call: ArgsRW(bufrw.buf2)}
+]);
+
+test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
 
     [
-        [Buffer('on')], [
+        TestBody([]), [
+        ]
+    ],
+
+    [
+        TestBody([Buffer('on')]), [
             0x00, 0x02, 0x6f, 0x6e  // arg1~2
         ]
     ],
 
     [
-        [Buffer('on'), Buffer('to')], [
+        TestBody([Buffer('on'), Buffer('to')]), [
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f  // arg2~2
         ]
     ],
 
     [
-        [Buffer('on'), Buffer('to'), Buffer('te')], [
+        TestBody([Buffer('on'), Buffer('to'), Buffer('te')]), [
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f, // arg2~2
             0x00, 0x02, 0x74, 0x65  // arg3~2

--- a/node/test/v2/args.js
+++ b/node/test/v2/args.js
@@ -32,7 +32,7 @@ function TestBody(csum, args) {
         return new TestBody(csum, args);
     }
     var self = this;
-    self.csum = Checksum.objOrType(csum);
+    self.csum = new Checksum.objOrType(csum);
     self.args = args || [];
 }
 
@@ -101,7 +101,7 @@ test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
 
     [
         TestBody(
-            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            new Checksum(Checksum.Types.CRC32, crc32('prior')),
             [Buffer('on')]
         ), [
             0x01,                   // csumtype:1
@@ -112,7 +112,7 @@ test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
 
     [
         TestBody(
-            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            new Checksum(Checksum.Types.CRC32, crc32('prior')),
             [Buffer('on'), Buffer('to')]
         ), [
             0x01,                   // csumtype:1
@@ -124,7 +124,7 @@ test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
 
     [
         TestBody(
-            Checksum(Checksum.Types.CRC32, crc32('prior')),
+            new Checksum(Checksum.Types.CRC32, crc32('prior')),
             [Buffer('on'), Buffer('to'), Buffer('te')]
         ), [
             0x01,                   // csumtype:1
@@ -132,6 +132,18 @@ test('ArgsRW: read/write payload', testRW.cases(TestBody.RW, [
             0x00, 0x02, 0x6f, 0x6e, // arg1~2
             0x00, 0x02, 0x74, 0x6f, // arg2~2
             0x00, 0x02, 0x74, 0x65  // arg3~2
+        ]
+    ],
+
+    [
+        TestBody(
+            null,
+            [Buffer('on'), Buffer(0), Buffer(0)]
+        ), [
+            0x00,                   // csumtype:1
+            0x00, 0x02, 0x6f, 0x6e, // arg1~2
+            0x00, 0x00,             // arg2~2
+            0x00, 0x00              // arg3~2
         ]
     ]
 

--- a/node/test/v2/call.js
+++ b/node/test/v2/call.js
@@ -38,7 +38,6 @@ var testReq = new Call.Request(
     Checksum.Types.Farm32,
     [Buffer('on'), Buffer('to'), Buffer('te')]
 );
-testReq.updateChecksum();
 
 var testReqBytes = [
     0x00,                   // flags:1
@@ -85,7 +84,6 @@ var testRes = new Call.Response(
     Checksum.Types.Farm32,
     [Buffer('ON'), Buffer('TO'), Buffer('TE')]
 );
-testRes.updateChecksum();
 
 var testResBytes = [
     0x00,                   // flags:1

--- a/node/test/v2/cont.js
+++ b/node/test/v2/cont.js
@@ -29,7 +29,6 @@ var testReqCont = new Cont.RequestCont(
     0, Checksum.Types.Farm32,
     [Buffer('on'), Buffer('to'), Buffer('te')]
 );
-testReqCont.updateChecksum();
 
 var testReqContBytes = [
     0x00,                   // flags:1
@@ -61,7 +60,6 @@ var testResCont = new Cont.ResponseCont(
     0, Checksum.Types.Farm32,
     [Buffer('ON'), Buffer('TO'), Buffer('TE')]
 );
-testResCont.updateChecksum();
 
 var testResContBytes = [
     0x00,                   // flags:1

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -77,18 +77,22 @@ ArgsRW.prototype.byteLength = function byteLength(body) {
 
 ArgsRW.prototype.writeInto = function writeInto(body, buffer, offset) {
     var self = this;
+    var start = offset;
     var res;
 
-    body.csum.update(body.args, body.csum.val);
-    res = Checksum.RW.writeInto(body.csum, buffer, offset);
-    if (res.err) return res;
-    offset = res.offset;
+    var lenres = Checksum.RW.byteLength(body.csum);
+    if (lenres.err) return WriteResult.error(lenres.err);
+    offset += lenres.length;
 
     for (var i = 0; i < body.args.length; i++) {
         res = self.argrw.writeInto(body.args[i], buffer, offset);
         if (res.err) return res;
         offset = res.offset;
     }
+
+    body.csum.update(body.args, body.csum.val);
+    res = Checksum.RW.writeInto(body.csum, buffer, start);
+    if (!res.err) res.offset = offset;
 
     return res;
 };

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -45,23 +45,24 @@ function ArgsRW(argrw) {
 }
 inherits(ArgsRW, bufrw.Base);
 
-ArgsRW.prototype.byteLength = function byteLength(args) {
+ArgsRW.prototype.byteLength = function byteLength(body) {
     var self = this;
     var length = 0;
     var res;
-    if (args === null) {
+
+    if (body.args === null) {
         return LengthResult.just(length);
     }
 
-    if (!Array.isArray(args)) {
+    if (!Array.isArray(body.args)) {
         return LengthResult.error(InvalidArgumentError({
-            argType: typeof args,
-            argConstructor: args.constructor.name
+            argType: typeof body.args,
+            argConstructor: body.args.constructor.name
         }));
     }
 
-    for (var i = 0; i < args.length; i++) {
-        res = self.argrw.byteLength(args[i]);
+    for (var i = 0; i < body.args.length; i++) {
+        res = self.argrw.byteLength(body.args[i]);
         if (res.err) return res;
         length += res.length;
     }
@@ -69,12 +70,12 @@ ArgsRW.prototype.byteLength = function byteLength(args) {
     return LengthResult.just(length);
 };
 
-ArgsRW.prototype.writeInto = function writeInto(args, buffer, offset) {
+ArgsRW.prototype.writeInto = function writeInto(body, buffer, offset) {
     var self = this;
     var res;
 
-    for (var i = 0; i < args.length; i++) {
-        res = self.argrw.writeInto(args[i], buffer, offset);
+    for (var i = 0; i < body.args.length; i++) {
+        res = self.argrw.writeInto(body.args[i], buffer, offset);
         if (res.err) return res;
         offset = res.offset;
     }
@@ -82,19 +83,19 @@ ArgsRW.prototype.writeInto = function writeInto(args, buffer, offset) {
     return WriteResult.just(offset);
 };
 
-ArgsRW.prototype.readFrom = function readFrom(buffer, offset) {
+ArgsRW.prototype.readFrom = function readFrom(body, buffer, offset) {
     var self = this;
-    var args = [];
     var res;
 
+    body.args = [];
     while (offset < buffer.length) {
         res = self.argrw.readFrom(buffer, offset);
         if (res.err) return res;
         offset = res.offset;
-        args.push(res.value);
+        body.args.push(res.value);
     }
 
-    return ReadResult.just(offset, args);
+    return ReadResult.just(offset, body);
 };
 
 module.exports = ArgsRW;

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -79,6 +79,7 @@ ArgsRW.prototype.writeInto = function writeInto(body, buffer, offset) {
     var self = this;
     var res;
 
+    body.csum.update(body.args, body.csum.val);
     res = Checksum.RW.writeInto(body.csum, buffer, offset);
     if (res.err) return res;
     offset = res.offset;
@@ -89,7 +90,7 @@ ArgsRW.prototype.writeInto = function writeInto(body, buffer, offset) {
         offset = res.offset;
     }
 
-    return WriteResult.just(offset);
+    return res;
 };
 
 ArgsRW.prototype.readFrom = function readFrom(body, buffer, offset) {

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -46,46 +46,54 @@ function ArgsRW(argrw) {
 inherits(ArgsRW, bufrw.Base);
 
 ArgsRW.prototype.byteLength = function byteLength(args) {
+    var self = this;
+    var length = 0;
+    var res;
     if (args === null) {
-        args = [];
-    } else if (!Array.isArray(args)) {
+        return LengthResult.just(length);
+    }
+
+    if (!Array.isArray(args)) {
         return LengthResult.error(InvalidArgumentError({
             argType: typeof args,
             argConstructor: args.constructor.name
         }));
     }
-    var self = this;
-    var length = 0;
-    var res;
+
     for (var i = 0; i < args.length; i++) {
         res = self.argrw.byteLength(args[i]);
         if (res.err) return res;
         length += res.length;
     }
+
     return LengthResult.just(length);
 };
 
 ArgsRW.prototype.writeInto = function writeInto(args, buffer, offset) {
     var self = this;
     var res;
+
     for (var i = 0; i < args.length; i++) {
         res = self.argrw.writeInto(args[i], buffer, offset);
         if (res.err) return res;
         offset = res.offset;
     }
+
     return WriteResult.just(offset);
 };
 
 ArgsRW.prototype.readFrom = function readFrom(buffer, offset) {
     var self = this;
-    var res;
     var args = [];
+    var res;
+
     while (offset < buffer.length) {
         res = self.argrw.readFrom(buffer, offset);
         if (res.err) return res;
         offset = res.offset;
         args.push(res.value);
     }
+
     return ReadResult.just(offset, args);
 };
 

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -109,6 +109,8 @@ ArgsRW.prototype.readFrom = function readFrom(body, buffer, offset) {
     var self = this;
     var res;
 
+    // TODO: missing symmetry: verify csum (requires prior somehow)
+
     res = Checksum.RW.readFrom(buffer, offset);
     if (res.err) return res;
     offset = res.offset;

--- a/node/v2/args.js
+++ b/node/v2/args.js
@@ -24,7 +24,7 @@ var TypedError = require('error/typed');
 var inherits = require('util').inherits;
 var bufrw = require('bufrw');
 var Checksum = require('./checksum');
-var v2 = require('./index');
+var Flags = require('./call_flags');
 
 var LengthResult = bufrw.LengthResult;
 var WriteResult = bufrw.WriteResult;
@@ -143,12 +143,12 @@ ArgsRW.prototype.writeFragmentInto = function writeFragmentInto(body, buffer, of
             var j = remain - overhead;
             body.args[i] = arg.slice(0, j);
             body.cont = new body.constructor.Cont(
-                body.flags & v2.CallFlags.Fragment,
+                body.flags & Flags.Fragment,
                 body.csum, // share on purpose
                 body.args.splice(i + 1)
             );
             body.cont.args.unshift(arg.slice(j));
-            body.flags |= v2.CallFlags.Fragment;
+            body.flags |= Flags.Fragment;
             arg = body.args[i];
         }
         res = self.argrw.writeInto(arg, buffer, offset);

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -109,11 +109,6 @@ CallRequest.prototype.splitArgs = function splitArgs(args, maxSize) {
     return ret;
 };
 
-CallRequest.prototype.updateChecksum = function updateChecksum() {
-    var self = this;
-    return self.csum.update(self.args);
-};
-
 CallRequest.prototype.verifyChecksum = function verifyChecksum() {
     var self = this;
     return self.csum.verify(self.args);
@@ -143,11 +138,6 @@ CallResponse.RW = bufrw.Struct(CallResponse, [
 ]);
 
 CallResponse.prototype.splitArgs = CallRequest.prototype.splitArgs;
-
-CallResponse.prototype.updateChecksum = function updateChecksum() {
-    var self = this;
-    return self.csum.update(self.args);
-};
 
 CallResponse.prototype.verifyChecksum = function verifyChecksum() {
     var self = this;

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -67,7 +67,7 @@ CallRequest.RW = bufrw.Struct(CallRequest, [
     {name: 'service', rw: bufrw.str1},     // service~1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
     {name: 'csum', rw: Checksum.RW},       // csumtype:1 (csum:4){0,1}
-    {name: 'args', rw: argsrw}             // (arg~2)*
+    {call: argsrw}                         // (arg~2)*
 ]);
 
 CallRequest.prototype.splitArgs = function splitArgs(args, maxSize) {
@@ -141,7 +141,7 @@ CallResponse.RW = bufrw.Struct(CallResponse, [
     {name: 'tracing', rw: Tracing.RW},     // tracing:24 traceflags:1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
     {name: 'csum', rw: Checksum.RW},       // csumtype:1 (csum:4){0},1}
-    {name: 'args', rw: argsrw}             // (arg~2)*
+    {call: argsrw}                         // (arg~2)*
 ]);
 
 CallResponse.prototype.splitArgs = CallRequest.prototype.splitArgs;

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -66,7 +66,6 @@ CallRequest.RW = bufrw.Struct(CallRequest, [
     {name: 'tracing', rw: Tracing.RW},     // tracing:24 traceflags:1
     {name: 'service', rw: bufrw.str1},     // service~1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
-    {name: 'csum', rw: Checksum.RW},       // csumtype:1 (csum:4){0,1}
     {call: argsrw}                         // (arg~2)*
 ]);
 
@@ -140,7 +139,6 @@ CallResponse.RW = bufrw.Struct(CallResponse, [
     {name: 'code', rw: bufrw.UInt8},       // code:1
     {name: 'tracing', rw: Tracing.RW},     // tracing:24 traceflags:1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
-    {name: 'csum', rw: Checksum.RW},       // csumtype:1 (csum:4){0},1}
     {call: argsrw}                         // (arg~2)*
 ]);
 

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -27,11 +27,6 @@ var header = require('./header');
 var Tracing = require('./tracing');
 var argsrw = ArgsRW(bufrw.buf2);
 
-var Flags;
-process.nextTick(function() {
-    Flags = require('./index').CallFlags;
-});
-
 var ResponseCodes = {
     OK: 0x00,
     Error: 0x01
@@ -56,58 +51,50 @@ function CallRequest(flags, ttl, tracing, service, headers, csum, args) {
     self.headers = headers || {};
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
+    self.cont = null;
+    self._flagsOffset = 0;
+}
+
+var flagsReadLen = {
+    byteLength: flagsLength,
+    writeInto: saveFlagsOffset,
+    readFrom: readFlagsFrom
+};
+
+var flagsRetWrite = {
+    writeInto: writeFlagsInto,
+};
+
+function saveFlagsOffset(body, buffer, offset) {
+    body._flagsOffset = offset;
+    return bufrw.WriteResult.just(offset + bufrw.UInt8.width);
+}
+
+function flagsLength() {
+    return bufrw.LengthResult.just(bufrw.UInt8.width);
+}
+
+function writeFlagsInto(body, buffer, offset) {
+    var res = bufrw.UInt8.writeInto(body.flags, buffer, body._flagsOffset);
+    if (!res.err) res.offset = offset;
+    return res;
+}
+
+function readFlagsFrom(body, buffer, offset) {
+    return bufrw.UInt8.readFrom(buffer, offset);
 }
 
 CallRequest.Cont = require('./cont').RequestCont;
 CallRequest.TypeCode = 0x03;
 CallRequest.RW = bufrw.Struct(CallRequest, [
-    {name: 'flags', rw: bufrw.UInt8},      // flags:1
+    {name: 'flags', call: flagsReadLen},   // flags:1 -- skipped at first
     {name: 'ttl', rw: bufrw.UInt32BE},     // ttl:4
     {name: 'tracing', rw: Tracing.RW},     // tracing:24 traceflags:1
     {name: 'service', rw: bufrw.str1},     // service~1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
-    {call: argsrw}                         // (arg~2)*
+    {call: argsrw},                        // (arg~2)*
+    {call: flagsRetWrite}                  // -- rw flags last
 ]);
-
-CallRequest.prototype.splitArgs = function splitArgs(args, maxSize) {
-    var self = this;
-    // assert not self.args
-    var lenRes = self.constructor.RW.byteLength(self);
-    if (lenRes.err) throw lenRes.err;
-    var maxBodySize = maxSize - lenRes.length;
-    var remain = maxBodySize;
-    var first = [];
-    var argSize = 2;
-
-    var split = false;
-    for (var i = 0; i < args.length; i++) {
-        var arg = args[i] || Buffer(0);
-        var argLength = argSize + arg.length;
-        if (argLength < remain) {
-            first.push(arg);
-            remain -= argLength;
-        } else {
-            first.push(arg.slice(0, remain - argSize));
-            args = [arg.slice(remain - argSize)].concat(args.slice(i+1));
-            split = true;
-            break;
-        }
-    }
-
-    self.args = first;
-    var ret = [self];
-
-    if (split) {
-        var isLast = !(self.flags & Flags.Fragment);
-        self.flags |= Flags.Fragment;
-        var cont = new self.constructor.Cont(self.flags, self.csum.type);
-        ret = cont.splitArgs(args, maxSize);
-        ret.unshift(self);
-        if (isLast) ret[ret.length - 1].flags &= ~ Flags.Fragment;
-    }
-
-    return ret;
-};
 
 CallRequest.prototype.verifyChecksum = function verifyChecksum() {
     var self = this;
@@ -124,20 +111,21 @@ function CallResponse(flags, code, tracing, headers, csum, args) {
     self.headers = headers || {};
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
+    self.cont = null;
+    self._flagsOffset = 0;
 }
 
 CallResponse.Cont = require('./cont').ResponseCont;
 CallResponse.TypeCode = 0x04;
 CallResponse.Codes = ResponseCodes;
 CallResponse.RW = bufrw.Struct(CallResponse, [
-    {name: 'flags', rw: bufrw.UInt8},      // flags:1
+    {name: 'flags', call: flagsReadLen},   // flags:1 -- skipped at first
     {name: 'code', rw: bufrw.UInt8},       // code:1
     {name: 'tracing', rw: Tracing.RW},     // tracing:24 traceflags:1
     {name: 'headers', rw: header.header1}, // nh:1 (hk~1 hv~1){nh}
-    {call: argsrw}                         // (arg~2)*
+    {call: argsrw},                        // (arg~2)*
+    {call: flagsRetWrite}                  // -- rw flags last
 ]);
-
-CallResponse.prototype.splitArgs = CallRequest.prototype.splitArgs;
 
 CallResponse.prototype.verifyChecksum = function verifyChecksum() {
     var self = this;

--- a/node/v2/call_flags.js
+++ b/node/v2/call_flags.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = {
+    Fragment: 0x01
+};

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -86,11 +86,6 @@ CallRequestCont.prototype.splitArgs = function splitArgs(args, maxSize) {
     return ret;
 };
 
-CallRequestCont.prototype.updateChecksum = function updateChecksum(prior) {
-    var self = this;
-    return self.csum.update(self.args, prior);
-};
-
 CallRequestCont.prototype.verifyChecksum = function verifyChecksum(prior) {
     var self = this;
     return self.csum.verify(self.args, prior);
@@ -112,11 +107,6 @@ CallResponseCont.RW = bufrw.Struct(CallResponseCont, [
 ]);
 
 CallResponseCont.prototype.splitArgs = CallRequestCont.prototype.splitArgs;
-
-CallResponseCont.prototype.updateChecksum = function updateChecksum(prior) {
-    var self = this;
-    return self.csum.update(self.args, prior);
-};
 
 CallResponseCont.prototype.verifyChecksum = function verifyChecksum(prior) {
     var self = this;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -43,7 +43,7 @@ CallRequestCont.TypeCode = 0x13;
 CallRequestCont.RW = bufrw.Struct(CallRequestCont, [
     {name: 'flags', rw: bufrw.UInt8}, // flags:1
     {name: 'csum', rw: Checksum.RW},  // csumtype:1 (csum:4){0,1}
-    {name: 'args', rw: argsrw}        // (arg~2)+
+    {call: argsrw}                    // (arg~2)+
 ]);
 
 CallRequestCont.prototype.splitArgs = function splitArgs(args, maxSize) {
@@ -110,7 +110,7 @@ CallResponseCont.TypeCode = 0x14;
 CallResponseCont.RW = bufrw.Struct(CallResponseCont, [
     {name: 'flags', rw: bufrw.UInt8}, // flags:1
     {name: 'csum', rw: Checksum.RW},  // csumtype:1 (csum:4){0},1}
-    {name: 'args', rw: argsrw}        // (arg~2)+
+    {call: argsrw}                    // (arg~2)+
 ]);
 
 CallResponseCont.prototype.splitArgs = CallRequestCont.prototype.splitArgs;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -25,11 +25,6 @@ var Checksum = require('./checksum');
 var ArgsRW = require('./args');
 var argsrw = ArgsRW(bufrw.buf2);
 
-var Flags;
-process.nextTick(function() {
-    Flags = require('./index').CallFlags;
-});
-
 // flags:1 csumtype:1 (csum:4){0,1} (arg~2)+
 function CallRequestCont(flags, csum, args) {
     var self = this;
@@ -37,54 +32,46 @@ function CallRequestCont(flags, csum, args) {
     self.flags = flags || 0;
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
+    self.cont = null;
+    self._flagsOffset = 0;
+}
+
+var flagsReadLen = {
+    byteLength: flagsLength,
+    writeInto: saveFlagsOffset,
+    readFrom: readFlagsFrom
+};
+
+var flagsRetWrite = {
+    writeInto: writeFlagsInto,
+};
+
+function saveFlagsOffset(body, buffer, offset) {
+    body._flagsOffset = offset;
+    return bufrw.WriteResult.just(offset + bufrw.UInt8.width);
+}
+
+function flagsLength() {
+    return bufrw.LengthResult.just(bufrw.UInt8.width);
+}
+
+function writeFlagsInto(body, buffer, offset) {
+    var res = bufrw.UInt8.writeInto(body.flags, buffer, body._flagsOffset);
+    if (!res.err) res.offset = offset;
+    return res;
+}
+
+function readFlagsFrom(body, buffer, offset) {
+    return bufrw.UInt8.readFrom(buffer, offset);
 }
 
 CallRequestCont.TypeCode = 0x13;
+CallRequestCont.Cont = CallRequestCont;
 CallRequestCont.RW = bufrw.Struct(CallRequestCont, [
-    {name: 'flags', rw: bufrw.UInt8}, // flags:1
-    {call: argsrw}                    // (arg~2)+
+    {name: 'flags', call: flagsReadLen}, // flags:1 -- skipped at first
+    {call: argsrw},                      // (arg~2)+
+    {call: flagsRetWrite}                // -- rw flags last
 ]);
-
-CallRequestCont.prototype.splitArgs = function splitArgs(args, maxSize) {
-    var self = this;
-    self.args = [];
-    var lenRes = self.constructor.RW.byteLength(self);
-    if (lenRes.err) throw lenRes.err;
-    var maxBodySize = maxSize - lenRes.length;
-    var remain = maxBodySize;
-    var ret = [];
-    var isLast = !(self.flags & Flags.Fragment);
-    self.flags |= Flags.Fragment;
-    var argSize = 2;
-
-    while (args.length) {
-        var first = [];
-        var split = false;
-        for (var i = 0; i < args.length; i++) {
-            var arg = args[i];
-            var argLength = argSize + arg.length;
-            if (argLength <= remain) {
-                first.push(arg);
-                remain -= argLength;
-            } else {
-                first.push(arg.slice(0, remain - argSize));
-                args = [arg.slice(remain - argSize)].concat(args.slice(i+1));
-                split = true;
-                break;
-            }
-        }
-        self.args = first;
-        ret.push(self);
-        if (split) {
-            self = new self.constructor(self.flags | Flags.Fragment, self.csum.type);
-        } else {
-            break;
-        }
-    }
-    if (isLast) ret[ret.length - 1].flags &= ~ Flags.Fragment;
-
-    return ret;
-};
 
 CallRequestCont.prototype.verifyChecksum = function verifyChecksum(prior) {
     var self = this;
@@ -98,15 +85,17 @@ function CallResponseCont(flags, csum, args) {
     self.flags = flags || 0;
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
+    self.cont = null;
+    self._flagsOffset = 0;
 }
 
 CallResponseCont.TypeCode = 0x14;
+CallResponseCont.Cont = CallResponseCont;
 CallResponseCont.RW = bufrw.Struct(CallResponseCont, [
-    {name: 'flags', rw: bufrw.UInt8}, // flags:1
-    {call: argsrw}                    // (arg~2)+
+    {name: 'flags', call: flagsReadLen}, // flags:1 -- skipped at first
+    {call: argsrw},                      // (arg~2)+
+    {call: flagsRetWrite}                // -- rw flags last
 ]);
-
-CallResponseCont.prototype.splitArgs = CallRequestCont.prototype.splitArgs;
 
 CallResponseCont.prototype.verifyChecksum = function verifyChecksum(prior) {
     var self = this;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -42,7 +42,6 @@ function CallRequestCont(flags, csum, args) {
 CallRequestCont.TypeCode = 0x13;
 CallRequestCont.RW = bufrw.Struct(CallRequestCont, [
     {name: 'flags', rw: bufrw.UInt8}, // flags:1
-    {name: 'csum', rw: Checksum.RW},  // csumtype:1 (csum:4){0,1}
     {call: argsrw}                    // (arg~2)+
 ]);
 
@@ -109,7 +108,6 @@ function CallResponseCont(flags, csum, args) {
 CallResponseCont.TypeCode = 0x14;
 CallResponseCont.RW = bufrw.Struct(CallResponseCont, [
     {name: 'flags', rw: bufrw.UInt8}, // flags:1
-    {name: 'csum', rw: Checksum.RW},  // csumtype:1 (csum:4){0},1}
     {call: argsrw}                    // (arg~2)+
 ]);
 

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -329,10 +329,10 @@ TChannelV2Handler.prototype._sendCallBodies = function _sendCallBodies(id, body,
     var bodies = body.splitArgs(args, v2.Frame.MaxBodySize);
     for (var i = 0; i < bodies.length; i++) {
         body = bodies[i];
-        body.updateChecksum(checksum && checksum.val || 0);
-        checksum = body.csum;
+        if (checksum) body.csum = checksum;
         var frame = new v2.Frame(id, body);
         self.pushFrame(frame);
+        checksum = body.csum;
     }
     return checksum;
 };

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -299,8 +299,8 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
     var self = this;
     var reqBody = new v2.CallRequest(
         flags, req.ttl, req.tracing, req.service, req.headers,
-        req.checksum.type);
-    req.checksum = self._sendCallBodies(req.id, reqBody, args, null);
+        req.checksum.type, args);
+    req.checksum = self._sendCallBodies(req.id, reqBody, null);
 };
 
 TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFrame(res, flags, args) {
@@ -308,32 +308,33 @@ TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFra
     var code = res.ok ? v2.CallResponse.Codes.OK : v2.CallResponse.Codes.Error;
     var resBody = new v2.CallResponse(
         flags, code, res.tracing, res.headers,
-        res.checksum.type);
-    res.checksum = self._sendCallBodies(res.id, resBody, args, null);
+        res.checksum.type, args);
+    res.checksum = self._sendCallBodies(res.id, resBody, null);
 };
 
 TChannelV2Handler.prototype.sendCallRequestContFrame = function sendCallRequestContFrame(req, flags, args) {
     var self = this;
     var reqBody = new v2.CallRequestCont(flags, req.checksum.type, args);
-    req.checksum = self._sendCallBodies(req.id, reqBody, args, req.checksum);
+    req.checksum = self._sendCallBodies(req.id, reqBody, req.checksum);
 };
 
 TChannelV2Handler.prototype.sendCallResponseContFrame = function sendCallResponseContFrame(res, flags, args) {
     var self = this;
     var resBody = new v2.CallResponseCont(flags, res.checksum.type, args);
-    res.checksum = self._sendCallBodies(res.id, resBody, args, res.checksum);
+    res.checksum = self._sendCallBodies(res.id, resBody, res.checksum);
 };
 
-TChannelV2Handler.prototype._sendCallBodies = function _sendCallBodies(id, body, args, checksum) {
+TChannelV2Handler.prototype._sendCallBodies = function _sendCallBodies(id, body, checksum) {
     var self = this;
-    var bodies = body.splitArgs(args, v2.Frame.MaxBodySize);
-    for (var i = 0; i < bodies.length; i++) {
-        body = bodies[i];
+    var frame;
+
+    // jshint boss:true
+    do {
         if (checksum) body.csum = checksum;
-        var frame = new v2.Frame(id, body);
+        frame = new v2.Frame(id, body);
         self.pushFrame(frame);
         checksum = body.csum;
-    }
+    } while (body = body.cont);
     return checksum;
 };
 

--- a/node/v2/index.js
+++ b/node/v2/index.js
@@ -27,9 +27,7 @@ module.exports.Types = Types;
 
 var Frame = require('./frame');
 
-module.exports.CallFlags = {
-    Fragment: 0x01
-};
+module.exports.CallFlags = require('./call_flags');
 
 var init = require('./init');
 Types.InitRequest = init.Request.TypeCode;


### PR DESCRIPTION
This one has something for everyone:
- [x] it's faster: ~30% on synthetic benchmark
- [x] it's simpler: 2 similar but slightly different splitArgs -> one writeFragmentInto
- [x] rather than synchronously compute all fragments, it's done one-at-a-time driver by _sendCallBodies; future work could defer the loop if useful
- [x] it's less coupled: we could now say "actually let's only send 32KiB or 16KiB" by capping the write buffer allocation; then argsrw would then naturally fragment at end of buffer