### PR TITLE
Make in/out req/res more cross-consistent

### DIFF
--- a/node/incoming_response.js
+++ b/node/incoming_response.js
@@ -66,6 +66,9 @@ function TChannelIncomingResponse(id, options) {
         self.arg2 = emptyBuffer;
         self.arg3 = emptyBuffer;
     }
+
+    self.start = self.timers.now();
+
     self.on('finish', self.onFinish);
 }
 

--- a/node/incoming_response.js
+++ b/node/incoming_response.js
@@ -42,6 +42,7 @@ function TChannelIncomingResponse(id, options) {
     self.timers = options.timers;
 
     self.state = States.Initial;
+    self.remoteAddr = null;
     self.id = id || 0;
     self.code = options.code || 0;
     self.checksum = options.checksum || null;

--- a/node/outgoing_response.js
+++ b/node/outgoing_response.js
@@ -46,6 +46,8 @@ function TChannelOutgoingResponse(id, options) {
     self.random = options.random;
     self.timers = options.timers;
 
+    self.start = 0;
+    self.end = 0;
     self.state = States.Initial;
     self.id = id || 0;
     self.code = options.code || 0;
@@ -86,6 +88,7 @@ inherits(TChannelOutgoingResponse, EventEmitter);
 
 TChannelOutgoingResponse.prototype.onFinish = function onFinish() {
     var self = this;
+    if (!self.end) self.end = self.timers.now();
     if (self.span) {
         self.emit('span', self.span);
     }
@@ -114,6 +117,7 @@ TChannelOutgoingResponse.prototype.sendCallResponseFrame = function sendCallResp
     var self = this;
     switch (self.state) {
         case States.Initial:
+            self.start = self.timers.now();
             self.sendFrame.callResponse(args, isLast);
             if (self.span) {
                 self.span.annotate('ss');

--- a/node/outgoing_response.js
+++ b/node/outgoing_response.js
@@ -79,14 +79,17 @@ function TChannelOutgoingResponse(id, options) {
         self.arg3 = null;
     }
 
-    self.on('finish', function onOutgoingResFinish() {
-        if (self.span) {
-            self.emit('span', self.span);
-        }
-    });
+    self.on('finish', self.onFinish);
 }
 
 inherits(TChannelOutgoingResponse, EventEmitter);
+
+TChannelOutgoingResponse.prototype.onFinish = function onFinish() {
+    var self = this;
+    if (self.span) {
+        self.emit('span', self.span);
+    }
+};
 
 TChannelOutgoingResponse.prototype.type = 'tchannel.outgoing-response';
 

--- a/node/outgoing_response.js
+++ b/node/outgoing_response.js
@@ -112,12 +112,10 @@ TChannelOutgoingResponse.prototype.sendCallResponseFrame = function sendCallResp
     switch (self.state) {
         case States.Initial:
             self.sendFrame.callResponse(args, isLast);
-            if (isLast) {
-                if (self.span) {
-                    self.span.annotate('ss');
-                }
-                self.state = States.Done;
+            if (self.span) {
+                self.span.annotate('ss');
             }
+            if (isLast) self.state = States.Done;
             else self.state = States.Streaming;
             break;
         case States.Streaming:
@@ -137,12 +135,7 @@ TChannelOutgoingResponse.prototype.sendCallResponseContFrame = function sendCall
             throw new Error('first response frame not sent'); // TODO: typed error
         case States.Streaming:
             self.sendFrame.callResponseCont(args, isLast);
-            if (isLast) {
-                if (self.span) {
-                    self.span.annotate('ss');
-                }
-                self.state = States.Done;
-            }
+            if (isLast) self.state = States.Done;
             break;
         case States.Done:
         case States.Error:

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -172,6 +172,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
         return callback(new Error('call response before init response')); // TODO typed error
     }
     var res = self.buildIncomingResponse(resFrame);
+    res.remoteAddr = self.remoteHostPort;
     self._handleCallFrame(res, resFrame, function(err) {
         if (err) return callback(err);
         if (res.state === IncomingResponse.States.Streaming) {


### PR DESCRIPTION
- span annotate at start of outgoing
- remoteAddr on both incoming
- start for everyone
- end for outgoing