### PR TITLE
Max pending

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -42,6 +42,7 @@ var errors = require('./errors');
 
 var TChannelConnection = require('./connection');
 var TChannelPeers = require('./peers');
+var TChannelServices = require('./services');
 
 var TracingAgent = require('./trace/agent');
 
@@ -110,6 +111,15 @@ function TChannel(options) {
     // - manually api (.peers.add etc)
     // - incoming connections on any listening socket
     self.peers = TChannelPeers(self, self.options);
+
+    // For tracking the number of pending requests to any service
+    self.services = new TChannelServices();
+    if (self.options.maxPending !== undefined) {
+        self.services.maxPending = self.options.maxPending;
+    }
+    if (self.options.maxPendingForService !== undefined) {
+        self.services.maxPendingForService = self.options.maxPendingForService;
+    }
 
     // TChannel advances through the following states.
     self.listened = false;

--- a/node/errors.js
+++ b/node/errors.js
@@ -139,6 +139,19 @@ module.exports.InvalidJSONBody = TypedError({
     body: null
 });
 
+module.exports.MaxPendingError = TypedError({
+    type: 'tchannel.max-pending',
+    message: 'maximum pending requests exceeded (limit was {pending})',
+    pending: null
+});
+
+module.exports.MaxPendingForServiceError = TypedError({
+    type: 'tchannel.max-pending-for-service',
+    message: 'maximum pending requests exceeded for service (limit was {pending} for service {serviceName})',
+    pending: null,
+    serviceName: null
+});
+
 module.exports.MissingInitHeaderError = TypedError({
     type: 'tchannel.missing-init-header',
     message: 'missing init frame header {field}',
@@ -279,6 +292,8 @@ module.exports.classify = function classify(err) {
     switch (err.type) {
         case 'tchannel.no-peer-available':
         case 'tchannel.no-service-handler':
+        case 'tchannel.max-pending':
+        case 'tchannel.max-pending-for-service':
             return 'Declined';
 
         case 'tchannel.timeout':

--- a/node/request.js
+++ b/node/request.js
@@ -58,6 +58,7 @@ function TChannelRequest(channel, options) {
     self.end = 0;
     self.elapsed = 0;
     self.resendSanity = 0;
+    self.trackPending = self.options.trackPending || false;
 
     self.serviceName = options.serviceName || '';
     self.headers = self.options.headers || {}; // so that as-foo can punch req.headers.X
@@ -145,7 +146,7 @@ TChannelRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
 TChannelRequest.prototype.resend = function resend() {
     var self = this;
 
-    if (self.checkPending()) return;
+    if (self.trackPending && self.checkPending()) return;
 
     if (self.checkTimeout()) return;
 

--- a/node/services.js
+++ b/node/services.js
@@ -1,0 +1,126 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var errors = require('./errors');
+
+function TChannelServices() {
+    var self = this;
+    // Maps service name with '$' prefix to service tracking object.
+    // The prefix ensures that we cannot be lost or confused if some joker
+    // names their service 'toString' or '__proto__'.
+    // '_' as a prefix would still be confused by '_proto__', '__' would be
+    // confused by 'proto__'.
+    self.services = {};
+    self.maxPendingForService = Infinity;
+    self.maxPending = Infinity;
+    self.pending = 0;
+}
+
+TChannelServices.prototype.errorIfExceedsMaxPending = function errorIfExceedsMaxPending(req) {
+    var self = this;
+    if (self.pending >= self.maxPending) {
+        return errors.MaxPendingError({
+            pending: self.pending
+        });
+    }
+    if (!req.serviceName) {
+        return;
+    }
+    var serviceKey = '$' + req.serviceName;
+    var service = self.services[serviceKey];
+    return service && service.errorIfExceedsMaxPending();
+};
+
+TChannelServices.prototype.onRequest = function onRequest(req) {
+    var self = this;
+    self.pending++;
+    if (!req.serviceName) {
+        return;
+    }
+    var serviceKey = '$' + req.serviceName;
+    var service = self.services[serviceKey];
+    if (!service) {
+        service = new TChannelService();
+        service.serviceName = req.serviceName;
+        if (self.maxPendingForService !== undefined) {
+            service.maxPending = self.maxPendingForService;
+        }
+        self.services[serviceKey] = service;
+    }
+    service.onRequest();
+};
+
+TChannelServices.prototype.onRequestResponse = function onRequestResponse(req) {
+    var self = this;
+    self.pending--;
+    if (!req.serviceName) {
+        return;
+    }
+    var serviceKey = '$' + req.serviceName;
+    var service = self.services[serviceKey];
+    service.onRequestResponse();
+};
+
+TChannelServices.prototype.onRequestError = function onRequestError(req) {
+    var self = this;
+    self.pending--;
+    if (!req.serviceName) {
+        return;
+    }
+    var serviceKey = '$' + req.serviceName;
+    var service = self.services[serviceKey];
+    service.onRequestError();
+};
+
+function TChannelService() {
+    var self = this;
+    self.serviceName = null;
+    self.maxPending = Infinity;
+    self.pending = 0;
+}
+
+TChannelService.prototype.errorIfExceedsMaxPending = function errorIfExceedsMaxPending() {
+    var self = this;
+    if (self.pending >= self.maxPending) {
+        return errors.MaxPendingForServiceError({
+            serviceName: self.serviceName,
+            pending: self.pending
+        });
+    }
+};
+
+TChannelService.prototype.onRequest = function onRequest() {
+    var self = this;
+    self.pending += 1;
+};
+
+TChannelService.prototype.onRequestResponse = function onRequestResponse() {
+    var self = this;
+    self.pending -= 1;
+};
+
+TChannelService.prototype.onRequestError = function onRequestError() {
+    var self = this;
+    self.pending -= 1;
+};
+
+module.exports = TChannelServices;

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -31,6 +31,7 @@ require('./streaming.js');
 require('./streaming_bisect.js');
 require('./register.js');
 require('./identify.js');
+require('./max_pending.js');
 require('./tchannel.js');
 require('./regression-inOps-leak.js');
 require('./v2/index.js');

--- a/node/test/max_pending.js
+++ b/node/test/max_pending.js
@@ -1,0 +1,100 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var parallel = require('run-parallel');
+var Result = require('bufrw/result');
+var MockTimers = require('time-mock');
+var allocCluster = require('./lib/alloc-cluster');
+
+testWithOptions({
+    numPeers: 2,
+    channelOptions: {
+        maxPending: 1,
+        timers: MockTimers(Date.now())
+    }
+}, [
+    'tchannel.timeout',
+    'tchannel.max-pending'
+]);
+
+testWithOptions({
+    numPeers: 2,
+    channelOptions: {
+        maxPendingForService: 1,
+        timers: MockTimers(1.5e12), // approximately soon
+        random: lucky
+    }
+}, [
+    'tchannel.timeout',
+    'tchannel.max-pending-for-service'
+]);
+
+function testWithOptions(options, expectedErrorTypes) {
+    allocCluster.test('exercise maximum pending requests', options, function t(cluster, assert) {
+        var tweedleDee = cluster.channels[0];
+        var tweedleDum = cluster.channels[1];
+        var timers = tweedleDee.timers;
+
+        var deeChannel = tweedleDee.makeSubChannel({
+            serviceName: 'battle'
+        });
+        var dumChannel = tweedleDum.makeSubChannel({
+            serviceName: 'battle'
+        });
+
+        dumChannel.peers.add(tweedleDee.hostPort);
+
+        deeChannel.register('start', function start() {
+            // Let's just say we did
+        });
+
+        parallel([challengeSender(), challengeSender()], function verifyIt(err, results) {
+            if (err) return assert.end(err);
+            assert.equals(results[0].err.type, expectedErrorTypes[0], 'first should fail due to a timeout');
+            assert.equals(results[1].err.type, expectedErrorTypes[1], 'second should fail because max pending exceeded');
+            assert.end();
+        });
+
+        // TODO ascertain why this test stalls non-deterministically, and with
+        // increasing probability, for values from 2000ms down to 1000ms.
+        timers.advance(2000);
+
+        function challengeSender() {
+            return function sendChallenge(cb) {
+                dumChannel.request({
+                    serviceName: 'battle',
+                    timeout: 1000
+                }).send('start', '', '', regardless(cb));
+            };
+        }
+
+        function regardless(cb) {
+            return function resultRegardless(err, value) {
+                return cb(null, new Result(err, value));
+            };
+        }
+    });
+}
+
+function lucky() {
+    return 1.0;
+}

--- a/node/test/max_pending.js
+++ b/node/test/max_pending.js
@@ -29,7 +29,11 @@ testWithOptions({
     numPeers: 2,
     channelOptions: {
         maxPending: 1,
-        timers: MockTimers(Date.now())
+        timers: MockTimers(Date.now()),
+        random: lucky,
+        requestDefaults: {
+            trackPending: true
+        }
     }
 }, [
     'tchannel.timeout',
@@ -41,7 +45,10 @@ testWithOptions({
     channelOptions: {
         maxPendingForService: 1,
         timers: MockTimers(1.5e12), // approximately soon
-        random: lucky
+        random: lucky,
+        requestDefaults: {
+            trackPending: true
+        }
     }
 }, [
     'tchannel.timeout',


### PR DESCRIPTION
Adds maxPending and maxPendingForService options (maxPendingPerService a better name?) and a trackPending option for requests (or requestDefaults for a subchannel). Between these features, we will be able to track all pending requests per service at egress nodes of Hyperbahn.

r @jcorbin @Raynos 
cc @ShanniLi 