### PR TITLE
Explicate RelayRequest

### DIFF
--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -80,6 +80,14 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
 RelayRequest.prototype.onResponse = function onResponse(res) {
     var self = this;
 
+    if (self.inres) {
+        self.channel.logger.warn('relay request got more than one response callback', {
+            // TODO: better context
+            remoteAddr: res.remoteAddr,
+            id: res.id
+        });
+        return;
+    }
     self.inres = res;
 
     if (!self.createOutResponse({

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -66,6 +66,11 @@ RelayRequest.prototype.createOutRequest = function createOutRequest() {
 RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     var self = this;
     if (self.outres) {
+        self.channel.logger.warn('relay request already responded', {
+            // TODO: better context
+            remoteAddr: self.inreq.remoteAddr,
+            id: self.inreq.id
+        });
         return;
     }
     self.outres = self.buildRes(options);

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -22,11 +22,9 @@
 
 var errors = require('./errors');
 
-function RelayHandler(channel, serviceName, clients) {
+function RelayHandler(channel) {
     var self = this;
-    self.serviceName = serviceName;
     self.channel = channel;
-    self.clients = clients;
 }
 
 RelayHandler.prototype.type = 'tchannel.relay-handler';
@@ -74,15 +72,13 @@ RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
         if (outres) {
             return;
         }
-        var logger = self.clients.logger;
-
         outres = buildRes();
         var codeName = errors.classify(err);
         if (codeName) {
             outres.sendError(codeName, err.message);
         } else {
             outres.sendError('UnexpectedError', err.message);
-            logger.error('unexpected error while forwarding', {
+            self.channel.logger.error('unexpected error while forwarding', {
                 error: err
                 // TODO context
             });

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -34,6 +34,16 @@ function RelayRequest(channel, inreq, buildRes) {
 
 RelayRequest.prototype.createOutRequest = function createOutRequest() {
     var self = this;
+
+    if (self.outreq) {
+        self.channel.logger.warn('relay request already started', {
+            // TODO: better context
+            remoteAddr: self.inreq.remoteAddr,
+            id: self.inreq.id
+        });
+        return;
+    }
+
     self.outreq = self.channel.request({
         streamed: self.inreq.streamed,
         ttl: self.inreq.ttl,

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -34,7 +34,7 @@ allocCluster.test('request retries', {
         serviceName: 'two',
         peers: [two.hostPort]
     });
-    oneToTwo.handler = new RelayHandler(oneToTwo, 'two', {logger: one.logger});
+    oneToTwo.handler = new RelayHandler(oneToTwo);
 
     var twoSvc = two.makeSubChannel({
         serviceName: 'two'


### PR DESCRIPTION
- reifies the prior closure `RelayHandler#handleRequest` closure
- made more obvious to handle pathological cases
- allows to add more visibility work for forwarding going forward