### PR TITLE
package: remove null-logtron

### DIFF
--- a/node/as/README.md
+++ b/node/as/README.md
@@ -6,20 +6,14 @@ to handle encoding and decoding for you
 ## JSON example
 
 ```js
-var NullLogtron = require('null-logtron');
 var TChannelJSON = require('tchannel/as/json');
 var TChannel = require('tchannel');
 
 var server = TChannel({
-    serviceName: 'server',
-    logger: NullLogtron()
+    serviceName: 'server'
 });
-var client = TChannel({
-    logger: NullLogtron()
-});
-var tchannelJSON = TChannelJSON({
-    logger: NullLogtron()
-});
+var client = TChannel();
+var tchannelJSON = TChannelJSON();
 
 var context = {};
 

--- a/node/as/json.js
+++ b/node/as/json.js
@@ -38,7 +38,8 @@ function TChannelJSON(options) {
 
     var self = this;
 
-    self.logger = options && options.logger || null;
+    // lazily populated from tchannel
+    self.logger = null;
 
     var bossMode = options && options.bossMode;
     self.bossMode = typeof bossMode === 'boolean' ? bossMode : false;
@@ -54,6 +55,10 @@ TChannelJSON.prototype.send = function send(
 ) {
 
     var self = this;
+
+    if (!self.logger) {
+        self.logger = req.logger;
+    }
 
     assert(typeof endpoint === 'string', 'endpoint must be a string');
     assert(typeof req.serviceName === 'string' && req.serviceName !== '',
@@ -113,6 +118,10 @@ TChannelJSON.prototype.register = function register(
     tchannel, arg1, opts, handlerFunc
 ) {
     var self = this;
+
+    if (!self.logger) {
+        self.logger = tchannel.logger;
+    }
 
     tchannel.register(arg1, endpointHandler);
 

--- a/node/as/json.js
+++ b/node/as/json.js
@@ -151,12 +151,10 @@ TChannelJSON.prototype.register = function register(
             if (err) {
                 assert(isError(err), 'Error argument must be an error');
 
-                if (self.logger) {
-                    self.logger.error('Got unexpected error in handler', {
-                        endpoint: arg1,
-                        err: err
-                    });
-                }
+                self.logger.error('Got unexpected error in handler', {
+                    endpoint: arg1,
+                    err: err
+                });
                 return res.sendError('UnexpectedError', 'Unexpected Error');
             }
 
@@ -211,13 +209,11 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
             head: cyclicStringify(opts.head)
         });
 
-        if (self.logger) {
-            self.logger.error('Got unexpected unserializable JSON for arg2', {
-                endpoint: opts.endpoint,
-                direction: opts.direction,
-                headErr: headStringifyErr
-            });
-        }
+        self.logger.error('Got unexpected unserializable JSON for arg2', {
+            endpoint: opts.endpoint,
+            direction: opts.direction,
+            headErr: headStringifyErr
+        });
         return new Result(headStringifyErr);
     }
 
@@ -229,13 +225,11 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
             body: cyclicStringify(opts.body)
         });
 
-        if (self.logger) {
-            self.logger.error('Got unexpected unserializable JSON for arg3', {
-                endpoint: opts.endpoint,
-                direction: opts.direction,
-                bodyErr: bodyStringifyErr
-            });
-        }
+        self.logger.error('Got unexpected unserializable JSON for arg3', {
+            endpoint: opts.endpoint,
+            direction: opts.direction,
+            bodyErr: bodyStringifyErr
+        });
         return new Result(bodyStringifyErr);
     }
 
@@ -256,7 +250,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
             headStr: opts.head.slice(0, 10)
         });
 
-        if (self.logParseFailures && self.logger) {
+        if (self.logParseFailures) {
             self.logger.warn('Got unexpected invalid JSON for arg2', {
                 endpoint: opts.endpoint,
                 direction: opts.direction,
@@ -275,7 +269,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
             bodyStr: opts.body.slice(0, 10)
         });
 
-        if (self.logParseFailures && self.logger) {
+        if (self.logParseFailures) {
             self.logger.warn('Got unexpected invalid JSON for arg3', {
                 endpoint: opts.endpoint,
                 direction: opts.direction,

--- a/node/as/json.js
+++ b/node/as/json.js
@@ -24,7 +24,6 @@
 
 var Buffer = require('buffer').Buffer;
 var assert = require('assert');
-var NullLogtron = require('null-logtron');
 var Result = require('bufrw/result');
 var cyclicStringify = require('json-stringify-safe');
 
@@ -39,7 +38,7 @@ function TChannelJSON(options) {
 
     var self = this;
 
-    self.logger = options && options.logger || NullLogtron();
+    self.logger = options && options.logger || null;
 
     var bossMode = options && options.bossMode;
     self.bossMode = typeof bossMode === 'boolean' ? bossMode : false;
@@ -143,10 +142,12 @@ TChannelJSON.prototype.register = function register(
             if (err) {
                 assert(isError(err), 'Error argument must be an error');
 
-                self.logger.error('Got unexpected error in handler', {
-                    endpoint: arg1,
-                    err: err
-                });
+                if (self.logger) {
+                    self.logger.error('Got unexpected error in handler', {
+                        endpoint: arg1,
+                        err: err
+                    });
+                }
                 return res.sendError('UnexpectedError', 'Unexpected Error');
             }
 
@@ -201,11 +202,13 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
             head: cyclicStringify(opts.head)
         });
 
-        self.logger.error('Got unexpected unserializable JSON for arg2', {
-            endpoint: opts.endpoint,
-            direction: opts.direction,
-            headErr: headStringifyErr
-        });
+        if (self.logger) {
+            self.logger.error('Got unexpected unserializable JSON for arg2', {
+                endpoint: opts.endpoint,
+                direction: opts.direction,
+                headErr: headStringifyErr
+            });
+        }
         return new Result(headStringifyErr);
     }
 
@@ -217,11 +220,13 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
             body: cyclicStringify(opts.body)
         });
 
-        self.logger.error('Got unexpected unserializable JSON for arg3', {
-            endpoint: opts.endpoint,
-            direction: opts.direction,
-            bodyErr: bodyStringifyErr
-        });
+        if (self.logger) {
+            self.logger.error('Got unexpected unserializable JSON for arg3', {
+                endpoint: opts.endpoint,
+                direction: opts.direction,
+                bodyErr: bodyStringifyErr
+            });
+        }
         return new Result(bodyStringifyErr);
     }
 
@@ -242,7 +247,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
             headStr: opts.head.slice(0, 10)
         });
 
-        if (self.logParseFailures) {
+        if (self.logParseFailures && self.logger) {
             self.logger.warn('Got unexpected invalid JSON for arg2', {
                 endpoint: opts.endpoint,
                 direction: opts.direction,
@@ -261,7 +266,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
             bodyStr: opts.body.slice(0, 10)
         });
 
-        if (self.logParseFailures) {
+        if (self.logParseFailures && self.logger) {
             self.logger.warn('Got unexpected invalid JSON for arg3', {
                 endpoint: opts.endpoint,
                 direction: opts.direction,

--- a/node/examples/as_example1.js
+++ b/node/examples/as_example1.js
@@ -18,20 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var NullLogtron = require('null-logtron');
 var TChannelJSON = require('../as/json');
 var TChannel = require('../');
 
 var server = TChannel({
-    serviceName: 'server',
-    logger: NullLogtron()
+    serviceName: 'server'
 });
-var client = TChannel({
-    logger: NullLogtron()
-});
-var tchannelJSON = TChannelJSON({
-    logger: NullLogtron()
-});
+var client = TChannel();
+var tchannelJSON = TChannelJSON();
 
 var context = {};
 

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,6 @@
     "error": "^6.2.0",
     "farmhash": "^0.2.0",
     "json-stringify-safe": "^5.0.0",
-    "null-logtron": "^2.2.0",
     "readable-stream": "1.0.33",
     "ready-signal": "^1.1.1",
     "run-parallel": "^1.1.0",

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -152,6 +152,15 @@ allocCluster.test('getting an UnexpectedError frame', {
     });
     var client = cluster.channels[1];
 
+    var _error = client.logger.error;
+    var messages = [];
+    client.logger.error = function error(msg) {
+        messages.push(msg);
+        if (msg !== 'Got unexpected error in handler') {
+            _error.apply(this, arguments);
+        }
+    };
+
     var opts = {
         isOptions: true
     };
@@ -174,6 +183,7 @@ allocCluster.test('getting an UnexpectedError frame', {
         assert.equal(err.message, 'Unexpected Error');
 
         assert.equal(resp, undefined);
+        assert.equal(messages.length, 1);
 
         assert.end();
     });

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -92,10 +92,8 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var parentSpan = options.parentSpan;
     if (options.outgoing && !parentSpan && !options.topLevelRequest) {
-        if (self.logger) {
-            self.logger.warn("TChannel tracer: parent span not specified " +
-                "for outgoing request!", options);
-        }
+        self.logger.warn("TChannel tracer: parent span not specified " +
+            "for outgoing request!", options);
     }
 
     if (parentSpan && (!options.parentid && !options.traceid)) {
@@ -125,8 +123,6 @@ Agent.prototype.reporter = function (span) {
     var self = this;
 
     // TODO: actual reporting
-    if (self.logger) {
-        self.logger.info('got span: ' + span.toString());
-    }
+    self.logger.info('got span: ' + span.toString());
 };
 

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+'use strict';
+
 var Span = require('./span');
 
 module.exports = Agent;

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var NullLogtron = require('null-logtron');
-
 var Span = require('./span');
 
 module.exports = Agent;
@@ -32,7 +30,7 @@ function Agent(options) {
 
     options = options || {};
 
-    self.logger = options.logger || NullLogtron();
+    self.logger = options.logger;
 
     // If this is set to true in a call to Agent#configure, all incoming
     // requests will have their traceflags forced to 1. It's intended to be
@@ -93,8 +91,10 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var parentSpan = options.parentSpan;
     if (options.outgoing && !parentSpan && !options.topLevelRequest) {
-        self.logger.warn("TChannel tracer: parent span not specified " +
-            "for outgoing request!", options);
+        if (self.logger) {
+            self.logger.warn("TChannel tracer: parent span not specified " +
+                "for outgoing request!", options);
+        }
     }
 
     if (parentSpan && (!options.parentid && !options.traceid)) {
@@ -124,6 +124,8 @@ Agent.prototype.reporter = function (span) {
     var self = this;
 
     // TODO: actual reporting
-    self.logger.info('got span: ' + span.toString());
+    if (self.logger) {
+        self.logger.info('got span: ' + span.toString());
+    }
 };
 

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -74,7 +74,6 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
     }
 
     var span = new Span({
-        logger: self.logger,
         endpoint: new Span.Endpoint(
             host, 
             port, 


### PR DESCRIPTION
We have a `null-logtron` dependency purely for as/json and
for the tracer.

Ideally I would like to remove it; this can be done in two
ways.

 - use `if (logger)` statements everywhere
 - allow the tracer and as layers to re-use `channel.logger`

This PR currently does the former; the `if` statements.

r: @jcorbin @kriskowal