### PR TITLE
remove legacy register() support

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -299,7 +299,6 @@ TChannel.prototype.listen = function listen(port, host, callback) {
     self.getServer().listen(port, host, callback);
 };
 
-// TODO: deprecated, callers should use .handler directly
 TChannel.prototype.register = function register(name, handler) {
     var self = this;
 
@@ -307,8 +306,7 @@ TChannel.prototype.register = function register(name, handler) {
 
     switch (handlerType) {
         case 'tchannel.endpoint-handler':
-            // If its still the legacy handler then we are good.
-            self.handler.register(name, onReqRes);
+            self.handler.register(name, handler);
             break;
 
         case 'tchannel.service-name-handler':
@@ -319,18 +317,6 @@ TChannel.prototype.register = function register(name, handler) {
                 handlerType: handlerType,
                 handler: self.handler
             });
-    }
-
-    function onReqRes(req, res, arg2, arg3) {
-        handler(arg2, arg3, req.remoteAddr, onResponse);
-
-        function onResponse(err, res1, res2) {
-            if (err) {
-                res.sendNotOk(res1, err.message);
-            } else {
-                res.sendOk(res1, res2);
-            }
-        }
     }
 };
 
@@ -352,19 +338,7 @@ TChannel.prototype.send = function send(options, arg1, arg2, arg3, callback) {
 
     return self
         .request(options)
-        .send(arg1, arg2, arg3, onResponse);
-
-    function onResponse(err, res, arg2, arg3) {
-        if (err) {
-            return callback(err);
-        }
-
-        if (!res.ok) {
-            return callback(new Error(String(arg3)));
-        }
-
-        return callback(null, arg2, arg3);
-    }
+        .send(arg1, arg2, arg3, callback);
 };
 /* jshint maxparams:4 */
 

--- a/node/examples/legacy_example.js
+++ b/node/examples/legacy_example.js
@@ -26,36 +26,39 @@ var CountedReadySignal = require('ready-signal/counted');
 var TChannel = require('../channel.js');
 
 var ready = CountedReadySignal(2);
-var server = new TChannel();
+var server = new TChannel({
+    serviceName: 'server'
+});
 server.listen(4040, '127.0.0.1', ready.signal);
 var client = new TChannel();
 client.listen(4041, '127.0.0.1', ready.signal);
 
 // normal response
-server.register('func 1', function func1(arg1, arg2, peerInfo, cb) {
+server.register('func 1', function func1(req, res, arg2, arg3) {
     console.log('func 1 responding immediately 1:' +
-        arg1.toString() + ' 2:' + arg2.toString());
-    cb(null, 'result', 'indeed it did');
+        arg2.toString() + ' 2:' + arg3.toString());
+    res.sendOk('result', 'indeed it did');
 });
 
 // err response
-server.register('func 2', function func2(arg1, arg2, peerInfo, cb) {
-    cb(new Error('it failed'));
+server.register('func 2', function func2(req, res, arg2, arg3) {
+    res.sendNotOk(null, 'it failed');
 });
 
 ready(function onReady() {
     client.send({
         host: '127.0.0.1:4040'
-    }, 'func 1', 'arg 1', 'arg 2', function onResp1(err, res1, res2) {
+    }, 'func 1', 'arg 1', 'arg 2', function onResp1(err, res, res1, res2) {
         if (err) {
             console.log('unexpected err: ' + err.message);
+        } else {
+            console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
         }
-        console.log('normal res: ' + res1.toString() + ' ' + res2.toString());
     });
 
     client.send({
         host: '127.0.0.1:4040'
-    }, 'func 2', 'arg 1', 'arg 2', function onResp2(err, res1, res2) {
-        console.log('err res: ' + err.message);
+    }, 'func 2', 'arg 1', 'arg 2', function onResp2(err, res, res1, res2) {
+        console.log('ok: ' + res.ok + ' err res: ' + res2.toString());
     });
 });


### PR DESCRIPTION
We want to re-purpose the top level `register()` to work
in the clean new v2 world.

This breaks the old legacy interface that was used in
various integration tests in ringpop + autobahn as well
as in ringpop itself.

This is going to be a painful breaking change + refactor.

We will want to do this; but the question is when.

As a secondary question; do we want to repurpose `.send()`
or just completely remove it ? 

I think it should be removed as it goes against the 
`as/json` and `as/thrift` implementations.

r: @kriskowal @jcorbin