### PR TITLE
Use ref counting for trace agent

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -107,7 +107,7 @@ function TChannel(options) {
     self.destroyed = false;
 
     if (self.options.trace) {
-        self.tracer = require('./trace/agent');
+        self.tracer = require('./trace/agent').ref();
     }
 
     // lazily created by .getServer (usually from .listen)
@@ -383,7 +383,7 @@ TChannel.prototype.close = function close(callback) {
     }
 
     if (self.tracer) {
-        self.tracer.destroy();
+        self.tracer.unref();
     }
 
     self.destroyed = true;


### PR DESCRIPTION
- the trace is a singleton
- however its use in TChannel currently assumes that there will only ever be one TChannel...
- ...and that you never try to use another (traced) channel in the future after closing that first channel

So instead this diff shifts the singleton to:
- use reference counting
- add the async listener whenever ref count goes > 0
- remove the async listener whenever ref count goes to 0

r @Raynos @rf 