### PR TITLE
events API tweaks

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,12 @@ setup(
     license='MIT',
     url='https://github.com/uber/tchannel',
     packages=find_packages(),
-    install_requires=['contextlib2', 'enum34', 'futures'],
+    install_requires=[
+        'contextlib2',
+        'enum34',
+        'futures',
+        'crcmod',
+    ],
     entry_points={
         'console_scripts': [
             'tcurl.py = tchannel.tcurl:start_ioloop'

--- a/python/tchannel/event.py
+++ b/python/tchannel/event.py
@@ -41,10 +41,17 @@ class EventType(IntEnum):
     receive_response: after client receive response
 
     """
-    send_request = 0x00,
-    send_response = 0x01,
-    receive_request = 0x02,
-    receive_response = 0x03
+    before_send_request = 0x00
+    after_send_request = 0x01
+
+    before_send_response = 0x10
+    after_send_response = 0x11
+
+    before_receive_request = 0x20
+    after_receive_request = 0x21
+
+    before_receive_response = 0x30
+    after_receive_response = 0x31
 
 
 class EventHook(object):
@@ -56,41 +63,40 @@ class EventHook(object):
     Example::
 
         TraceHook(EventHook):
-            def send_request(self, context):
+            def before_send_request(self, request):
                 ....
 
     """
-
-    def send_request(self, context):
-        """Event hook for sending request
-
-        :param context:
-            request object to send
-        """
+    def before_send_request(self, request):
+        """Called before any part of a ``CALL_REQ`` message is sent."""
         pass
 
-    def send_response(self, context):
-        """Event hook for sending response
-
-        :param context:
-            response object sent
-        """
+    def after_send_request(self, request):
+        """Not implemented."""
         pass
 
-    def receive_request(self, context):
-        """Event hook for receiving request
-
-        :param context:
-            request object received
-        """
+    def before_send_response(self, response):
+        """Not implemented."""
         pass
 
-    def receive_response(self, context):
-        """Event hook for receiving response
+    def after_send_response(self, response):
+        """Called after all of a ``CALL_RESP`` message is sent."""
+        pass
 
-        :param context:
-            response object received
-        """
+    def before_receive_request(self, request):
+        """Called after a ``CALL_REQ`` message's arg1 (endpoint) is read."""
+        pass
+
+    def after_receive_request(self, request):
+        """Not implemented."""
+        pass
+
+    def before_receive_response(self, response):
+        """Not implemented."""
+        pass
+
+    def after_receive_response(self, response):
+        """Called after a ``CALL_RESP`` message is read."""
         pass
 
 

--- a/python/tchannel/event.py
+++ b/python/tchannel/event.py
@@ -134,11 +134,20 @@ class EventEmitter(object):
             except Exception as e:
                 log.error(e.message)
 
+
+class EventRegistrar(object):
+
+    def __init__(self, event_emitter):
+        self.event_emitter = event_emitter
+
+    def register(self, hook, event_type=None):
+        return self.event_emitter.register_hook(hook, event_type)
+
     def __getattr__(self, attr):
         if attr in EventType.__members__:
             event_type = EventType[attr]
             return functools.partial(
-                self.register_hook,
+                self.register,
                 event_type=event_type,
             )
         return super(EventEmitter, self).__getattr__(attr)

--- a/python/tchannel/tornado/connection.py
+++ b/python/tchannel/tornado/connection.py
@@ -541,7 +541,7 @@ class StreamConnection(TornadoConnection):
 
             # event: send_response
             if self.tchannel:
-                self.tchannel.event_emitter.fire(
+                self.tchannel.hooks.fire(
                     EventType.after_send_response,
                     response,
                 )
@@ -554,7 +554,7 @@ class StreamConnection(TornadoConnection):
 
         # event: send_request
         if self.tchannel:
-            self.tchannel.event_emitter.fire(
+            self.tchannel.hooks.fire(
                 EventType.before_send_request,
                 request,
             )
@@ -598,8 +598,9 @@ class StreamConnection(TornadoConnection):
             response_future.set_result(f.result())
             # event: receive_response
             if self.tchannel:
-                self.tchannel.event_emitter.fire(
-                    EventType.after_receive_response, f.result(),
+                self.tchannel.hooks.fire(
+                    EventType.after_receive_response,
+                    f.result(),
                 )
 
         tornado.ioloop.IOLoop.current().add_future(

--- a/python/tchannel/tornado/connection.py
+++ b/python/tchannel/tornado/connection.py
@@ -541,7 +541,7 @@ class StreamConnection(TornadoConnection):
 
             # event: send_response
             if self.tchannel:
-                self.tchannel.hooks.fire(
+                self.tchannel.event_emitter.fire(
                     EventType.after_send_response,
                     response,
                 )
@@ -554,7 +554,7 @@ class StreamConnection(TornadoConnection):
 
         # event: send_request
         if self.tchannel:
-            self.tchannel.hooks.fire(
+            self.tchannel.event_emitter.fire(
                 EventType.before_send_request,
                 request,
             )
@@ -598,7 +598,7 @@ class StreamConnection(TornadoConnection):
             response_future.set_result(f.result())
             # event: receive_response
             if self.tchannel:
-                self.tchannel.hooks.fire(
+                self.tchannel.event_emitter.fire(
                     EventType.after_receive_response,
                     f.result(),
                 )

--- a/python/tchannel/tornado/connection.py
+++ b/python/tchannel/tornado/connection.py
@@ -480,7 +480,7 @@ class StreamConnection(TornadoConnection):
     "post_response(response)"
         stream response object into wire
 
-    "post_request(request)"
+    "stream_request(request)"
         stream request object into wire without waiting for a response
 
     "send_request(request)"
@@ -536,26 +536,33 @@ class StreamConnection(TornadoConnection):
     @tornado.gen.coroutine
     def post_response(self, response):
         try:
+            # TODO: before_send_response
             yield self._stream(response, self.response_message_factory)
 
             # event: send_response
             if self.tchannel:
                 self.tchannel.event_emitter.fire(
-                    EventType.send_response, response)
+                    EventType.after_send_response,
+                    response,
+                )
         finally:
             response.close_argstreams(force=True)
 
     @tornado.gen.coroutine
-    def post_request(self, request):
+    def stream_request(self, request):
         """send the given request and response is not required"""
 
         # event: send_request
         if self.tchannel:
-            self.tchannel.event_emitter.fire(EventType.send_request, request)
+            self.tchannel.event_emitter.fire(
+                EventType.before_send_request,
+                request,
+            )
 
         try:
             request.close_argstreams()
             yield self._stream(request, self.request_message_factory)
+            # TODO: add after_send_request callback
         finally:
             request.close_argstreams(force=True)
 
@@ -579,22 +586,25 @@ class StreamConnection(TornadoConnection):
 
         future = tornado.gen.Future()
         self._outstanding[request.id] = future
-        self.post_request(request)
+        self.stream_request(request)
 
         # the actual future that caller will yield
-        res_future = tornado.gen.Future()
+        response_future = tornado.gen.Future()
+        # TODO: fire before_receive_response
 
         def adapt_tracing(f):
             # fetch the request tracing for response
             f.result().tracing = request.tracing
-            res_future.set_result(f.result())
+            response_future.set_result(f.result())
             # event: receive_response
             if self.tchannel:
                 self.tchannel.event_emitter.fire(
-                    EventType.receive_response, f.result())
+                    EventType.after_receive_response, f.result(),
+                )
 
         tornado.ioloop.IOLoop.current().add_future(
             future,
-            adapt_tracing)
+            adapt_tracing,
+        )
 
-        return res_future
+        return response_future

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -68,7 +68,7 @@ class RequestDispatcher(BaseRequestHandler):
         # event: receive_request
         if connection.tchannel:
             request.tracing.name = request.endpoint
-            connection.tchannel.hooks.fire(
+            connection.tchannel.event_emitter.fire(
                 EventType.before_receive_request,
                 request,
             )

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -68,7 +68,7 @@ class RequestDispatcher(BaseRequestHandler):
         # event: receive_request
         if connection.tchannel:
             request.tracing.name = request.endpoint
-            connection.tchannel.event_emitter.fire(
+            connection.tchannel.hooks.fire(
                 EventType.before_receive_request,
                 request,
             )

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -69,7 +69,9 @@ class RequestDispatcher(BaseRequestHandler):
         if connection.tchannel:
             request.tracing.name = request.endpoint
             connection.tchannel.event_emitter.fire(
-                EventType.receive_request, request)
+                EventType.before_receive_request,
+                request,
+            )
 
         endpoint = self.endpoints.get(request.endpoint, None)
         if endpoint is None:
@@ -79,16 +81,24 @@ class RequestDispatcher(BaseRequestHandler):
                     request.endpoint, request.service),
                 request.id)
         else:
-            response = Response(id=request.id,
-                                checksum=request.checksum,
-                                tracing=request.tracing,
-                                connection=connection)
+            response = Response(
+                id=request.id,
+                checksum=request.checksum,
+                tracing=request.tracing,
+                connection=connection,
+            )
 
             connection.post_response(response)
-            yield self._call_endpoint(endpoint, request, response,
-                                      TChannelProxy(
-                                          connection.tchannel,
-                                          request.tracing))
+
+            yield self._call_endpoint(
+                endpoint,
+                request,
+                response,
+                TChannelProxy(
+                    connection.tchannel,
+                    request.tracing,
+                ),
+            )
 
     def route(self, rule, helper=None):
         """See ``register`` for documentation."""

--- a/python/tchannel/tornado/tchannel.py
+++ b/python/tchannel/tornado/tchannel.py
@@ -82,14 +82,14 @@ class TChannel(object):
         self._handler = None
 
         # register event hooks
-        self.event_emitter = EventEmitter()
+        self.hooks = EventEmitter()
         if hooks:
             for hook in hooks:
-                self.event_emitter.register_hook(hook)
+                self.hooks.register_hook(hook)
 
     def add_hook(self, hook):
         if hook:
-            self.event_emitter.register_hook(hook)
+            self.hooks.register_hook(hook)
 
     @property
     def closed(self):

--- a/python/tchannel/tornado/tchannel.py
+++ b/python/tchannel/tornado/tchannel.py
@@ -33,6 +33,7 @@ from tornado.netutil import bind_sockets
 from enum import IntEnum
 
 from ..event import EventEmitter
+from ..event import EventRegistrar
 from ..handler import CallableRequestHandler
 from ..net import local_ip
 from .connection import StreamConnection
@@ -55,7 +56,7 @@ class TChannel(object):
     separate instances, use the ``ignore_singleton`` argument.
     """
 
-    def __init__(self, hostport=None, process_name=None, hooks=None):
+    def __init__(self, hostport=None, process_name=None):
         """Build or re-use a TChannel.
 
         :param hostport:
@@ -82,14 +83,8 @@ class TChannel(object):
         self._handler = None
 
         # register event hooks
-        self.hooks = EventEmitter()
-        if hooks:
-            for hook in hooks:
-                self.hooks.register_hook(hook)
-
-    def add_hook(self, hook):
-        if hook:
-            self.hooks.register_hook(hook)
+        self.event_emitter = EventEmitter()
+        self.hooks = EventRegistrar(self.event_emitter)
 
     @property
     def closed(self):

--- a/python/tchannel/zipkin/zipkin_trace.py
+++ b/python/tchannel/zipkin/zipkin_trace.py
@@ -39,21 +39,21 @@ class ZipkinTraceHook(EventHook):
             # to dst. By default it writes to stdout
             self.tracer = DebugTracer(dst)
 
-    def send_request(self, context):
+    def before_send_request(self, context):
         if not context.tracing.traceflags:
             return
 
         ann = annotation.client_send()
         context.tracing.annotations.append(ann)
 
-    def receive_request(self, context):
+    def before_receive_request(self, context):
         if not context.tracing.traceflags:
             return
 
         ann = annotation.server_recv()
         context.tracing.annotations.append(ann)
 
-    def send_response(self, context):
+    def after_send_response(self, context):
         if not context.tracing.traceflags:
             return
 
@@ -62,7 +62,7 @@ class ZipkinTraceHook(EventHook):
         context.tracing.annotations.append(ann)
         self.tracer.record([(context.tracing, context.tracing.annotations)])
 
-    def receive_response(self, context):
+    def after_receive_response(self, context):
         if not context.tracing.traceflags:
             return
 

--- a/python/tests/integration/trace/test_zipkin_trace.py
+++ b/python/tests/integration/trace/test_zipkin_trace.py
@@ -75,8 +75,11 @@ def trace_server(random_open_port, handlers):
         port=random_open_port,
         dispatcher=handlers
     ) as manager:
-        manager.tchannel.add_hook(ZipkinTraceHook(
-            dst=trace_buf))
+        manager.tchannel.hooks.register(
+            ZipkinTraceHook(
+                dst=trace_buf,
+            ),
+        )
         yield manager
 
 
@@ -84,9 +87,8 @@ def trace_server(random_open_port, handlers):
 def test_zipkin_trace(trace_server):
     endpoint = b'endpoint1'
     zipkin_tracer = ZipkinTraceHook(dst=trace_buf)
-    tchannel = TChannel(
-        hooks=[zipkin_tracer]
-    )
+    tchannel = TChannel()
+    tchannel.hooks.register(zipkin_tracer)
 
     hostport = 'localhost:%d' % trace_server.port
 

--- a/python/tests/test_event.py
+++ b/python/tests/test_event.py
@@ -35,3 +35,16 @@ def test_event_hook():
     for event_type in EventType:
         event_emitter.fire(event_type, None)
         assert getattr(mock_hook, event_type.name).called is True
+
+
+def test_decorator_registration():
+    event_emitter = EventEmitter()
+
+    called = [False]
+
+    @event_emitter.before_send_request
+    def foo():
+        called[0] = True
+
+    event_emitter.fire(EventType.before_send_request)
+    assert called[0] is True

--- a/python/tests/test_event.py
+++ b/python/tests/test_event.py
@@ -28,22 +28,10 @@ from tchannel.event import EventType
 
 def test_event_hook():
     mock_hook = MagicMock()
-    mock_hook.send_request.return_value = None
-    mock_hook.receive_request.return_value = None
-    mock_hook.receive_response.return_value = None
-    mock_hook.send_response.return_Value = None
 
     event_emitter = EventEmitter()
     event_emitter.register_hook(mock_hook)
 
-    event_emitter.fire(EventType.receive_response, None)
-    assert mock_hook.receive_response.called
-
-    event_emitter.fire(EventType.receive_request, None)
-    assert mock_hook.receive_request.called
-
-    event_emitter.fire(EventType.send_request, None)
-    assert mock_hook.send_request.called
-
-    event_emitter.fire(EventType.send_response, None)
-    assert mock_hook.send_response.called
+    for event_type in EventType:
+        event_emitter.fire(event_type, None)
+        assert getattr(mock_hook, event_type.name).called is True

--- a/python/tests/test_event.py
+++ b/python/tests/test_event.py
@@ -24,6 +24,7 @@ from mock import MagicMock
 
 from tchannel.event import EventEmitter
 from tchannel.event import EventType
+from tchannel.event import EventRegistrar
 
 
 def test_event_hook():
@@ -39,10 +40,11 @@ def test_event_hook():
 
 def test_decorator_registration():
     event_emitter = EventEmitter()
+    registrar = EventRegistrar(event_emitter)
 
     called = [False]
 
-    @event_emitter.before_send_request
+    @registrar.before_send_request
     def foo():
         called[0] = True
 


### PR DESCRIPTION
@junchaowu @abhinav 

* Rename `tchannel.event_emitter` to `tchannel.hooks` for a nicer API.
* Add `@tchannel.hooks.event_name` decorator registration.
* Break events into before/after; doesn't add implementations.