### PR TITLE
Factor out {req,res}.withArg23

### DIFF
--- a/node/endpoint-handler.js
+++ b/node/endpoint-handler.js
@@ -22,7 +22,6 @@
 
 var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
-var parallel = require('run-parallel');
 var util = require('util');
 var errors = require('./errors');
 
@@ -99,11 +98,7 @@ TChannelEndpointHandler.prototype.handleArg1 = function handleArg1(req, buildRes
 };
 
 TChannelEndpointHandler.prototype.bufferArg23 = function bufferArg23(req, buildResponse, handler) {
-    parallel({
-        arg2: req.arg2.onValueReady,
-        arg3: req.arg3.onValueReady
-    }, argsDone);
-    function argsDone(err, args) {
+    req.withArg23(function gotArg23(err, arg2, arg3) {
         var res = buildResponse({streamed: false});
         if (err) {
             // TODO: log error
@@ -111,9 +106,9 @@ TChannelEndpointHandler.prototype.bufferArg23 = function bufferArg23(req, buildR
                 'error accumulating arg2/arg3: %s: %s',
                 err.constructor.name, err.message));
         } else {
-            handler(req, res, args.arg2, args.arg3);
+            handler(req, res, arg2, arg3);
         }
-    }
+    });
 };
 
 module.exports = TChannelEndpointHandler;

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -120,4 +120,9 @@ TChannelInRequest.prototype.checkTimeout = function checkTimeout() {
     return self.timedOut;
 };
 
+TChannelInRequest.prototype.withArg23 = function withArg23(callback) {
+    var self = this;
+    callback(null, self.arg2, self.arg3);
+};
+
 module.exports = TChannelInRequest;

--- a/node/in_response.js
+++ b/node/in_response.js
@@ -83,4 +83,9 @@ TChannelInResponse.prototype.handleFrame = function handleFrame(parts) {
     self.finishEvent.emit(self);
 };
 
+TChannelInResponse.prototype.withArg23 = function withArg23(callback) {
+    var self = this;
+    callback(null, self.arg2, self.arg3);
+};
+
 module.exports = TChannelInResponse;

--- a/node/streaming_in_request.js
+++ b/node/streaming_in_request.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var parallel = require('run-parallel');
 var InRequest = require('./in_request');
 var inherits = require('util').inherits;
 
@@ -53,6 +54,17 @@ StreamingInRequest.prototype.type = 'tchannel.incoming-request.streaming';
 StreamingInRequest.prototype.handleFrame = function handleFrame(parts) {
     var self = this;
     self._argstream.handleFrame(parts);
+};
+
+StreamingInRequest.prototype.withArg23 = function withArg23(callback) {
+    var self = this;
+    parallel({
+        arg2: self.arg2.onValueReady,
+        arg3: self.arg3.onValueReady
+    }, compatCall);
+    function compatCall(err, args) {
+        callback(err, args.arg2, args.arg3);
+    }
 };
 
 module.exports = StreamingInRequest;

--- a/node/streaming_in_response.js
+++ b/node/streaming_in_response.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+var parallel = require('run-parallel');
 var InResponse = require('./in_response');
 var inherits = require('util').inherits;
 
@@ -54,6 +55,17 @@ StreamingInResponse.prototype.type = 'tchannel.incoming-response.streaming';
 StreamingInResponse.prototype.handleFrame = function handleFrame(parts) {
     var self = this;
     self._argstream.handleFrame(parts);
+};
+
+StreamingInResponse.prototype.withArg23 = function withArg23(callback) {
+    var self = this;
+    parallel({
+        arg2: self.arg2.onValueReady,
+        arg3: self.arg3.onValueReady
+    }, compatCall);
+    function compatCall(err, args) {
+        callback(err, args.arg2, args.arg3);
+    }
 };
 
 module.exports = StreamingInResponse;


### PR DESCRIPTION
Towards #488, this makes it easier to shift around who / when buffering occurs.