### PR TITLE
[node] Create a stat emitter library

### DIFF
--- a/node/lib/stat.js
+++ b/node/lib/stat.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+function Stat(name, type, value, tags) {
+    var self = this;
+    self.name = name;
+    self.type = type;
+    self.value = value;
+    self.tags = {};
+}
+
+module.exports = Stat;

--- a/node/lib/stat_emitter.js
+++ b/node/lib/stat_emitter.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var inherits = require('util').inherits;
+var EventEmitter = require('./event_emitter');
+var Stat = require('./stat');
+
+// This is an interface that exists only to explicitly declare the stats we are
+// tracking and avoid bugs due to mis-spelled names and types.
+
+function StatEmitter() {
+    var self = this;
+    EventEmitter.call(self);
+    self.statEvent = self.defineEvent('stat');
+}
+
+inherits(StatEmitter, EventEmitter);
+
+// These methods are intended to be used in the constructor to declare stats.
+StatEmitter.prototype.defineCounter = function defineCounter(name) {
+    var self = this;
+    return new Counter(name, self);
+};
+
+StatEmitter.prototype.defineGauge = function defineGauge(name) {
+    var self = this;
+    return new Gauge(name, self);
+};
+
+StatEmitter.prototype.defineTiming = function defineTiming(name) {
+    var self = this;
+    return new Timing(name, self);
+};
+
+// May be overridden to add tags to the stat object.
+StatEmitter.prototype.emitStat = function emitStat(stat) {
+    var self = this;
+    self.statEvent.emit(self.emitter, stat);
+};
+
+function emitStat(value) {
+    /*jshint validthis: true */
+    var self = this;
+    var stat = new Stat(self.name, self.type, value);
+    self.emitter.emitStat(stat);
+}
+
+function Counter(name, emitter) {
+    var self = this;
+    self.name = name;
+    self.emitter = emitter;
+}
+Counter.prototype.type = 'counter';
+Counter.prototype.increment = emitStat;
+
+function Gauge(name, emitter) {
+    var self = this;
+    self.name = name;
+    self.emitter = emitter;
+}
+Gauge.prototype.type = 'gauge';
+Gauge.prototype.update = emitStat;
+
+function Timing(name, emitter) {
+    var self = this;
+    self.name = name;
+    self.emitter = emitter;
+}
+Timing.prototype.type = 'timing';
+Timing.prototype.add = emitStat;
+
+module.exports = StatEmitter;


### PR DESCRIPTION
This library surfaces stat events through our EventEmitter library.

- Enables us to declare our stats in the constructor, just as we do with
  EventEmitter.
- Helps us avoid errors due to mis-spelled stat names.
- Illuminates which stat type is appropriate by providing a method with
  an appropriate verb name: increment for Counter, update for Gauge, add
  for Timing.
- Interns stat name strings (maybe helpful, maybe not)