### PR TITLE
As http

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,41 @@
+# HTTP over TChannel
+
+This document outlines how we encode HTTP over TChannel.
+
+For HTTP call requests the `as` (arg scheme) transport header must be set to
+`http`. Requests will be made with `call req` messages and responses will be
+sent using `call res` messages, with values for `arg1`, `arg2` and `arg3` as
+defined below.
+
+The HTTP arg scheme does not support dispatch on `arg1`, all dispatching
+decisions must be made on the `service` field.
+
+## Arguments
+
+- `arg1` is an arbitrary circuit string, which can be left empty
+- `arg2` is encoded request/response meta data detailed below
+- `arg3` is a raw byte stream piped through from the http request/response
+
+### `arg2`: request meta data
+
+Binary schema:
+```
+method~1
+url~2
+numHeaders:2 (headerName~2 headerValue~2){numHeaders}
+```
+
+### `arg2`: response meta data
+
+Binary schema:
+```
+statusCode:2
+message~2
+numHeaders:2 (headerName~2 headerValue~2){numHeaders}
+```
+
+Notes:
+- statusCode is the HTTP status code
+- message is utf-8 encoded
+- the headers section is to be implemented as a multi-map, or list of
+  pairs; a single-valued map is insufficient

--- a/docs/http.md
+++ b/docs/http.md
@@ -21,21 +21,25 @@ decisions must be made on the `service` field.
 Binary schema:
 ```
 method~1
-url~2
+url~N
 numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 ```
+
+Notes:
+- the url field's length is encoded as a varint
 
 ### `arg2`: response meta data
 
 Binary schema:
 ```
 statusCode:2
-message~2
+message~N
 numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 ```
 
 Notes:
 - statusCode is the HTTP status code
 - message is utf-8 encoded
