### PR TITLE
Add StreamingOut{Request,Response}#sendStreams

### DIFF
--- a/node/lib/pipeline_streams.js
+++ b/node/lib/pipeline_streams.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = pipelineStreams;
+
+function pipelineStreams(sources, dests) {
+    next(0);
+    function next(i) {
+        if (i >= dests.length) return;
+        var src = sources[i];
+        var dst = dests[i];
+        if (src === null || src === undefined ) {
+            dst.end();
+            next(i + 1);
+        } else if (typeof src === 'string' || Buffer.isBuffer(src)) {
+            dst.end(src);
+            next(i + 1);
+        } else {
+            src.pipe(dst);
+            dst.once('finish', onStreamFinished);
+        }
+        function onStreamFinished() {
+            next(i + 1);
+        }
+    }
+}

--- a/node/streaming_out_request.js
+++ b/node/streaming_out_request.js
@@ -69,4 +69,30 @@ StreamingOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     return self;
 };
 
+StreamingOutRequest.prototype.sendStreams = function send(arg1, arg2, arg3, callback) {
+    var self = this;
+    if (callback) self.hookupStreamCallback(callback);
+    var streams = [self.arg1, self.arg2, self.arg3];
+    var args = [arg1, arg2, arg3];
+    next(0);
+    function next(i) {
+        if (i >= streams.length) return;
+        var stream = streams[i];
+        var arg = args[i];
+        if (arg === null || arg === undefined ) {
+            stream.end();
+            next(i + 1);
+        } else if (typeof arg === 'string' || Buffer.isBuffer(arg)) {
+            stream.end(arg);
+            next(i + 1);
+        } else {
+            arg.pipe(stream);
+            stream.once('finish', onStreamFinished);
+        }
+        function onStreamFinished() {
+            next(i + 1);
+        }
+    }
+};
+
 module.exports = StreamingOutRequest;

--- a/node/streaming_out_request.js
+++ b/node/streaming_out_request.js
@@ -23,6 +23,7 @@
 var inherits = require('util').inherits;
 
 var OutArgStream = require('./argstream').OutArgStream;
+var pipelineStreams = require('./lib/pipeline_streams');
 var TChannelOutRequest = require('./out_request');
 
 function StreamingOutRequest(id, options) {
@@ -69,30 +70,12 @@ StreamingOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     return self;
 };
 
-StreamingOutRequest.prototype.sendStreams = function send(arg1, arg2, arg3, callback) {
+StreamingOutRequest.prototype.sendStreams = function sendStreams(arg1, arg2, arg3, callback) {
     var self = this;
     if (callback) self.hookupStreamCallback(callback);
-    var streams = [self.arg1, self.arg2, self.arg3];
-    var args = [arg1, arg2, arg3];
-    next(0);
-    function next(i) {
-        if (i >= streams.length) return;
-        var stream = streams[i];
-        var arg = args[i];
-        if (arg === null || arg === undefined ) {
-            stream.end();
-            next(i + 1);
-        } else if (typeof arg === 'string' || Buffer.isBuffer(arg)) {
-            stream.end(arg);
-            next(i + 1);
-        } else {
-            arg.pipe(stream);
-            stream.once('finish', onStreamFinished);
-        }
-        function onStreamFinished() {
-            next(i + 1);
-        }
-    }
+    pipelineStreams(
+        [arg1, arg2, arg3],
+        [self.arg1, self.arg2, self.arg3]);
 };
 
 module.exports = StreamingOutRequest;

--- a/node/streaming_out_response.js
+++ b/node/streaming_out_response.js
@@ -24,6 +24,7 @@
 var inherits = require('util').inherits;
 
 var OutArgStream = require('./argstream').OutArgStream;
+var pipelineStreams = require('./lib/pipeline_streams');
 var OutResponse = require('./out_response');
 var errors = require('./errors');
 var States = require('./reqres_states');
@@ -95,6 +96,13 @@ StreamingOutResponse.prototype.send = function send(res1, res2) {
     var self = this;
     self.arg2.end(res1);
     self.arg3.end(res2);
+};
+
+StreamingOutResponse.prototype.sendStreams = function sendStreams(res1, res2) {
+    var self = this;
+    pipelineStreams(
+        [res1, res2],
+        [self.arg2, self.arg3]);
 };
 
 module.exports = StreamingOutResponse;


### PR DESCRIPTION
Allows things like:
```diff
commit c120673
Author: Joshua T Corbin <joshua@uber.com>
Date:   3 days ago

    test/streaming_bisect: use StreamingOutRequest#sendStreams

diff --git a/node/test/streaming_bisect.js b/node/test/streaming_bisect.js
index 316ec01..6e8ea06 100644
--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -200,16 +200,10 @@ function inprocClusterTest(state, assert) {

         var reqHeadStream = CountStream({limit: hSize});
         var reqBodyStream = CountStream({limit: bSize});
-        var req = client.request({
+        client.request({
             host: cluster.hosts[0],
             streamed: true
-        });
-        req.hookupStreamCallback(onResult);
-        req.arg1.end('foo');
-        reqHeadStream.pipe(req.arg2);
-        req.arg2.once('finish', function onArg2Finished() {
-            reqBodyStream.pipe(req.arg3);
-        });
+        }).sendStreams('foo', reqHeadStream, reqBodyStream, onResult);
     }

     function onResult(err, req, res) {
```

r @Raynos @kriskowal 