### PR TITLE
Trace default; better handling of service name

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -364,6 +364,13 @@ TChannel.prototype.request = function channelRequest(options) {
     options = extend(options);
     var self = this;
 
+    if (self.tracer) {
+        // When tracer is enabled, default outgoing requests to enable tracing
+        if (options.trace !== false) {
+            options.trace = true;
+        }
+    }
+
     if (!options.service) {
         if (options.serviceName) {
             options.service = options.serviceName;

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -238,10 +238,6 @@ TChannelConnectionBase.prototype.handleCallRequest = function handleCallRequest(
     req.on('error', onReqError);
     process.nextTick(runHandler);
 
-    if (req.span) {
-        req.span.endpoint.serviceName = self.channel.serviceName;
-    }
-
     function onReqError(err) {
         if (!req.res) buildResponse();
         if (err.type === 'tchannel.timeout') {

--- a/node/incoming_request.js
+++ b/node/incoming_request.js
@@ -80,9 +80,9 @@ function TChannelIncomingRequest(id, options) {
 
             // If a service hasn't been specified on the tracer, use the 
             // service on the incoming request. This is to handle the
-            // pathological case of the service router, which has a different
-            // service name than the one specified in the incoming request.
-            service: options.tracer.service || self.service,
+            // case of the service router, which has a different service name 
+            // than the one specified in the incoming request.
+            serviceName: options.tracer.serviceName || self.serviceName,
             name: '' // fill this in later
         });
 

--- a/node/incoming_request.js
+++ b/node/incoming_request.js
@@ -77,7 +77,12 @@ function TChannelIncomingRequest(id, options) {
             parentid: self.tracing.parentid,
             flags: options.tracer.forceTrace? 1 : self.tracing.flags,
             hostPort: options.hostPort,
-            service: options.tracer.service,
+
+            // If a service hasn't been specified on the tracer, use the 
+            // service on the incoming request. This is to handle the
+            // pathological case of the service router, which has a different
+            // service name than the one specified in the incoming request.
+            service: options.tracer.service || self.service,
             name: '' // fill this in later
         });
 

--- a/node/incoming_request.js
+++ b/node/incoming_request.js
@@ -77,7 +77,7 @@ function TChannelIncomingRequest(id, options) {
             parentid: self.tracing.parentid,
             flags: options.tracer.forceTrace? 1 : self.tracing.flags,
             hostPort: options.hostPort,
-            serviceName: '', // the service in options.service is not what we want
+            service: options.tracer.service,
             name: '' // fill this in later
         });
 

--- a/node/outgoing_request.js
+++ b/node/outgoing_request.js
@@ -87,7 +87,7 @@ function TChannelOutgoingRequest(id, options) {
             parentid: null,
             flags: options.trace? 1 : 0,
             hostPort: options.host,
-            service: options.service,
+            serviceName: options.serviceName,
             name: '' // fill this in later
         });
 

--- a/node/outgoing_request.js
+++ b/node/outgoing_request.js
@@ -87,7 +87,7 @@ function TChannelOutgoingRequest(id, options) {
             parentid: null,
             flags: options.trace? 1 : 0,
             hostPort: options.host,
-            serviceName: options.service,
+            service: options.service,
             name: '' // fill this in later
         });
 

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -70,7 +70,7 @@ function Agent () {
 
     // 'our' service name that is used as the service name on spans for
     // incoming reuqests
-    self.service = null;
+    self.serviceName = null;
 }
 
 Agent.prototype.getInstance = function () {
@@ -114,7 +114,7 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var span = new Span({
         logger: self.logger,
-        endpoint: new Span.Endpoint(host, port, options.service),
+        endpoint: new Span.Endpoint(host, port, options.serviceName),
         name: options.name,
         id: options.spanid,
         parentid: options.parentid,

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -67,6 +67,10 @@ function Agent () {
     // requests will have their traceflags forced to 1. It's intended to be
     // set on the 'top level service'.
     self.forceTrace = false;
+
+    // 'our' service name that is used as the service name on spans for
+    // incoming reuqests
+    self.service = '';
 }
 
 Agent.prototype.getInstance = function () {
@@ -110,7 +114,7 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var span = new Span({
         logger: self.logger,
-        endpoint: new Span.Endpoint(host, port, options.serviceName),
+        endpoint: new Span.Endpoint(host, port, options.service),
         name: options.name,
         id: options.spanid,
         parentid: options.parentid,

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -70,7 +70,7 @@ function Agent () {
 
     // 'our' service name that is used as the service name on spans for
     // incoming reuqests
-    self.service = '';
+    self.service = null;
 }
 
 Agent.prototype.getInstance = function () {


### PR DESCRIPTION
Defaults trace to true for outgoing requests when the tracer is loaded.

Added a `service` property to the tracer to be used as the service name on incoming requests. This is for strange cases like the service router where the service name specified on the request itself isn't the one we want in the span.