### PR TITLE
Define new "network error" error frame code, implement in node

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -464,6 +464,7 @@ code   | name                 | description
 `0x04` | declined             | Node declined request for reasons other than load, the request is safe to retry elsewhere if desired, do not change peer preferencing for future requests.
 `0x05` | unexpected error     | Request resulted in an unexpected error. The request may have been completed before the error, retry only if the request is idempotent or duplicate execution can be handled.
 `0x06` | bad request          | Request args do not match expectations, request will never be satisfied, do not retry
+`0x07` | network error        | A network error (e.g. socket error) occurred.
 `0xFF` | fatal protocol error | Connection will close after this frame. message ID of this frame should be `0xFFFFFFFF`.
 
 ### id:4

--- a/node/errors.js
+++ b/node/errors.js
@@ -274,9 +274,9 @@ module.exports.classify = function classify(err) {
         case 'tchannel.unhandled-frame-type':
             return 'ProtocolError';
 
-        // TODO: NetworkError would be nice to differentiate
-        // case 'tchannel.socket':
-        // case 'tchannel.socket-closed':
+        case 'tchannel.socket':
+        case 'tchannel.socket-closed':
+            return 'NetworkError';
 
         default:
             return null;

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -78,13 +78,6 @@ RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
 
         outres = buildRes();
         var codeName = errors.classify(err);
-        // TODO: would be great if tchannel could define these as network errors
-        if (!codeName && (
-            err.type === 'tchannel.socket' ||
-            err.type === 'tchannel.socket-closed')) {
-            codeName = 'UnexpectedError';
-        }
-
         if (codeName) {
             outres.sendError(codeName, err.message);
         } else {

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -50,6 +50,7 @@ Codes.Busy = 0x03;
 Codes.Declined = 0x04;
 Codes.UnexpectedError = 0x05;
 Codes.BadRequest = 0x06;
+Codes.NetworkError = 0x07;
 Codes.ProtocolError = 0xff;
 
 var CodeNames = Object.create(null);
@@ -59,6 +60,7 @@ CodeNames[Codes.Busy] = 'busy';
 CodeNames[Codes.Declined] = 'declined';
 CodeNames[Codes.UnexpectedError] = 'unexpected error';
 CodeNames[Codes.BadRequest] = 'bad request';
+CodeNames[Codes.NetworkError] = 'network error';
 CodeNames[Codes.ProtocolError] = 'protocol error';
 
 var CodeErrors = Object.create(null);
@@ -102,6 +104,13 @@ CodeErrors[Codes.BadRequest] = TypedError({
     isErrorFrame: true,
     codeName: 'BadRequest',
     errorCode: Codes.BadRequest,
+    originalId: null
+});
+CodeErrors[Codes.NetworkError] = TypedError({
+    type: 'tchannel.network',
+    isErrorFrame: true,
+    codeName: 'NetworkError',
+    errorCode: Codes.NetworkError,
     originalId: null
 });
 CodeErrors[Codes.ProtocolError] = TypedError({


### PR DESCRIPTION
Need felt when implementing the forwarding layer of *bahn, the core of which is the `RelayHandler` now in tchannel.

Basically the forwarder had no way of differentiating network errors to its caller.  This is chiefly a visibility concern at present, network errors aren't notable (sentry and/or logging), but an unexpected error is.