### PR TITLE
ConnectionBase: allow full opt-out of timeout fuzz

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -71,7 +71,10 @@ TChannelConnectionBase.prototype.getTimeoutDelay = function getTimeoutDelay() {
     var self = this;
     var base = self.options.timeoutCheckInterval;
     var fuzz = self.options.timeoutFuzz;
-    return base + Math.round(Math.floor(self.random() * fuzz) - (fuzz / 2));
+    if (fuzz) {
+        fuzz = Math.round(Math.floor(self.random() * fuzz) - (fuzz / 2));
+    }
+    return base + fuzz;
 };
 
 TChannelConnectionBase.prototype.startTimeoutTimer = function startTimeoutTimer() {

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -179,15 +179,12 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
 
 allocCluster.test('request().send() to a pool of servers', 4, function t(cluster, assert) {
     var client = TChannel({
+        timeoutFuzz: 0,
         random: randSeq([
             1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
-            0.0,                // timeout fuzz
             0.1, 1.0, 0.1, 0.1, // .request, chan 2 wins
-            0.0,                // timeout fuzz
             0.1, 0.1, 1.0, 0.1, // .request, chan 3 wins
-            0.0,                // timeout fuzz
             0.1, 0.1, 0.1, 1.0, // .request, chan 4 wins
-            0.0,                // timeout fuzz
             1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
             0.1, 1.0, 0.1, 0.1, // .request, chan 2 wins
             0.1, 0.1, 1.0, 0.1, // .request, chan 3 wins
@@ -195,7 +192,6 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
         ])
     });
 
-    
     var channel = client.makeSubChannel({
         serviceName: 'lol'
     });


### PR DESCRIPTION
Makes fixed-random tests much easier to write, and less brittle.

r @kriskowal @Raynos 