### PR TITLE
Adding Caller Name as Transport Header to Protocol

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -558,6 +558,7 @@ name  | req | res | description
 `as`  | Y   | Y   | the Arg Scheme
 `cas` | Y   | N   | Claim At Start
 `caf` | Y   | N   | Claim At Finish
+`cn`  | Y   | N   | Caller Name
 `re`  | Y   | N   | Retry Flags
 `se`  | Y   | N   | Speculative Execution
 `fd`  | Y   | Y   | Failure Domain
@@ -589,6 +590,10 @@ Send a claim message when work is started.
 Value is string "host:port".
 
 Send claim message to `host:port` when response is being sent.
+
+### Transport Header `cn` -- Caller Name
+
+Value is name of the service making the call.
 
 ### Transport Header `re` -- Retry Flags
 


### PR DESCRIPTION
This will be useful for:

* Stats - Answering questions like "How much traffic was being sent to Service A from Service B?".
* Circuit Breaking - We'll need this in order to create `SOURCE->SERVICE::ENDPOINT` Circuits.
* Tracing - We should be able to use this with Zipkin.