### PR TITLE
Upgrade debug-logtron & cleanup logs

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -314,6 +314,7 @@ TChannelConnectionBase.prototype.onReqDone = function onReqDone(req) {
     if (self.requests.in[req.id] !== req) {
         self.logger.warn('mismatched onReqDone callback', {
             hostPort: self.channel.hostPort,
+            hasInReq: self.requests.in[req.id] !== undefined,
             id: req.id
         });
     } else {

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "async": "^0.9.0",
     "chalk": "^1.0.0",
     "child_pty": "^0.5.1",
-    "debug-logtron": "3.1.0",
+    "debug-logtron": "3.2.0",
     "duplexer": "^0.1.1",
     "istanbul": "^0.3.5",
     "jshint": "^2.5.6",

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "async": "^0.9.0",
     "chalk": "^1.0.0",
     "child_pty": "^0.5.1",
-    "debug-logtron": "^2.0.0",
+    "debug-logtron": "3.1.0",
     "duplexer": "^0.1.1",
     "istanbul": "^0.3.5",
     "jshint": "^2.5.6",

--- a/node/self_out_response.js
+++ b/node/self_out_response.js
@@ -85,8 +85,12 @@ function passError(codeString, message) {
         originalId: self.id,
         message: message
     });
-    self.inreq.outreq.errorEvent.emit(self, err);
     if (!self.closing) self.conn.lastTimeoutTime = 0;
+    process.nextTick(emitError);
+
+    function emitError() {
+        self.inreq.outreq.errorEvent.emit(self, err);
+    }
 };
 
 module.exports.OutResponse = SelfOutResponse;

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -28,7 +28,6 @@ var util = require('util');
 var TChannel = require('../../channel.js');
 var parallel = require('run-parallel');
 var debugLogtron = require('debug-logtron');
-var LEVELS = require('debug-logtron/levels');
 
 module.exports = allocCluster;
 
@@ -36,21 +35,9 @@ function allocCluster(opts) {
     opts = opts || {};
 
     var host = 'localhost';
-    var logger = debugLogtron('tchannel');
-
-    // TODO: debugLogtron should do this by default imo
-    var orig = logger._log;
-    logger._log = function _log(level, msg, meta, cb) {
-        if (level >= LEVELS.warn) {
-            var mess = msg;
-            if (meta && meta.error) {
-                mess += ' - ' + meta.error.message;
-            }
-            var levelName = LEVELS.LEVELS_BY_VALUE[level];
-            console.error('%s: %s ~', levelName, mess, meta);
-        }
-        orig.call(logger, level, msg, meta, cb);
-    };
+    var logger = debugLogtron('tchannel', {
+        enabled: true
+    });
 
     var cluster = {
         logger: logger,

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -145,6 +145,26 @@ allocCluster.test = function testCluster(desc, opts, t) {
     });
 };
 
+allocCluster.test.only = function testClusterOnly(desc, opts, t) {
+    if (typeof opts === 'number') {
+        opts = {
+            numPeers: opts
+        };
+    }
+    if (typeof opts === 'function') {
+        t = opts;
+        opts = {};
+    }
+    test.only(desc, function t2(assert) {
+        allocCluster(opts).ready(function clusterReady(cluster) {
+            assert.once('end', function testEnded() {
+                cluster.destroy();
+            });
+            t(cluster, assert);
+        });
+    });
+};
+
 function ClusterPool(setup) {
     var self = this;
     self.free = [];

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -36,8 +36,7 @@ function allocCluster(opts) {
 
     var host = 'localhost';
     var logger = debugLogtron('tchannel', {
-        enabled: true,
-        assert: opts.assert
+        enabled: true
     });
 
     var cluster = {

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -36,7 +36,8 @@ function allocCluster(opts) {
 
     var host = 'localhost';
     var logger = debugLogtron('tchannel', {
-        enabled: true
+        enabled: true,
+        assert: opts.assert
     });
 
     var cluster = {
@@ -136,6 +137,7 @@ allocCluster.test = function testCluster(desc, opts, t) {
         opts = {};
     }
     test(desc, function t2(assert) {
+        opts.assert = assert;
         allocCluster(opts).ready(function clusterReady(cluster) {
             assert.once('end', function testEnded() {
                 cluster.destroy();
@@ -156,6 +158,7 @@ allocCluster.test.only = function testClusterOnly(desc, opts, t) {
         opts = {};
     }
     test.only(desc, function t2(assert) {
+        opts.assert = assert;
         allocCluster(opts).ready(function clusterReady(cluster) {
             assert.once('end', function testEnded() {
                 cluster.destroy();


### PR DESCRIPTION
 - DebugLogtron() has enabled to to true so writes
    info, warn, error & fatal.
 - Fix log spew for socket closes
 - Fix warns around self response race condition
 - Add allocCluster.test.only() for sanity.

r: @jcorbin @kriskowal