### PR TITLE
as/thrift: simplify and improve error handling

### DIFF
--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -65,17 +65,12 @@ function register(channel, name, opts, handle) {
                 return res.sendError('UnexpectedError', err.message);
             }
 
-            // TODO {head,body} or {arg2,arg3}?
-
-            var ok = thriftRes.ok;
-            var outBody = thriftRes.body;
-
-            if (typeof ok !== 'boolean') {
-                throw new Error('Expected true or false boolean on response object');
-            }
+            assert(typeof thriftRes.ok === 'boolean',
+                'expected response.ok to be a boolean');
 
             var outResult = {};
-            if (ok) {
+            var outBody = thriftRes.body;
+            if (thriftRes.ok) {
                 outResult.success = outBody;
             } else if (!outBody) {
                 throw new Error('Error body required in the not ok response case'); // TODO TypedError
@@ -97,7 +92,7 @@ function register(channel, name, opts, handle) {
             // var outHead = res.head;
             var outHeadBuffer = null;
 
-            if (ok) {
+            if (thriftRes.ok) {
                 return res.sendOk(outHeadBuffer, outBodyBuffer);
             } else {
                 return res.sendNotOk(outHeadBuffer, outBodyBuffer);

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -98,11 +98,14 @@ function send(request, endpoint, outHead, outBody, callback) {
     var argsType = self.spec.getType(endpoint + '_args');
     var resultType = self.spec.getType(endpoint + '_result');
 
-    // This will throw locally if the body is malformed.
-    var outBodyBuffer = argsType.toBuffer(outBody).toValue();
+    var outRes = argsType.toBuffer(outBody);
+    if (outRes.err) {
+        callback(outRes.err, null);
+        return;
+    }
 
-    // TODO outHeadBuffer from outHead
     var outHeadBuffer = null;
+    var outBodyBuffer = outRes.value;
 
     // Punch as=thrift into the transport headers
     request.headers.as = "thrift";

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -70,32 +70,19 @@ function register(channel, name, opts, handle) {
 
             var outResult = {};
             var outBody = thriftRes.body;
-            if (thriftRes.ok) {
-                outResult.success = outBody;
-            } else if (!outBody) {
-                throw new Error('Error body required in the not ok response case'); // TODO TypedError
-            } else if (typeof outBody.nameAsThrift !== 'string') {
-                throw new Error('Can\'t serialize error response that lacks nameAsThrift'); // TODO TypedError
-            } else if (!resultType.fieldsByName[outBody.nameAsThrift]) {
-                throw new Error('Can\'t serialize error response with unrecognized nameAsThrift: ' + outBody.nameAsThrift); // TODO TypedError
-            } else {
+            if (!thriftRes.ok) {
                 outResult[outBody.nameAsThrift] = outBody;
+            } else {
+                outResult.success = outBody;
             }
 
-            // outBody must be a Thrift result, e.g., {success: value}, or
-            // {oops: {}}.
+            var outRes = resultType.toBuffer(outResult);
 
-            // This will throw locally if the response body is malformed.
-            var outBodyBuffer = resultType.toBuffer(outResult).toValue();
-
-            // TODO process outHeadBuffer
-            // var outHead = res.head;
-            var outHeadBuffer = null;
-
+            var outBodyBuffer = outRes.toValue();
             if (thriftRes.ok) {
-                return res.sendOk(outHeadBuffer, outBodyBuffer);
+                return res.sendOk(null, outBodyBuffer);
             } else {
-                return res.sendNotOk(outHeadBuffer, outBodyBuffer);
+                return res.sendNotOk(null, outBodyBuffer);
             }
         }
     }

--- a/node/package.json
+++ b/node/package.json
@@ -30,7 +30,7 @@
     "ready-signal": "^1.1.1",
     "run-parallel": "^1.1.0",
     "sse4_crc32": "^3.1.0",
-    "thriftify": "1.0.0-alpha12",
+    "thriftify": "1.0.0-alpha13",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- use AResult from thriftify alpha13
- don't throw errors in the send case, pass to callback
- make remaining programmer error an assert
- add bossMode for handlers similar to as/json in #476

r @kriskowal @Raynos 
cc @leizha 