### PR TITLE
top level requests should error if no host.

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -372,6 +372,10 @@ TChannel.prototype.request = function channelRequest(options) {
         }
     }
 
+    if (!self.serviceName && !options.host) {
+        throw errors.TopLevelRequestError();
+    }
+
     // TODO: moar defaults
     if (self.destroyed) {
         throw new Error('cannot request() to destroyed tchannel'); // TODO typed error

--- a/node/errors.js
+++ b/node/errors.js
@@ -145,3 +145,9 @@ module.exports.TopLevelRegisterError = TypedError({
     message: 'Cannot register endpoints points on top-level channel.\n' +
         'Provide serviceName to constructor, or create a sub-channel.'
 });
+
+module.exports.TopLevelRequestError = TypedError({
+    type: 'tchyannel.top-level-request',
+    message: 'Cannot make request() on top level tchannel without host.\n' +
+        'Must set a direct host or use a sub channel.'
+});

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -195,14 +195,20 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
         ])
     });
 
+    
+    var channel = client.makeSubChannel({
+        serviceName: 'lol'
+    });
+
     cluster.channels.forEach(function each(chan, i) {
         var chanNum = i + 1;
         chan.handler = EndpointHandler();
         chan.handler.register('foo', function foo(req, res, arg2, arg3) {
             res.sendOk(arg2, arg3 + ' served by ' + chanNum);
         });
-        client.peers.add(chan.hostPort);
+        channel.peers.add(chan.hostPort);
     });
+
 
     parallel([
 
@@ -235,7 +241,7 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
     ].map(function eachTestCase(testCase) {
         return sendTest(extend({
             logger: cluster.logger,
-            channel: client
+            channel: channel
         }, testCase), assert);
     }), function onResults(err) {
         assert.ifError(err, 'no errors from sending');


### PR DESCRIPTION
Assuming that the top level tchannel only contains peers
for a single `service` is a bad assumption.

We add incoming peers to the top level tchannel so if
its a server we would randomly select incoming peers.

r: @rf @jcorbin @kriskowal