### PR TITLE
package: upgrade error to ^6.1.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "bufrw": "^0.9.19",
     "crc": "^3.2.1",
-    "error": "^5.1.1",
+    "error": "^6.1.0",
     "farmhash": "^0.2.0",
     "is-error": "2.0.0",
     "json-stringify-safe": "5.0.0",


### PR DESCRIPTION
Updating error to latest version.

 - version 6 adds a better `fullType` field for wrapped.
 - version 6 adds a `cause` field on a wrapped error. This
    is the error that we are wrapping.
 - version 6.1 fixes message formatting, syscall and
    code and others now show up. This fixes the
    `tchannel.socket` messages as well as others

r: @jcorbin @kriskowal