+- the message field's length is encoded as a varint
 - the headers section is to be implemented as a multi-map, or list of
   pairs; a single-valued map is insufficient

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -40,7 +40,7 @@ function HTTPReqArg2(method, url, headerPairs) {
 
 HTTPReqArg2.RW = bufrw.Struct(HTTPReqArg2, {
     method: bufrw.str1,   // method~1
-    url: bufrw.str2,      // url~2
+    url: bufrw.strn,      // url~N
     headerPairs: headerRW // numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 });
 
@@ -53,7 +53,7 @@ function HTTPResArg2(statusCode, message, headerPairs) {
 
 HTTPResArg2.RW = bufrw.Struct(HTTPResArg2, {
     statusCode: bufrw.UInt16BE, // statusCode:2
-    message: bufrw.str2,        // message~2
+    message: bufrw.strn,        // message~N
     headerPairs: headerRW       // numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 });
 

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -1,0 +1,339 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var bufrw = require('bufrw');
+var http = require('http');
+var PassThrough = require('readable-stream').PassThrough;
+var extend = require('xtend');
+
+/*
+ * arg1: empty
+ *
+ * arg2: binary
+ * - requests
+ *   - schema:
+ *     method~1
+ *     url~2
+ *     numHeaders:2 (headerName~2 headerValue~2){numHeaders}
+ * - responses
+ *   - schema:
+ *     statusCode:2
+ *     message~2
+ *     numHeaders:2 (headerName~2 headerValue~2){numHeaders}
+ *   - notes:
+ *     - statusCode is the HTTP status code
+ *     - message is utf-8-encoded
+ *     - the headers section is to be implemented as a multi-map, or list of
+ *       pairs; a single-valued map is insufficient
+ *
+ * arg3: raw binary stream, all bytes after the double newline separator
+ */
+
+var headerRW = bufrw.Repeat(bufrw.UInt16BE,
+    bufrw.Series(bufrw.str2, bufrw.str2));
+
+module.exports = TChannelHTTP;
+
+function HTTPReqArg2(method, url, headerPairs) {
+    var self = this;
+    self.method = method || '';
+    self.url = url || '';
+    self.headerPairs = headerPairs || [];
+}
+
+HTTPReqArg2.RW = bufrw.Struct(HTTPReqArg2, {
+    method: bufrw.str1,
+    url: bufrw.str2,
+    headerPairs: headerRW
+});
+
+function HTTPResArg2(statusCode, message, headerPairs) {
+    var self = this;
+    self.statusCode = statusCode || 0;
+    self.message = message || '';
+    self.headerPairs = headerPairs || [];
+}
+
+HTTPResArg2.RW = bufrw.Struct(HTTPResArg2, {
+    statusCode: bufrw.UInt16BE,
+    message: bufrw.str2,
+    headerPairs: headerRW
+});
+
+function TChannelHTTP(options) {
+    if (!(this instanceof TChannelHTTP)) {
+        return new TChannelHTTP(options);
+    }
+}
+
+TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback) {
+    assert(treq.streamed, 'as http must have a streamed tchannel request');
+
+    if (typeof options === 'function') {
+        callback = options;
+        options = null;
+    }
+
+    var head = new HTTPReqArg2(hreq.method, hreq.url);
+    // TODO: get lower level access to raw request header pairs
+    var keys = Object.keys(hreq.headers);
+    for (var i = 0; i < keys.length; i++) {
+        head.headerPairs.push([keys[i], hreq.headers[keys[i]]]);
+    }
+
+    var arg1 = ''; // TODO: left empty for now, could compute circuit names heuristically
+    var arg2res = bufrw.toBufferResult(HTTPReqArg2.RW, head);
+    if (arg2res.err) {
+        callback(arg2res.err, null, null);
+        return;
+    }
+    var arg2 = arg2res.value;
+
+    treq.headers.as = 'http';
+    return treq.sendStreams(arg1, arg2, hreq, onResponse);
+
+    function onResponse(err, treq, tres) {
+        if (err) {
+            callback(err, null, null);
+        } else if (tres.streamed) {
+            tres.arg2.onValueReady(arg2Ready);
+        } else {
+            arg2Ready(null, tres.arg2);
+        }
+        function arg2Ready(err, arg2) {
+            if (err) {
+                callback(err, null, null);
+            } else {
+                readArg2(tres, arg2);
+            }
+        }
+    }
+
+    function readArg2(tres, arg2) {
+        // TODO: currently does the wrong thing and doesn't implement a
+        // multi-map, due to assuming node-like mangling on the other side
+        // to ensure singularity
+        var arg2res = bufrw.fromBufferResult(HTTPResArg2.RW, arg2);
+        if (arg2res.err) {
+            callback(arg2res.err, null, null);
+        } else if (tres.streamed) {
+            callback(null, arg2res.value, tres.arg3);
+        } else {
+            var body = PassThrough();
+            body.end(tres.arg3);
+            callback(null, arg2res.value, body);
+        }
+
+    }
+};
+
+TChannelHTTP.prototype.sendResponse = function send(buildResponse, hres, callback) {
+    // TODO: map http response codes onto error frames and application errors
+
+    var head = new HTTPResArg2(hres.statusCode, hres.statusMessage);
+    var keys = Object.keys(hres.headers);
+    for (var i = 0; i < keys.length; i++) {
+        head.headerPairs.push([keys[i], hres.headers[keys[i]]]);
+    }
+
+    var arg2res = bufrw.toBufferResult(HTTPResArg2.RW, head);
+    if (arg2res.err) {
+        // TODO: wrapped error
+        callback(arg2res.err, null, null);
+        buildResponse().sendError('UnexpectedError',
+            'Couldn\'t encode as-http response arg2: ' +
+            arg2res.err.message);
+        return;
+    }
+    var arg2 = arg2res.value;
+
+    return buildResponse({
+        streamed: true,
+        headers: {
+            as: 'http'
+        }
+    }).sendStreams(arg2, hres, callback);
+};
+
+TChannelHTTP.prototype.setHandler = function register(tchannel, handler) {
+    var self = this;
+    tchannel.handler = new AsHTTPHandler(self, tchannel, handler);
+    return tchannel.handler;
+};
+
+TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, hreq, hres) {
+    var self = this;
+
+    // TODO: no retrying due to:
+    // - streamed bypasses TChannelRequest
+    // - driving peer selection manually therefore
+    // TODO: more http state machine integration
+
+    var options = tchannel.requestOptions({
+        streamed: true
+    });
+    var peer = tchannel.peers.choosePeer(null, options);
+    if (!peer) {
+        hres.writeHead(503, 'Service Unavailable: no tchannel peer');
+        hres.end(); // TODO: error content
+        return null;
+    } else {
+        // TODO: observable
+        var treq = peer.request(options);
+        self.sendRequest(treq, hreq, forwarded);
+        return treq;
+    }
+
+    function forwarded(err, head, body) {
+        if (err) {
+            // TODO: better map of error type -> http status code, see
+            // tchannel/errors.classify
+            // TODO: observable
+            hres.writeHead(500, err.type + ' - ' + err.message);
+            hres.end(); // TODO: error content
+        } else {
+            // TODO: observable
+            // TODO: better lower level mapping of headerPairs
+            var headers = {};
+            for (var i = 0; i < head.headerPairs.length; i++) {
+                var pair = head.headerPairs[i];
+                headers[pair[0]] = pair[1];
+            }
+            hres.writeHead(head.statusCode, head.message, headers);
+            body.pipe(hres);
+        }
+    }
+};
+
+TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(ingressChan, options, inreq, outres) {
+    // TODO: should use lb_pool
+
+    options = extend(options, {
+        method: inreq.head.method,
+        path: inreq.head.url,
+        headers: {},
+        keepAlive: true
+    });
+    for (var i = 0; i < inreq.head.headerPairs.length; i++) {
+        var pair = inreq.head.headerPairs[i];
+        options.headers[pair[0]] = pair[1];
+    }
+
+    var sent = false;
+    // TODO: observable
+    var outreq = http.request(options, onResponse);
+    outreq.on('error', onError);
+    // TODO: more http state machine integration
+    inreq.body.pipe(outreq);
+
+    function onResponse(inres) {
+        if (!sent) {
+            sent = true;
+            // TODO: observable
+            outres.sendResponse(inres);
+        }
+    }
+
+    function onError(err) {
+        if (!sent) {
+            sent = true;
+            // TODO: observable
+            outres.sendError(err);
+        }
+    }
+};
+
+function AsHTTPHandler(asHTTP, channel, handler) {
+    if (typeof handler === 'function') {
+        handler = {handleRequest: handler}; // TODO: explicate type?
+    }
+    var self = this;
+    self.asHTTP = asHTTP;
+    self.channel = channel;
+    self.handler = handler;
+}
+
+AsHTTPHandler.prototype.handleRequest = function handleRequest(req, buildResponse) {
+    var self = this;
+    var hreq = {};
+
+    // TODO: real soon arg1 won't be streamable / fragmentable
+    if (req.streamed) {
+        req.arg1.onValueReady(onArg1);
+    } else {
+        onArg1(null, req.arg1);
+    }
+
+    function onArg1(err, arg1) {
+        if (err) {
+            sendError(err);
+        } else {
+            hreq.url = arg1;
+            req.withArg2(onArg2);
+        }
+    }
+
+    function onArg2(err, arg2) {
+        if (err) {
+            sendError(err);
+            return;
+        }
+
+        var arg2res = bufrw.fromBufferResult(HTTPReqArg2.RW, arg2);
+        if (arg2res.err) {
+            sendError(arg2res.err);
+            return;
+        }
+
+        hreq.head = arg2res.value;
+        if (req.streamed) {
+            hreq.body = req.arg3;
+        } else {
+            hreq.body = PassThrough();
+            hreq.body.end(req.arg3);
+        }
+
+        handle();
+    }
+
+    function handle() {
+        var hres = { // TODO: explicate type
+            head: new HTTPResArg2(200, 'Ok'),
+            sendError: sendError,
+            sendResponse: sendResponse
+        };
+        // TODO: observable
+        self.handler.handleRequest(hreq, hres);
+    }
+
+    function sendResponse(hres) {
+        self.asHTTP.sendResponse(buildResponse, hres, sendError);
+    }
+
+    function sendError(err) {
+        if (err) {
+            // TODO: map type?
+            buildResponse().sendError('UnexpectedError', err.message);
+        }
+    }
+};

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -26,29 +26,6 @@ var http = require('http');
 var PassThrough = require('readable-stream').PassThrough;
 var extend = require('xtend');
 
-/*
- * arg1: empty
- *
- * arg2: binary
- * - requests
- *   - schema:
- *     method~1
- *     url~2
- *     numHeaders:2 (headerName~2 headerValue~2){numHeaders}
- * - responses
- *   - schema:
- *     statusCode:2
- *     message~2
- *     numHeaders:2 (headerName~2 headerValue~2){numHeaders}
- *   - notes:
- *     - statusCode is the HTTP status code
- *     - message is utf-8-encoded
- *     - the headers section is to be implemented as a multi-map, or list of
- *       pairs; a single-valued map is insufficient
- *
- * arg3: raw binary stream, all bytes after the double newline separator
- */
-
 var headerRW = bufrw.Repeat(bufrw.UInt16BE,
     bufrw.Series(bufrw.str2, bufrw.str2));
 
@@ -62,9 +39,9 @@ function HTTPReqArg2(method, url, headerPairs) {
 }
 
 HTTPReqArg2.RW = bufrw.Struct(HTTPReqArg2, {
-    method: bufrw.str1,
-    url: bufrw.str2,
-    headerPairs: headerRW
+    method: bufrw.str1,   // method~1
+    url: bufrw.str2,      // url~2
+    headerPairs: headerRW // numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 });
 
 function HTTPResArg2(statusCode, message, headerPairs) {
@@ -75,9 +52,9 @@ function HTTPResArg2(statusCode, message, headerPairs) {
 }
 
 HTTPResArg2.RW = bufrw.Struct(HTTPResArg2, {
-    statusCode: bufrw.UInt16BE,
-    message: bufrw.str2,
-    headerPairs: headerRW
+    statusCode: bufrw.UInt16BE, // statusCode:2
+    message: bufrw.str2,        // message~2
+    headerPairs: headerRW       // numHeaders:2 (headerName~2 headerValue~2){numHeaders}
 });
 
 function TChannelHTTP(options) {

--- a/node/examples/http_egress.js
+++ b/node/examples/http_egress.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var parseArgs = require('minimist');
+var http = require('http');
+var TChannel = require('../channel');
+var TChannelAsHTTP = require('../as/http');
+
+var argv = parseArgs(process.argv.slice(2), {
+    default: {
+        bind: '127.0.0.1',
+        httpPort: 0,
+        tchannelPort: 0
+    },
+    alias: {
+        'tchannel-port': 'tchannelPort',
+        'http-port': 'httpPort'
+    }
+});
+
+function usage() {
+    console.error('usage http_relay [options] <serviceName>');
+    console.error('\nOptions:');
+    console.error('  --bind <address> (default: 127.0.0.1)');
+    console.error('  --http-port <port> (default: 0)');
+    console.error('  --tchannel-port <port> (default: 0)');
+    console.error('  --peers <host:port>[,<host:port>[,...]]');
+    process.exit(1);
+}
+
+if (argv._.length !== 1) usage();
+
+var serviceName = argv._[0];
+
+var asHTTP = TChannelAsHTTP();
+
+var tchan = TChannel();
+tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);
+
+var httpServer = http.createServer(onHTTPRequest);
+httpServer.listen(argv.httpPort, argv.bind, onHTTPListening);
+
+var svcChan = tchan.makeSubChannel({
+    serviceName: serviceName,
+    requestDefaults: {
+        serviceName: serviceName
+    }
+});
+
+if (argv.peers) {
+    argv.peers.split(/\s*,\s*/).forEach(function each(hostPort) {
+        var peer = svcChan.peers.add(hostPort);
+        console.log('added peer', peer.hostPort);
+    });
+}
+
+function onChannelListening() {
+    var addr = tchan.address();
+    console.log('tchannel listening on %s:%s', addr.address, addr.port);
+}
+
+function onHTTPListening() {
+    var addr = httpServer.address();
+    console.log('http listening on %s:%s', addr.address, addr.port);
+}
+
+function onHTTPRequest(hreq, hres) {
+    asHTTP.forwardToTChannel(svcChan, hreq, hres);
+}

--- a/node/examples/http_ingress.js
+++ b/node/examples/http_ingress.js
@@ -1,0 +1,90 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var parseArgs = require('minimist');
+var TChannel = require('../channel');
+var TChannelAsHTTP = require('../as/http');
+
+/* Minimal working example of an HTTP "bridge" over TChannel:
+ * 1) start an http service:
+ *    $ python -m SimpleHTTPServer # listens on port 8000
+ *
+ * 2) start an ingress proxy which will convert TChannel calls to http requests:
+ *    $ node examples/http_ingress.js --tchannel-port 4040 example 127.0.0.1:8000
+ *
+ * 3) start an egress proxy which will convert HTTP requests to TChannel calls:
+ *    $ node examples/http_egress.js --http-port 8080 --peers 127.0.0.1:4040
+ *
+ * 4) use it through the egress node:
+ *    $ curl http://localhost:8080 # or open in browser to taste
+ */
+
+var argv = parseArgs(process.argv.slice(2), {
+    default: {
+        bind: '127.0.0.1',
+        tchannelPort: 0
+    },
+    alias: {
+        'tchannel-port': 'tchannelPort'
+    }
+});
+
+function usage() {
+    console.error('usage http_relay [options] <serviceName> <dest>');
+    console.error('\nOptions:');
+    console.error('  --bind <address>');
+    console.error('  --tchannel-port <port>');
+    process.exit(1);
+}
+
+if (argv._.length !== 2) usage();
+
+var serviceName = argv._[0];
+var dest = argv._[1];
+var parts = dest.split(':');
+assert(parts.length === 2);
+
+var destHost = parts[0];
+var destPort = parts[1];
+
+var asHTTP = TChannelAsHTTP();
+
+var tchan = TChannel();
+tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);
+
+var svcChan = tchan.makeSubChannel({
+    serviceName: serviceName
+});
+asHTTP.setHandler(svcChan, onRequest);
+
+function onChannelListening() {
+    var addr = tchan.address();
+    console.log('tchannel listening on %s:%s', addr.address, addr.port);
+}
+
+function onRequest(inreq, outres) {
+    asHTTP.forwardToHTTP(svcChan, {
+        host: destHost,
+        port: destPort,
+    }, inreq, outres);
+}

--- a/node/package.json
+++ b/node/package.json
@@ -19,7 +19,7 @@
     "url": "git@github.com:uber/tchannel"
   },
   "dependencies": {
-    "bufrw": "^0.9.21",
+    "bufrw": "^0.9.23",
     "crc": "^3.2.1",
     "error": "^6.2.0",
     "farmhash": "^0.2.0",

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -1,0 +1,269 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var CountedReadySignal = require('ready-signal/counted');
+var extend = require('xtend');
+var http = require('http');
+var parallel = require('run-parallel');
+var PassThrough = require('readable-stream').PassThrough;
+var test = require('tape');
+
+var TChannelHTTP = require('../as/http.js');
+var allocCluster = require('./lib/alloc-cluster.js');
+
+allocHTTPTest('as/http can bridge a service', {
+    onServiceRequest: handleTestHTTPRequest
+}, function t(cluster, assert) {
+
+    var egressHost = cluster.httpEgress.address().address + ':' +
+                     cluster.httpEgress.address().port;
+
+    parallel([
+
+        cluster.sendRequest.thunk({
+            method: 'GET',
+            path: '/such/stuff',
+        }, null, {
+            statusCode: 200,
+            statusMessage: 'Ok',
+            body:
+                '{"request":{"method":"GET","url":"/such/stuff","headers":{"host":"' + egressHost + '","connection":"keep-alive"}}}\n'
+        }),
+
+        cluster.sendRequest.thunk({
+            method: 'PUT',
+            path: '/wat/even/is',
+            headers: {
+                'Content-Type': 'text/plain',
+                'X-Test-Header': 'test header value'
+            }
+        }, 'hello world', {
+            statusCode: 200,
+            statusMessage: 'Ok',
+            body:
+                '{"request":{"method":"PUT","url":"/wat/even/is","headers":{"content-type":"text/plain","x-test-header":"test header value","host":"' +
+                egressHost +
+                '","connection":"keep-alive","transfer-encoding":"chunked"}}}\n' +
+                '{"chunk":"hello world"}\n'
+        }),
+
+        cluster.sendRequest.thunk({
+            method: 'GET',
+            path: '/returnStatus/420/obviously',
+        }, null, {
+            statusCode: 420,
+            statusMessage: 'obviously',
+            body:
+                '{"request":{"method":"GET","url":"/returnStatus/420/obviously","headers":{"host":"' + egressHost + '","connection":"keep-alive"}}}\n'
+        }),
+
+    ], assert.end);
+});
+
+function handleTestHTTPRequest(hreq, hres) {
+    var statusCode = 200;
+    var statusMessage = 'Ok';
+    var match = /\/returnStatus\/(\d+)(?:\/(.*))?/.exec(hreq.url);
+    if (match) {
+        statusCode = parseInt(match[1]);
+        statusMessage = match[2] || '';
+    }
+
+    hres.writeHead(statusCode, statusMessage, {
+        'content-type': 'application/json'
+    });
+
+    hres.write(JSON.stringify({
+        request: {
+            method: hreq.method,
+            url: hreq.url,
+            headers: hreq.headers
+        }
+    }) + '\n');
+    hreq.on('data', onData);
+    hreq.on('end', onEnd);
+
+    function onData(chunk) {
+        hres.write(JSON.stringify({
+            chunk: String(chunk)
+        }) + '\n');
+    }
+
+    function onEnd() {
+        hres.end();
+    }
+}
+
+function allocHTTPTest(desc, opts, testFunc) {
+    test(desc, function t(assert) {
+        opts.assert = assert;
+        var cluster = allocHTTPBridge(opts);
+        assert.once('end', onAssertEnd);
+        cluster.ready(onReady);
+
+        function onAssertEnd() {
+            cluster.destroy();
+        }
+
+        function onReady() {
+            testFunc(cluster, assert);
+        }
+    });
+}
+
+function allocHTTPBridge(opts) {
+    // egress( HTTP -> TChannel ) -> ingress( TChannel -> HTTP )
+
+    var cluster = allocCluster({
+        numPeers: 2,
+        listen: [4040, 4041]
+    });
+    var tready = cluster.ready;
+    var tdestroy = cluster.destroy;
+
+    cluster.ready = CountedReadySignal(3);
+    cluster.destroy = destroy;
+    tready(cluster.ready.signal);
+    cluster.httpEgress = allocHTTPServer(opts.onEgressRequest, cluster.ready.signal);
+    cluster.httpService = allocHTTPServer(opts.onServiceRequest, cluster.ready.signal);
+
+    var serviceName = opts.serviceName || 'test_http';
+    var chanOpts = {
+        serviceName: serviceName,
+        requestDefaults: {
+            serviceName: serviceName
+        }
+    };
+
+    cluster.ingressServer = cluster.channels[0];
+    cluster.egressServer = cluster.channels[1];
+
+    cluster.ingressChan = cluster.ingressServer.makeSubChannel(chanOpts);
+    cluster.egressChan = cluster.egressServer.makeSubChannel(chanOpts);
+
+    cluster.asHTTP = new TChannelHTTP();
+    cluster.asHTTP.setHandler(cluster.ingressChan, onIngressRequest);
+    cluster.httpEgress.on('request', onEgressRequest);
+
+    cluster.requestOptions = {
+        keepAlive: true
+    };
+    cluster.sendRequest = testRequester(opts.assert, cluster.requestOptions);
+
+    cluster.ready(onReady);
+
+    function onReady() {
+        if (!cluster.ingressServer.hostPort) throw new Error('no ingress hostPort');
+        cluster.egressChan.peers.add(cluster.ingressServer.hostPort);
+
+        var addr = cluster.httpEgress.address();
+        cluster.requestOptions.host = addr.address;
+        cluster.requestOptions.port = addr.port;
+    }
+
+    function onIngressRequest(treq, tres) {
+        var addr = cluster.httpService.address();
+        cluster.asHTTP.forwardToHTTP(cluster.ingressChan, {
+            host: addr.address,
+            port: addr.port
+        }, treq, tres);
+    }
+
+    function onEgressRequest(hreq, hres) {
+        cluster.asHTTP.forwardToTChannel(cluster.egressChan, hreq, hres);
+    }
+
+    function destroy(callback) {
+        var closed = CountedReadySignal(3);
+        tdestroy(closed.signal);
+        cluster.httpEgress.close(closed.signal);
+        cluster.httpService.close(closed.signal);
+        if (callback) closed(callback);
+    }
+
+    return cluster;
+}
+
+function testRequester(assert, baseOptions) {
+    testRequest.thunk = testRequestBind;
+    return testRequest;
+
+    function testRequestBind(options, body, expected) {
+        return function testRequestThunk(callback) {
+            testRequest(options, body, expected, callback);
+        };
+    }
+
+    function testRequest(options, body, expected, callback) {
+        if (typeof expected === 'function') {
+            callback = expected;
+            expected = body;
+            body = null;
+        }
+
+        options = extend(baseOptions, options);
+        var req = http.request(options, onResponse);
+
+        if (!options.host) throw new Error('no host specified');
+        if (!options.port) throw new Error('no port specified');
+
+        var buf = PassThrough();
+        var called = false;
+        req.on('error', onError);
+        if (body) req.write(body);
+        req.end();
+
+        function onError(err) {
+            if (!called) {
+                called = true;
+                callback(err);
+            }
+        }
+
+        function onResponse(res) {
+            if (!called) {
+                called = true;
+                assert.equal(res.statusCode, expected.statusCode, 'expected status code');
+
+                // TODO: >= 0.12
+                // assert.equal(res.statusMessage, expected.statusMessage, 'expected status message');
+
+                res.on('end', onEnd);
+                res.pipe(buf);
+            }
+        }
+
+        function onEnd() {
+            assert.equal(String(buf.read()), expected.body, 'expected body');
+            callback(null);
+        }
+    }
+}
+
+function allocHTTPServer(onRequest, callback) {
+    var httpServer = http.createServer(onRequest);
+    httpServer.listen(0, '127.0.0.1', onListening);
+    return httpServer;
+    function onListening() {
+        callback();
+    }
+}

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -38,6 +38,7 @@ require('./v2/index.js');
 require('./regression-listening-on-used-port.js');
 require('./as-thrift.js');
 require('./as-json.js');
+require('./as-http.js');
 require('./peers.js');
 require('./peer_states.js');
 require('./trace/');


### PR DESCRIPTION
Minimal working example of an HTTP "bridge" over TChannel:
1) start an http service:
```
$ python -m SimpleHTTPServer # listens on port 8000
```
2) start an ingress proxy which will convert TChannel calls to http requests:
```
$ node examples/http_ingress.js --tchannel-port 4040 example 127.0.0.1:8000
```

3) start an egress proxy which will convert HTTP requests to TChannel calls: 
```
$ node examples/http_egress.js --http-port 8080 --peers 127.0.0.1:4040
```

4) use it through the egress node:
```
$ curl http://localhost:8080 # or open in browser to taste
```