### PR TITLE
Fix test hang

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -356,7 +356,9 @@ TChannel.prototype.request = function channelRequest(options) {
     }
 
     var req = null;
-    if (opts.streamed) {
+    if (opts.host || // retries are only between hosts
+        opts.streamed // streaming retries not yet implemented
+    ) {
         req = self.peers.request(null, opts);
     } else {
         req = new TChannelRequest(self, opts);

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var assert = require('assert');
 var inherits = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 
@@ -29,6 +30,8 @@ var OutgoingResponse = require('./outgoing_response');
 var DEFAULT_OUTGOING_REQ_TIMEOUT = 2000;
 
 function TChannelConnectionBase(channel, direction, remoteAddr) {
+    assert(!channel.destroyed, 'refuse to create connection for destroyed channel');
+
     var self = this;
     EventEmitter.call(self);
     self.channel = channel;


### PR DESCRIPTION
This was an interesting one, at least affecting `test/send.js`:
- .request contained host option
- so TChannelRequest#choosePeer was always choosing the same (self) peer
- so even past channel / peers / peer / connection / socket closes, it kept trying to next-tick retry