### PR TITLE
Correctly handle errors for incoming requests

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -181,7 +181,6 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
             return;
         }
         op.req.emit('error', err);
-        // TODO: should terminate corresponding inc res
     }
 
     function onTimedOut() {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -292,7 +292,9 @@ TChannelConnectionBase.prototype.handleCallRequest = function handleCallRequest(
 
     function buildResponse(options) {
         if (op.res && op.res.state !== OutgoingResponse.States.Initial) {
-            throw new Error('response already built and started'); // TODO: typed error
+            throw errors.ResponseAlreadyStarted({
+                state: op.res.state
+            });
         }
         op.res = self.buildOutgoingResponse(req, options);
         op.res.on('finish', opDone);

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -269,10 +269,17 @@ TChannelConnectionBase.prototype.handleCallRequest = function handleCallRequest(
     self.inPending++;
     var op = self.inOps[id] = new TChannelServerOp(self, self.timers.now(), req);
     var done = false;
+    req.on('error', onReqError);
     process.nextTick(runHandler);
 
     if (req.span) {
         req.span.endpoint.serviceName = self.channel.serviceName;
+    }
+
+    function onReqError(err) {
+        if (!op.res) buildResponse();
+        var errName = err.name || err.constructor.name;
+        op.res.sendError('UnexpectedError', errName + ': ' + err.message);
     }
 
     function runHandler() {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -289,6 +289,7 @@ TChannelConnectionBase.prototype.handleCallRequest = function handleCallRequest(
         }
         op.res = self.buildOutgoingResponse(req, options);
         op.res.on('finish', opDone);
+        op.res.on('errored', opDone);
         op.res.on('span', handleSpanFromRes);
         return op.res;
     }

--- a/node/errors.js
+++ b/node/errors.js
@@ -107,6 +107,12 @@ module.exports.NullKeyError = TypedError({
     endOffset: null
 });
 
+module.exports.ResponseAlreadyStarted = TypedError({
+    type: 'tchannel.response-already-started',
+    message: 'response already started (state {state})',
+    state: null
+});
+
 module.exports.SocketClosedError = TypedError({
     type: 'tchannel.socket-closed',
     message: 'socket closed, {reason}',

--- a/node/errors.js
+++ b/node/errors.js
@@ -113,6 +113,12 @@ module.exports.ResponseAlreadyStarted = TypedError({
     state: null
 });
 
+module.exports.ResponseAlreadyDone = TypedError({
+    type: 'tchannel.response-already-done',
+    message: 'cannot {attempted}, response already done',
+    attempted: null
+});
+
 module.exports.SocketClosedError = TypedError({
     type: 'tchannel.socket-closed',
     message: 'socket closed, {reason}',

--- a/node/outgoing_response.js
+++ b/node/outgoing_response.js
@@ -24,6 +24,7 @@
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 
+var errors = require('./errors');
 var OutArgStream = require('./argstream').OutArgStream;
 
 var emptyBuffer = Buffer(0);
@@ -121,7 +122,9 @@ TChannelOutgoingResponse.prototype.sendCallResponseFrame = function sendCallResp
             throw new Error('first response frame already sent'); // TODO: typed error
         case States.Done:
         case States.Error:
-            throw new Error('response already done'); // TODO: typed error
+            throw errors.ResponseAlreadyDone({
+                attempted: 'send call res frame'
+            });
     }
 };
 
@@ -141,14 +144,18 @@ TChannelOutgoingResponse.prototype.sendCallResponseContFrame = function sendCall
             break;
         case States.Done:
         case States.Error:
-            throw new Error('response already done'); // TODO: typed error
+            throw errors.ResponseAlreadyDone({
+                attempted: 'send call res cont frame'
+            });
     }
 };
 
 TChannelOutgoingResponse.prototype.sendError = function sendError(codeString, message) {
     var self = this;
     if (self.state === States.Done || self.state === States.Error) {
-        throw new Error('response already done'); // TODO: typed error
+        throw errors.ResponseAlreadyDone({
+            attempted: 'send error frame: ' + codeString + ': ' + message
+        });
     } else {
         if (self.span) {
             self.span.annotate('ss');

--- a/node/outgoing_response.js
+++ b/node/outgoing_response.js
@@ -162,6 +162,7 @@ TChannelOutgoingResponse.prototype.sendError = function sendError(codeString, me
             self.arg3.end();
         }
         self.sendFrame.error(codeString, message);
+        self.emit('errored', codeString, message);
     }
 };
 


### PR DESCRIPTION
- firstly, finish handling a server op when we send an error frame
- secondly, hookup req error events to send an error frame

r @kriskowal @Raynos 