### PR TITLE
v2/{call,cont}: drop old _flagsOffset

### DIFF
--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -52,7 +52,6 @@ function CallRequest(flags, ttl, tracing, service, headers, csum, args) {
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
     self.cont = null;
-    self._flagsOffset = 0;
 }
 
 CallRequest.Cont = require('./cont').RequestCont;
@@ -187,7 +186,6 @@ function CallResponse(flags, code, tracing, headers, csum, args) {
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
     self.cont = null;
-    self._flagsOffset = 0;
 }
 
 CallResponse.Cont = require('./cont').ResponseCont;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -33,7 +33,6 @@ function CallRequestCont(flags, csum, args) {
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
     self.cont = null;
-    self._flagsOffset = 0;
 }
 
 CallRequestCont.TypeCode = 0x13;
@@ -103,7 +102,6 @@ function CallResponseCont(flags, csum, args) {
     self.csum = Checksum.objOrType(csum);
     self.args = args || [];
     self.cont = null;
-    self._flagsOffset = 0;
 }
 
 CallResponseCont.TypeCode = 0x14;


### PR DESCRIPTION
Leftover from using StructRW