### PR TITLE
golang: internal refactorings ahead of connection close

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -56,12 +56,12 @@ type ChannelOptions struct {
 	Logger Logger
 }
 
-// A TChannel is a bi-directional connection to the peering and routing network.  Applications
-// can use a TChannel to make service calls to remote peers via BeginCall, or to listen for incoming calls
+// A Channel is a bi-directional connection to the peering and routing network.  Applications
+// can use a Channel to make service calls to remote peers via BeginCall, or to listen for incoming calls
 // from peers.  Once the channel is created, applications should call the ListenAndHandle method to
 // listen for incoming peer connections.  Because channels are bi-directional, applications should call
 // ListenAndHandle even if they do not offer any services
-type TChannel struct {
+type Channel struct {
 	log               Logger
 	hostPort          string
 	processName       string
@@ -72,7 +72,7 @@ type TChannel struct {
 
 // NewChannel creates a new Channel that will bind to the given host and port.  If no port is provided,
 // the channel will start on an OS assigned port
-func NewChannel(hostPort string, opts *ChannelOptions) (*TChannel, error) {
+func NewChannel(hostPort string, opts *ChannelOptions) (*Channel, error) {
 	if opts == nil {
 		opts = &ChannelOptions{}
 	}
@@ -87,7 +87,7 @@ func NewChannel(hostPort string, opts *ChannelOptions) (*TChannel, error) {
 		processName = fmt.Sprintf("%s[%d]", filepath.Base(os.Args[0]), os.Getpid())
 	}
 
-	ch := &TChannel{
+	ch := &Channel{
 		connectionOptions: opts.DefaultConnectionOptions,
 		processName:       processName,
 		log:               logger,
@@ -115,19 +115,19 @@ func NewChannel(hostPort string, opts *ChannelOptions) (*TChannel, error) {
 }
 
 // HostPort returns the host and port on which the Channel is listening
-func (ch *TChannel) HostPort() string {
+func (ch *Channel) HostPort() string {
 	return ch.hostPort
 }
 
 // Register regsters a handler for a service+operation pair
-func (ch *TChannel) Register(h Handler, serviceName, operationName string) {
+func (ch *Channel) Register(h Handler, serviceName, operationName string) {
 	ch.handlers.register(h, serviceName, operationName)
 }
 
 // BeginCall starts a new call to a remote peer, returning an OutboundCall that can
 // be used to write the arguments of the call
 // TODO(mmihic): Support CallOptions such as format, request specific checksums, retries, etc
-func (ch *TChannel) BeginCall(ctx context.Context, hostPort,
+func (ch *Channel) BeginCall(ctx context.Context, hostPort,
 	serviceName, operationName string) (*OutboundCall, error) {
 	// TODO(mmihic): Keep-alive, manage pools, use existing inbound if possible, all that jazz
 	nconn, err := net.Dial("tcp", hostPort)
@@ -157,7 +157,7 @@ func (ch *TChannel) BeginCall(ctx context.Context, hostPort,
 }
 
 // RoundTrip calls a peer and waits for the response
-func (ch *TChannel) RoundTrip(ctx context.Context, hostPort, serviceName, operationName string,
+func (ch *Channel) RoundTrip(ctx context.Context, hostPort, serviceName, operationName string,
 	reqArg2, reqArg3 Output, resArg2, resArg3 Input) (bool, error) {
 
 	call, err := ch.BeginCall(ctx, hostPort, serviceName, operationName)
@@ -186,7 +186,7 @@ func (ch *TChannel) RoundTrip(ctx context.Context, hostPort, serviceName, operat
 
 // ListenAndHandle runs a listener to accept and manage new incoming connections.
 // Blocks until the channel is closed.
-func (ch *TChannel) ListenAndHandle() error {
+func (ch *Channel) ListenAndHandle() error {
 	acceptBackoff := 0 * time.Millisecond
 
 	for {

--- a/golang/channel.go
+++ b/golang/channel.go
@@ -135,7 +135,7 @@ func (ch *Channel) BeginCall(ctx context.Context, hostPort,
 		return nil, err
 	}
 
-	conn, err := newOutboundConnection(ch, nconn, &ch.connectionOptions)
+	conn, err := newOutboundConnection(nconn, ch.handlers, ch.log, &ch.connectionOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (ch *Channel) ListenAndHandle() error {
 
 		acceptBackoff = 0
 
-		_, err = newInboundConnection(ch, netConn, &ch.connectionOptions)
+		_, err = newInboundConnection(netConn, ch.handlers, ch.log, &ch.connectionOptions)
 		if err != nil {
 			// Server is getting overloaded - begin rejecting new connections
 			ch.log.Errorf("could not create new TChannelConnection for incoming conn: %v", err)

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -84,7 +84,7 @@ type ConnectionOptions struct {
 
 // Connection represents a connection to a remote peer.
 type Connection struct {
-	ch             *TChannel
+	ch             *Channel
 	log            Logger
 	checksumType   ChecksumType
 	framePool      FramePool
@@ -128,21 +128,21 @@ const (
 )
 
 // Creates a new TChannelConnection around an outbound connection initiated to a peer
-func newOutboundConnection(ch *TChannel, conn net.Conn,
+func newOutboundConnection(ch *Channel, conn net.Conn,
 	opts *ConnectionOptions) (*Connection, error) {
 	c := newConnection(ch, conn, connectionWaitingToSendInitReq, opts)
 	return c, nil
 }
 
 // Creates a new TChannelConnection based on an incoming connection from a peer
-func newInboundConnection(ch *TChannel, conn net.Conn,
+func newInboundConnection(ch *Channel, conn net.Conn,
 	opts *ConnectionOptions) (*Connection, error) {
 	c := newConnection(ch, conn, connectionWaitingToRecvInitReq, opts)
 	return c, nil
 }
 
 // Creates a new connection in a given initial state
-func newConnection(ch *TChannel, conn net.Conn, initialState connectionState,
+func newConnection(ch *Channel, conn net.Conn, initialState connectionState,
 	opts *ConnectionOptions) *Connection {
 
 	if opts == nil {

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -59,7 +59,7 @@ func echo(ctx context.Context, call *InboundCall) {
 }
 
 func TestRoundTrip(t *testing.T) {
-	withTestChannel(t, func(ch *TChannel) {
+	withTestChannel(t, func(ch *Channel) {
 
 		ch.Register(HandlerFunc(echo), "Capture", "ping")
 
@@ -83,7 +83,7 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestBadRequest(t *testing.T) {
-	withTestChannel(t, func(ch *TChannel) {
+	withTestChannel(t, func(ch *Channel) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()
 
@@ -94,7 +94,7 @@ func TestBadRequest(t *testing.T) {
 }
 
 func TestServerBusy(t *testing.T) {
-	withTestChannel(t, func(ch *TChannel) {
+	withTestChannel(t, func(ch *Channel) {
 		ch.Register(HandlerFunc(serverBusy), "TestService", "busy")
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -107,7 +107,7 @@ func TestServerBusy(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	withTestChannel(t, func(ch *TChannel) {
+	withTestChannel(t, func(ch *Channel) {
 		ch.Register(HandlerFunc(timeout), "TestService", "timeout")
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
@@ -121,7 +121,7 @@ func TestTimeout(t *testing.T) {
 }
 
 func testFragmentation(t *testing.T) {
-	withTestChannel(t, func(ch *TChannel) {
+	withTestChannel(t, func(ch *Channel) {
 		ch.Register(HandlerFunc(echo), "TestService", "echo")
 
 		arg2 := make([]byte, MaxFramePayloadSize*2)
@@ -144,7 +144,7 @@ func testFragmentation(t *testing.T) {
 	})
 }
 
-func sendRecv(ctx context.Context, ch *TChannel, hostPort string, serviceName, operation string,
+func sendRecv(ctx context.Context, ch *Channel, hostPort string, serviceName, operation string,
 	arg2, arg3 []byte) ([]byte, []byte, error) {
 
 	var respArg2 BytesInput
@@ -158,7 +158,7 @@ func sendRecv(ctx context.Context, ch *TChannel, hostPort string, serviceName, o
 	return []byte(respArg2), []byte(respArg3), nil
 }
 
-func withTestChannel(t *testing.T, f func(ch *TChannel)) {
+func withTestChannel(t *testing.T, f func(ch *Channel)) {
 	opts := ChannelOptions{
 		Logger: SimpleLogger,
 	}

--- a/golang/frame.go
+++ b/golang/frame.go
@@ -189,3 +189,22 @@ func (f *Frame) WriteTo(w io.Writer) error {
 func (f *Frame) SizedPayload() []byte {
 	return f.Payload[:f.Header.PayloadSize()]
 }
+
+func (f *Frame) write(msg message) error {
+	var wbuf typed.WriteBuffer
+	wbuf.Wrap(f.Payload[:])
+	if err := msg.write(&wbuf); err != nil {
+		return err
+	}
+
+	f.Header.ID = msg.ID()
+	f.Header.messageType = msg.messageType()
+	f.Header.SetPayloadSize(uint16(wbuf.BytesWritten()))
+	return nil
+}
+
+func (f *Frame) read(msg message) error {
+	var rbuf typed.ReadBuffer
+	rbuf.Wrap(f.SizedPayload())
+	return msg.read(&rbuf)
+}

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -280,13 +280,12 @@ func (call *InboundCallResponse) SendSystemError(err error) error {
 	call.state = inboundCallResponseComplete
 
 	// Send the error frame
-	frame, err := marshalMessage(&errorMessage{
+	frame := call.conn.framePool.Get()
+	if err := frame.write(&errorMessage{
 		id:        call.id,
 		tracing:   call.span,
 		errorCode: GetSystemErrorCode(err),
-		message:   err.Error()}, call.conn.framePool)
-
-	if err != nil {
+		message:   err.Error()}); err != nil {
 		// Nothing we can do here
 		call.conn.log.Warnf("Could not create outbound frame to %s for %d: %v",
 			call.conn.remotePeerInfo, call.id, err)


### PR DESCRIPTION
Main one is breaking the coupling between Channel and Connection so that we can manually create test connections.