### PR TITLE
make as/json consistent with as/thrift

### DIFF
--- a/node/as/json.js
+++ b/node/as/json.js
@@ -112,7 +112,7 @@ TChannelJSON.prototype.send = function send(
 };
 
 TChannelJSON.prototype.register = function register(
-    tchannel, opts, arg1, handlerFunc
+    tchannel, arg1, opts, handlerFunc
 ) {
     var self = this;
 

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -41,7 +41,7 @@ allocCluster.test('getting an ok response', {
     };
 
     var tchannelJSON = TChannelJSON();
-    tchannelJSON.register(server, opts, 'echo', echo);
+    tchannelJSON.register(server, 'echo', opts, echo);
 
     tchannelJSON.send(client.request({
         service: 'server',
@@ -100,7 +100,7 @@ allocCluster.test('getting a not ok response', {
     };
 
     var tchannelJSON = TChannelJSON();
-    tchannelJSON.register(server, opts, 'echo', echo);
+    tchannelJSON.register(server, 'echo', opts, echo);
 
     tchannelJSON.send(client.request({
         service: 'server',
@@ -157,7 +157,7 @@ allocCluster.test('getting an UnexpectedError frame', {
     };
 
     var tchannelJSON = TChannelJSON();
-    tchannelJSON.register(server, opts, 'echo', echo);
+    tchannelJSON.register(server, 'echo', opts, echo);
 
     tchannelJSON.send(client.request({
         service: 'server',
@@ -199,7 +199,7 @@ allocCluster.test('getting a BadRequest frame', {
     };
 
     var tchannelJSON = TChannelJSON();
-    tchannelJSON.register(server, opts, 'echo', echo);
+    tchannelJSON.register(server, 'echo', opts, echo);
 
     client.request({
         service: 'server',


### PR DESCRIPTION
This makes the `register()` method of json and thrift
consistent.

The json one had the arguments in the wrong way.

r: @kriskowal @jcorbin