### PR TITLE
Dedupe and better encapsulate timeout checknig

### DIFF
--- a/node/client_op.js
+++ b/node/client_op.js
@@ -20,11 +20,9 @@
 
 'use strict';
 
-function TChannelClientOp(req, start) {
+function TChannelClientOp(req) {
     var self = this;
     self.req = req;
-    self.start = start;
-    self.timedOut = false;
 }
 
 module.exports = TChannelClientOp;

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -101,76 +101,57 @@ TChannelConnectionBase.prototype.onTimeoutCheck = function onTimeoutCheck() {
     if (self.lastTimeoutTime) {
         self.emit('timedOut');
     } else {
-        self.checkOutOpsForTimeout(self.outOps);
-        self.checkInOpsForTimeout(self.inOps);
+        self.checkTimeout(self.outOps, 'out');
+        self.checkTimeout(self.inOps, 'in');
         self.startTimeoutTimer();
     }
 };
 
-TChannelConnectionBase.prototype.checkInOpsForTimeout = function checkInOpsForTimeout(ops) {
+TChannelConnectionBase.prototype.checkTimeout = function checkTimeout(ops, direction) {
     var self = this;
     var opKeys = Object.keys(ops);
-    var now = self.timers.now();
-
     for (var i = 0; i < opKeys.length; i++) {
         var id = opKeys[i];
         var op = ops[id];
-
         if (op === undefined) {
-            continue;
-        }
-
-        var duration = now - op.start;
-        if (duration > op.req.ttl) {
-            delete ops[id];
-            self.pending.in--;
-        }
-    }
-};
-
-TChannelConnectionBase.prototype.checkOutOpsForTimeout = function checkOutOpsForTimeout(ops) {
-    var self = this;
-    var opKeys = Object.keys(ops);
-    var now = self.timers.now();
-    for (var i = 0; i < opKeys.length ; i++) {
-        var id = opKeys[i];
-        var op = ops[id];
-        if (op.timedOut) {
-            delete ops[id];
-            self.pending.out--;
-            self.logger.warn('lingering timed-out outgoing operation');
-            continue;
-        }
-        if (op === undefined) {
-            // TODO: why not null and empty string too? I mean I guess false
-            // and 0 might be a thing, but really why not just !op?
             self.logger.warn('unexpected undefined operation', {
-                id: id,
-                op: op
+                direction: direction,
+                id: id
             });
-            continue;
-        }
-        var duration = now - op.start;
-        if (duration > op.req.ttl) {
+        } else if (op.timedOut) {
+            self.logger.warn('lingering timed-out operation', {
+                direction: direction,
+                id: id
+            });
             delete ops[id];
-            self.pending.out--;
-            self.onReqTimeout(op);
+            self.pending[direction]--;
+        } else if (self.checkOpTimeout(op)) {
+            if (direction === 'out') {
+                self.lastTimeoutTime = self.timers.now();
+            }
+            delete ops[id];
+            self.pending[direction]--;
         }
     }
 };
 
-TChannelConnectionBase.prototype.onReqTimeout = function onReqTimeout(op) {
+TChannelConnectionBase.prototype.checkOpTimeout = function checkOpTimeout(op) {
     var self = this;
-    op.timedOut = true;
-    op.req.emit('error', errors.TimeoutError({
-        id: op.req.id,
-        start: op.start,
-        elapsed: self.timers.now() - op.start,
-        timeout: op.req.ttl
-    }));
-
-    // TODO: why don't we pop the op?
-    self.lastTimeoutTime = self.timers.now();
+    if (!op.timedOut) {
+        var duration = self.timers.now() - op.start;
+        if (duration > op.req.ttl) {
+            op.timedOut = true;
+            process.nextTick(function() {
+                op.req.emit('error', errors.TimeoutError({
+                    id: op.req.id,
+                    start: op.start,
+                    elapsed: duration,
+                    timeout: op.req.ttl
+                }));
+            });
+        }
+    }
+    return op.timedOut;
 };
 
 // this connection is completely broken, and is going away

--- a/node/server_op.js
+++ b/node/server_op.js
@@ -1,5 +1,5 @@
-// Copyright (c) 2015 Uber Technologies, Inc.
 //
+// Copyright (c) 2015 Uber Technologies, Inc.
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -20,14 +20,12 @@
 
 'use strict';
 
-function TChannelServerOp(connection, start, req, res) {
+function TChannelServerOp(connection, req, res) {
     var self = this;
     self.req = req;
     self.res = res || null;
     self.connection = connection;
     self.logger = connection.logger;
-    self.timedOut = false;
-    self.start = start;
 }
 
 module.exports = TChannelServerOp;


### PR DESCRIPTION
- dedupe the similar but needlessly different paths
- shift timeout checking and state tracking concerns into the req objcets

r @kriskowal @Raynos 