### PR TITLE
Clarify and add a new CRC checksum code

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -686,14 +686,19 @@ This behavior changes slightly when messages are fragmented. See the
 `type:1` | scheme                 | value length
 ---------|------------------------|-------------
 `0x00`   | none                   | 0 bytes
-`0x01`   | crc32                  | 4 bytes
+`0x01`   | crc-32 (adler-32)      | 4 bytes
 `0x02`   | farmhash Fingerprint32 | 4 bytes
+`0x03`   | crc-32C                | 4 bytes
 
-CRC32 is intended as a checksum, and many implementations exist, including
-SSE4.2 instructions on supported platforms.
+CRC32 is intended as a checksum as defined by Adler for zlib (technically this
+isn't a CRC according to wikipedia, although it seems to be frequently confused
+with one).
 
 Farmhash is a hash function with excellent distribution. It is surprisingly
 faster than CRC32 on modern CPUs, depending on how it is compiled.
+
+CRC32-C is the Castagnoli variant which is implemented directly by Intel CPUS
+(SSE4.2) and used by other systems (e.g. btrfs, ext4, SCTP).
 
 ## Fragmentation
 

--- a/node/package.json
+++ b/node/package.json
@@ -30,6 +30,7 @@
     "readable-stream": "1.0.33",
     "ready-signal": "^1.1.1",
     "run-parallel": "^1.1.0",
+    "sse4_crc32": "^3.1.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns out the zlib thing we've been calling "crc32" isn't the "go fast sse" one at all; nor is it even a CRC according to wikipedia.  So:
- update doc to clarify CRC (adler vs castagnoli)
- support CRC-32C in node
- default to it

Synthetic benchmark shows that it's a win (on my macbook with confirmed hardware compiled version), we see anywhere from a 15% to 30% speedup when actual content size is involved:
```
GET large str, 1/0     rate: hi-diff:    927.23 ( 17.5%)
GET large str, 200/0   rate: hi-diff:   2311.80 ( 16.2%)
GET large str, 20000/0 rate: hi-diff:   3752.12 ( 39.4%)
GET large str, 50/0    rate: hi-diff:   2408.32 ( 17.0%)
GET small str, 1/0     rate: hi-diff:   -754.31 (-10.2%)
GET small str, 200/0   rate: hi-diff:   -353.11 ( -1.7%)
GET small str, 20000/0 rate: hi-diff:   -777.65 ( -4.1%)
GET small str, 50/0    rate: hi-diff:  -2346.44 (-10.5%)
PING, 1/0              rate: hi-diff:   -474.47 ( -6.2%)
PING, 200/0            rate: hi-diff:    -44.41 ( -0.2%)
PING, 20000/0          rate: hi-diff:   -727.27 ( -3.7%)
PING, 50/0             rate: hi-diff:   -447.02 ( -2.1%)
SET large buf, 1/0     rate: hi-diff:    509.23 (  9.3%)
SET large buf, 200/0   rate: hi-diff:   2147.07 ( 14.9%)
SET large buf, 20000/0 rate: hi-diff:   1838.62 ( 18.7%)
SET large buf, 50/0    rate: hi-diff:   1988.31 ( 13.6%)
SET large str, 1/0     rate: hi-diff:    139.37 (  2.5%)
SET large str, 200/0   rate: hi-diff:   2155.03 ( 15.1%)
SET large str, 20000/0 rate: hi-diff:   2512.70 ( 28.4%)
SET large str, 50/0    rate: hi-diff:   2039.07 ( 14.2%)
SET small buf, 1/0     rate: hi-diff:   -463.78 ( -6.4%)
SET small buf, 200/0   rate: hi-diff:  -1325.38 ( -6.1%)
SET small buf, 20000/0 rate: hi-diff:    166.26 (  0.9%)
SET small buf, 50/0    rate: hi-diff:  -2046.41 ( -9.3%)
SET small str, 1/0     rate: hi-diff:    215.40 (  3.3%)
SET small str, 200/0   rate: hi-diff:  -1345.45 ( -6.4%)
SET small str, 20000/0 rate: hi-diff:    271.34 (  1.5%)
SET small str, 50/0    rate: hi-diff:  -1806.47 ( -8.3%)
```

cc @mranney @abhinav 