### PR TITLE
Make `serviceName` not go into requestDefaults

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -83,7 +83,6 @@ function TChannel(options) {
     self.serviceName = '';
     if (self.options.serviceName) {
         self.serviceName = self.options.serviceName;
-        self.requestDefaults.serviceName = self.serviceName;
         delete self.options.serviceName;
     }
 

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -24,7 +24,7 @@ var allocCluster = require('./lib/alloc-cluster');
 var TChannel = require('../channel');
 var RelayHandler = require('../relay_handler');
 
-allocCluster.test('request retries', {
+allocCluster.test('send relay requests', {
     numPeers: 2
 }, function t(cluster, assert) {
     var one = cluster.channels[0];
@@ -49,7 +49,9 @@ allocCluster.test('request retries', {
         peers: [one.hostPort]
     });
 
-    twoClient.request().send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request({
+        service: 'two'
+    }).send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.ifError(err, 'no unexpected error');
         assert.equal(String(arg2), 'foo', 'expected arg2');
         assert.equal(String(arg3), 'bar', 'expected arg3');
@@ -94,7 +96,9 @@ allocCluster.test('relay an error frame', {
         peers: [one.hostPort, four.hostPort]
     });
 
-    twoClient.request().send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request({
+        service: 'two'
+    }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');
 
         assert.end();

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -46,12 +46,13 @@ allocCluster.test('send relay requests', {
     });
     var twoClient = client.makeSubChannel({
         serviceName: 'two',
-        peers: [one.hostPort]
+        peers: [one.hostPort],
+        requestDefaults: {
+            serviceName: 'two'
+        }
     });
 
-    twoClient.request({
-        service: 'two'
-    }).send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request().send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.ifError(err, 'no unexpected error');
         assert.equal(String(arg2), 'foo', 'expected arg2');
         assert.equal(String(arg3), 'bar', 'expected arg3');
@@ -93,12 +94,13 @@ allocCluster.test('relay an error frame', {
     });
     var twoClient = client.makeSubChannel({
         serviceName: 'two',
-        peers: [one.hostPort, four.hostPort]
+        peers: [one.hostPort, four.hostPort],
+        requestDefaults: {
+            serviceName: 'two'
+        }
     });
 
-    twoClient.request({
-        service: 'two'
-    }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request().send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');
 
         assert.end();

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -69,7 +69,8 @@ allocCluster.test('request retries', {
     });
 
     var req = chan.request({
-        timeout: 100
+        timeout: 100,
+        service: 'tristan'
     });
     req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
         if (err) return finish(err);
@@ -172,6 +173,7 @@ allocCluster.test('request application retries', {
 
     var req = chan.request({
         timeout: 100,
+        service: 'tristan',
         shouldApplicationRetry: function shouldApplicationRetry(req, res, arg2, arg3) {
             return String(arg2) === 'meh';
         }
@@ -273,7 +275,8 @@ allocCluster.test('retryFlags work', {
 
         function defaultToNotRetryingTimeout(next) {
             var req = chan.request({
-                timeout: 100
+                timeout: 100,
+                service: 'tristan'
             });
             req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
                 assert.equal(req.outReqs.length, 1, 'expected 1 tries');
@@ -284,6 +287,7 @@ allocCluster.test('retryFlags work', {
 
         function canRetryTimeout(next) {
             var req = chan.request({
+                service: 'tristan',
                 retryFlags: {
                     never: false,
                     onConnectionError: true,
@@ -312,6 +316,7 @@ allocCluster.test('retryFlags work', {
         function canOptOutFully(next) {
             var req = chan.request({
                 timeout: 100,
+                service: 'tristan',
                 retryFlags: {
                     never: true,
                     onConnectionError: false,

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -65,12 +65,14 @@ allocCluster.test('request retries', {
     });
     var chan = client.makeSubChannel({
         serviceName: 'tristan',
-        peers: cluster.hosts
+        peers: cluster.hosts,
+        requestDefaults: {
+            serviceName: 'tristan'
+        }
     });
 
     var req = chan.request({
-        timeout: 100,
-        service: 'tristan'
+        timeout: 100
     });
     req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
         if (err) return finish(err);
@@ -168,12 +170,14 @@ allocCluster.test('request application retries', {
     });
     var chan = client.makeSubChannel({
         serviceName: 'tristan',
-        peers: cluster.hosts
+        peers: cluster.hosts,
+        requestDefaults: {
+            serviceName: 'tristan'
+        }
     });
 
     var req = chan.request({
         timeout: 100,
-        service: 'tristan',
         shouldApplicationRetry: function shouldApplicationRetry(req, res, arg2, arg3) {
             return String(arg2) === 'meh';
         }
@@ -268,15 +272,17 @@ allocCluster.test('retryFlags work', {
     });
     var chan = client.makeSubChannel({
         serviceName: 'tristan',
-        peers: cluster.hosts
+        peers: cluster.hosts,
+        requestDefaults: {
+            serviceName: 'tristan'
+        }
     });
 
     series([
 
         function defaultToNotRetryingTimeout(next) {
             var req = chan.request({
-                timeout: 100,
-                service: 'tristan'
+                timeout: 100
             });
             req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
                 assert.equal(req.outReqs.length, 1, 'expected 1 tries');
@@ -287,7 +293,6 @@ allocCluster.test('retryFlags work', {
 
         function canRetryTimeout(next) {
             var req = chan.request({
-                service: 'tristan',
                 retryFlags: {
                     never: false,
                     onConnectionError: true,
@@ -316,7 +321,6 @@ allocCluster.test('retryFlags work', {
         function canOptOutFully(next) {
             var req = chan.request({
                 timeout: 100,
-                service: 'tristan',
                 retryFlags: {
                     never: true,
                     onConnectionError: false,


### PR DESCRIPTION
This removes the "feature" from subChannels where we put
the serviceName of a sub channel into the requestDefaults

In this PR I also wrote a test for the peers feature.

r: @kriskowal @jcorbin