### PR TITLE
Improving as/thrift with header & error supports

### DIFF
--- a/node/as/json.js
+++ b/node/as/json.js
@@ -203,7 +203,7 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
 
     var headR = safeJSONStringify(opts.head);
     if (headR.err) {
-        var headStringifyErr = errors.HeadStringifyError(headR.err, {
+        var headStringifyErr = errors.JSONHeadStringifyError(headR.err, {
             endpoint: opts.endpoint,
             direction: opts.direction,
             head: cyclicStringify(opts.head)
@@ -219,7 +219,7 @@ TChannelJSON.prototype._stringify = function stringify(opts) {
 
     var bodyR = safeJSONStringify(opts.body);
     if (bodyR.err) {
-        var bodyStringifyErr = errors.BodyStringifyError(bodyR.err, {
+        var bodyStringifyErr = errors.JSONBodyStringifyError(bodyR.err, {
             endpoint: opts.endpoint,
             direction: opts.direction,
             body: cyclicStringify(opts.body)
@@ -244,7 +244,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
 
     var headR = safeJSONParse(opts.head);
     if (headR.err) {
-        var headParseErr = errors.HeadParserError(headR.err, {
+        var headParseErr = errors.JSONHeadParserError(headR.err, {
             endpoint: opts.endpoint,
             direction: opts.direction,
             headStr: opts.head.slice(0, 10)
@@ -263,7 +263,7 @@ TChannelJSON.prototype._parse = function parse(opts) {
 
     var bodyR = safeJSONParse(opts.body);
     if (bodyR.err) {
-        var bodyParseErr = errors.BodyParserError(bodyR.err, {
+        var bodyParseErr = errors.JSONBodyParserError(bodyR.err, {
             endpoint: opts.endpoint,
             direction: opts.direction,
             bodyStr: opts.body.slice(0, 10)

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2015 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -35,7 +35,7 @@ var HeaderRW = bufrw.Repeat(
 module.exports = TChannelAsThrift;
 
 function TChannelAsThrift(opts) {
-    if (!this instanceof TChannelAsThrift) {
+    if (!(this instanceof TChannelAsThrift)) {
         return new TChannelAsThrift(opts);
     }
 

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2015 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,77 +22,115 @@
 'use strict';
 
 var assert = require('assert');
+var bufrw = require('bufrw');
+var Result = require('bufrw/result');
+
+var errors = require('../errors.js');
+
+var HeaderRW = bufrw.Repeat(
+    bufrw.UInt16BE,
+    bufrw.Series(bufrw.str2, bufrw.str2)
+);
 
 module.exports = TChannelAsThrift;
 
 function TChannelAsThrift(opts) {
+    if (!this instanceof TChannelAsThrift) {
+        return new TChannelAsThrift(opts);
+    }
+
     var self = this;
+
     assert(opts && opts.spec, 'TChannelAsThrift expected spec');
     self.spec = opts.spec;
 
+    self.logger = null;
+
     var bossMode = opts && opts.bossMode;
     self.bossMode = typeof bossMode === 'boolean' ? bossMode : false;
+
+    var logParseFailures = opts && opts.logParseFailures;
+    self.logParseFailures = typeof logParseFailures === 'boolean' ?
+        logParseFailures : true;
 }
 
 TChannelAsThrift.prototype.register =
 function register(channel, name, opts, handle) {
     var self = this;
 
-    var argsName = name + '_args';
-    var argsType = self.spec.getType(argsName);
-
-    var returnName = name + '_result';
-    var resultType = self.spec.getType(returnName);
+    if (!self.logger) {
+        self.logger = channel.logger;
+    }
 
     channel.register(name, handleThriftRequest);
 
     function handleThriftRequest(req, res, inHeadBuffer, inBodyBuffer) {
-
         if (req.headers.as !== 'thrift') {
-            return res.sendError('BadRequest', 'Expected as=thrift TChannel request header');
+            var message = 'Expected call request as header to be thrift';
+            return res.sendError('BadRequest', message);
         }
 
         // Process incoming thrift body
-        var inBodyResult = argsType.fromBuffer(inBodyBuffer);
-        if (inBodyResult.err) {
-            return res.sendError('BadRequest', inBodyResult.err.message);
+        var parseResult = self._parse({
+            head: inHeadBuffer,
+            body: inBodyBuffer,
+            endpoint: name,
+            direction: 'in.request'
+        });
+
+        if (parseResult.err) {
+            var message2 = parseResult.err.type + ': ' +
+                parseResult.err.message;
+            return res.sendError('BadRequest', message2);
         }
-        var inBody = inBodyResult.value;
 
-        // TODO process inHeadBuffer into inHead
-        var inHead = null;
-
-        handle(opts, req, inHead, inBody, handleThriftResponse);
+        var v = parseResult.value;
+        handle(opts, req, v.head, v.body, handleThriftResponse);
 
         function handleThriftResponse(err, thriftRes) {
             if (err) {
-                return res.sendError('UnexpectedError', err.message);
+                assert(isError(err), 'Error argument must be an error');
+
+                self.logger.error('Got unexpected error in handler', {
+                    endpoint: name,
+                    err: err
+                });
+
+                return res.sendError('UnexpectedError', 'Unexpected Error');
             }
 
-            assert(typeof thriftRes.ok === 'boolean',
-                'expected response.ok to be a boolean');
+            if (!self.bossMode) {
+                assert(typeof thriftRes.ok === 'boolean',
+                    'expected response.ok to be a boolean');
+                assert(thriftRes.body !== undefined,
+                    'expected response.body to exist');
 
-            var outResult = {};
-            var outBody = thriftRes.body;
-            if (!thriftRes.ok) {
-                outResult[outBody.nameAsThrift] = outBody;
-            } else {
-                outResult.success = outBody;
-            }
-
-            var outRes = resultType.toBuffer(outResult);
-
-            if (outRes.err && self.bossMode) {
-                return res.sendError('UnexpectedError', outRes.err.message);
-            } else {
-                var outHeadBuffer = null;
-                var outBodyBuffer = outRes.toValue();
-                if (thriftRes.ok) {
-                    return res.sendOk(outHeadBuffer, outBodyBuffer);
-                } else {
-                    return res.sendNotOk(outHeadBuffer, outBodyBuffer);
+                if (!thriftRes.ok) {
+                    assert(isError(thriftRes.body),
+                        'not-ok body should be an error');
+                    assert(thriftRes.body.nameAsThrift,
+                        'expected not-ok body to have nameAsThrift field');
                 }
             }
+
+            var stringifyResult = self._stringify({
+                head: thriftRes.head,
+                body: thriftRes.body,
+                ok: thriftRes.ok,
+                endpoint: name,
+                direction: 'out.response'
+            });
+
+            if (stringifyResult.err) {
+                return res.sendError('UnexpectedError',
+                    'Could not serialize thrift');
+            }
+
+            res.setOk(thriftRes.ok);
+            res.send(
+                stringifyResult.value.head,
+                stringifyResult.value.body
+            );
         }
     }
 };
@@ -102,51 +141,210 @@ function send(request, endpoint, outHead, outBody, callback) {
     var self = this;
 
     assert(typeof endpoint === 'string', 'send requires endpoint');
+    assert(typeof request.serviceName === 'string' &&
+        request.serviceName !== '',
+        'req.serviceName must be a string');
 
-    var argsType = self.spec.getType(endpoint + '_args');
-    var resultType = self.spec.getType(endpoint + '_result');
-
-    var outRes = argsType.toBuffer(outBody);
-    if (outRes.err) {
-        callback(outRes.err, null);
-        return;
+    var stringifyResult = self._stringify({
+        head: outHead,
+        body: outBody,
+        endpoint: endpoint,
+        direction: 'out.request'
+    });
+    if (stringifyResult.err) {
+        return callback(stringifyResult.err);
     }
 
-    var outHeadBuffer = null;
-    var outBodyBuffer = outRes.value;
-
     // Punch as=thrift into the transport headers
-    request.headers.as = "thrift";
+    request.headers.as = 'thrift';
 
-    request.send(endpoint, outHeadBuffer, outBodyBuffer, handleResponse);
+    request.send(
+        endpoint,
+        stringifyResult.value.head,
+        stringifyResult.value.body,
+        handleResponse
+    );
 
     function handleResponse(err, res, arg2, arg3) {
         if (err) {
             return callback(err);
         }
 
-        var inBodyResult = resultType.fromBuffer(arg3);
-        if (inBodyResult.err) {
-            return inBodyResult.toCallback(callback); // TODO WrappedError
+        var parseResult = self._parse({
+            head: arg2,
+            body: arg3,
+            ok: res.ok,
+            endpoint: endpoint,
+            direction: 'in.response'
+        });
+
+        if (parseResult.err) {
+            return callback(parseResult.err);
         }
 
-        var inBody;
+        var v = parseResult.value;
+        var resp;
+
         if (res.ok) {
-            inBody = inBodyResult.value.success;
+            resp = new TChannelThriftResponse(res.ok, v.head, v.body);
         } else {
-            inBody = onlyProperty(inBodyResult.value);
+            resp = new TChannelThriftResponse(
+                res.ok, v.head, errors.ReconstructedError(v.body)
+            );
         }
 
-        // TODO translate inHeadBuffer into inHead
-        // var inHeadBuffer = arg2;
-        var inHead = null;
-
-        callback(null, new Response(res.ok, inHead, inBody));
+        callback(null, resp);
     }
-
 };
 
-function Response(ok, head, body) {
+TChannelAsThrift.prototype._parse = function parse(opts) {
+    var self = this;
+
+    var argsName = opts.endpoint + '_args';
+    var argsType = self.spec.getType(argsName);
+
+    var returnName = opts.endpoint + '_result';
+    var resultType = self.spec.getType(returnName);
+
+    var headR = bufrw.fromBufferResult(HeaderRW, opts.head);
+    if (headR.err) {
+        var headParseErr = errors.ThriftHeadParserError(headR.err, {
+            endpoint: opts.endpoint,
+            direction: opts.direction,
+            ok: opts.ok,
+            headBuf: opts.head.slice(0, 10)
+        });
+
+        if (self.logParseFailures) {
+            self.logger.warn('Got unexpected invalid thrift arg2', {
+                endpoint: opts.endpoint,
+                direction: opts.direction,
+                ok: opts.ok,
+                headErr: headParseErr
+            });
+        }
+
+        return new Result(headParseErr);
+    }
+
+    var bodyR;
+    if (opts.direction === 'in.request') {
+        bodyR = argsType.fromBuffer(opts.body);
+    } else if (opts.direction === 'in.response') {
+        bodyR = resultType.fromBuffer(opts.body);
+
+        if (bodyR.value && opts.ok) {
+            bodyR.value = bodyR.value.success;
+        } else if (bodyR.value && !opts.ok) {
+            bodyR.value = onlyProperty(bodyR.value);
+        }
+    }
+
+    if (bodyR.err) {
+        var bodyParseErr = errors.ThriftBodyParserError(bodyR.err, {
+            endpoint: opts.endpoint,
+            direction: opts.direction,
+            ok: opts.ok,
+            bodyBuf: opts.body.slice(0, 10)
+        });
+
+        if (self.logParseFailures) {
+            self.logger.warn('Got unexpected invalid thrift for arg3', {
+                endpoint: opts.endpoint,
+                ok: opts.ok,
+                direction: opts.direction,
+                bodyErr: bodyParseErr
+            });
+        }
+
+        return new Result(bodyParseErr);
+    }
+
+    var headers = {};
+    for (var i = 0; i < headR.value.length; i++) {
+        var pair = headR.value[i];
+        headers[pair[0]] = pair[1];
+    }
+
+    return new Result(null, {
+        head: headers,
+        body: bodyR.value
+    });
+};
+
+TChannelAsThrift.prototype._stringify = function stringify(opts) {
+    var self = this;
+
+    var argsName = opts.endpoint + '_args';
+    var argsType = self.spec.getType(argsName);
+
+    var returnName = opts.endpoint + '_result';
+    var resultType = self.spec.getType(returnName);
+
+    opts.head = opts.head || {};
+    var headers = Object.keys(opts.head);
+
+    var headerPairs = [];
+    for (var i = 0; i < headers.length; i++) {
+        headerPairs.push([headers[i], opts.head[headers[i]]]);
+    }
+
+    var headR = bufrw.toBufferResult(HeaderRW, headerPairs);
+    if (headR.err) {
+        var headStringifyErr = errors.ThriftHeadStringifyError(headR.err, {
+            endpoint: opts.endpoint,
+            ok: opts.ok,
+            direction: opts.direction,
+            head: opts.head
+        });
+
+        self.logger.error('Got unexpected unserializable thrift for arg2', {
+            endpoint: opts.endpoint,
+            ok: opts.ok,
+            direction: opts.direction,
+            headErr: headStringifyErr
+        });
+        return new Result(headStringifyErr);
+    }
+
+    var bodyR;
+    if (opts.direction === 'out.request') {
+        bodyR = argsType.toBuffer(opts.body);
+    } else if (opts.direction === 'out.response') {
+        var thriftResult = {};
+        if (!opts.ok) {
+            thriftResult[opts.body.nameAsThrift] = opts.body;
+        } else {
+            thriftResult.success = opts.body;
+        }
+
+        bodyR = resultType.toBuffer(thriftResult);
+    }
+
+    if (bodyR.err) {
+        var bodyStringifyErr = errors.ThriftBodyStringifyError(bodyR.err, {
+            endpoint: opts.endpoint,
+            ok: opts.ok,
+            direction: opts.direction,
+            body: opts.body
+        });
+
+        self.logger.error('Got unexpected unserializable thrift for arg3', {
+            endpoint: opts.endpoint,
+            direction: opts.direction,
+            ok: opts.ok,
+            bodyErr: bodyStringifyErr
+        });
+        return new Result(bodyStringifyErr);
+    }
+
+    return new Result(null, {
+        head: headR.value,
+        body: bodyR.value
+    });
+};
+
+function TChannelThriftResponse(ok, head, body) {
     var self = this;
     self.ok = ok;
     self.head = head;
@@ -161,4 +359,8 @@ function onlyProperty(object) {
             return object[name];
         }
     }
+}
+
+function isError(err) {
+    return Object.prototype.toString.call(err) === '[object Error]';
 }

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -26,10 +26,7 @@ var Result = require('bufrw/result');
 
 var errors = require('../errors.js');
 
-var HeaderRW = bufrw.Repeat(
-    bufrw.UInt16BE,
-    bufrw.Series(bufrw.str2, bufrw.str2)
-);
+var HeaderRW = require('../v2/header.js').header2;
 
 module.exports = TChannelAsThrift;
 
@@ -258,14 +255,8 @@ TChannelAsThrift.prototype._parse = function parse(opts) {
         return new Result(bodyParseErr);
     }
 
-    var headers = {};
-    for (var i = 0; i < headRes.value.length; i++) {
-        var pair = headRes.value[i];
-        headers[pair[0]] = pair[1];
-    }
-
     return new Result(null, {
-        head: headers,
+        head: headRes.value,
         body: bodyRes.value
     });
 };
@@ -280,14 +271,8 @@ TChannelAsThrift.prototype._stringify = function stringify(opts) {
     var resultType = self.spec.getType(returnName);
 
     opts.head = opts.head || {};
-    var headers = Object.keys(opts.head);
 
-    var headerPairs = [];
-    for (var i = 0; i < headers.length; i++) {
-        headerPairs.push([headers[i], opts.head[headers[i]]]);
-    }
-
-    var headRes = bufrw.toBufferResult(HeaderRW, headerPairs);
+    var headRes = bufrw.toBufferResult(HeaderRW, opts.head);
     if (headRes.err) {
         var headStringifyErr = errors.ThriftHeadStringifyError(headRes.err, {
             endpoint: opts.endpoint,

--- a/node/errors.js
+++ b/node/errors.js
@@ -266,7 +266,8 @@ module.exports.ThriftBodyParserError = WrappedError({
     type: 'tchannel-thrift-handler.parse-error.body-failed',
     message: 'Could not parse body (arg3) argument.\n' +
         'Expected Thrift encoded arg3 for endpoint {endpoint}.\n' +
-        'Got {bodyBuf} instead of Thrift.',
+        'Got {bodyBuf} instead of Thrift.\n' +
+        'Parsing error was: {causeMessage}.\n',
     isSerializationError: true,
     endpoint: null,
     direction: null,
@@ -289,7 +290,8 @@ module.exports.ThriftHeadParserError = WrappedError({
     type: 'tchannel-thrift-handler.parse-error.head-failed',
     message: 'Could not parse head (arg2) argument.\n' +
         'Expected Thrift encoded arg2 for endpoint {endpoint}.\n' +
-        'Got {headBuf} instead of Thrift.',
+        'Got {headBuf} instead of Thrift.\n' +
+        'Parsing error was: {causeMessage}.\n',
     isSerializationError: true,
     endpoint: null,
     ok: null,

--- a/node/errors.js
+++ b/node/errors.js
@@ -44,27 +44,6 @@ module.exports.Arg1OverLengthLimit = TypedError({
     limit: null
 });
 
-module.exports.BodyParserError = WrappedError({
-    type: 'tchannel-handler.parse-error.body-failed',
-    message: 'Could not parse body (arg3) argument.\n' +
-        'Expected JSON encoded arg3 for endpoint {endpoint}.\n' +
-        'Got {bodyStr} instead of JSON.',
-    isSerializationError: true,
-    endpoint: null,
-    direction: null,
-    bodyStr: null
-});
-
-module.exports.BodyStringifyError = WrappedError({
-    type: 'tchannel-handler.stringify-error.body-failed',
-    message: 'Could not stringify body (res2) argument.\n' +
-        'Expected JSON serializable res2 for endpoint {endpoint}.',
-    isSerializationError: true,
-    endpoint: null,
-    body: null,
-    direction: null
-});
-
 module.exports.ChecksumError = TypedError({
     type: 'tchannel.checksum',
     message: 'invalid checksum (type {checksumType}) expected: {expectedValue} actual: {actualValue}',
@@ -81,27 +60,6 @@ module.exports.DuplicateHeaderKeyError = TypedError({
     key: null,
     value: null,
     priorValue: null
-});
-
-module.exports.HeadParserError = WrappedError({
-    type: 'tchannel-handler.parse-error.head-failed',
-    message: 'Could not parse head (arg2) argument.\n' +
-        'Expected JSON encoded arg2 for endpoint {endpoint}.\n' +
-        'Got {headStr} instead of JSON.',
-    isSerializationError: true,
-    endpoint: null,
-    direction: null,
-    headStr: null
-});
-
-module.exports.HeadStringifyError = WrappedError({
-    type: 'tchannel-handler.stringify-error.head-failed',
-    message: 'Could not stringify head (res1) argument.\n' +
-        'Expected JSON serializable res1 for endpoint {endpoint}.',
-    isSerializationError: true,
-    endpoint: null,
-    head: null,
-    direction: null
 });
 
 module.exports.InvalidArgumentError = TypedError({
@@ -144,6 +102,48 @@ module.exports.InvalidJSONBody = TypedError({
     isSerializationError: true,
     head: null,
     body: null
+});
+
+module.exports.JSONBodyParserError = WrappedError({
+    type: 'tchannel-json-handler.parse-error.body-failed',
+    message: 'Could not parse body (arg3) argument.\n' +
+        'Expected JSON encoded arg3 for endpoint {endpoint}.\n' +
+        'Got {bodyStr} instead of JSON.',
+    isSerializationError: true,
+    endpoint: null,
+    direction: null,
+    bodyStr: null
+});
+
+module.exports.JSONBodyStringifyError = WrappedError({
+    type: 'tchannel-json-handler.stringify-error.body-failed',
+    message: 'Could not stringify body (res2) argument.\n' +
+        'Expected JSON serializable res2 for endpoint {endpoint}.',
+    isSerializationError: true,
+    endpoint: null,
+    body: null,
+    direction: null
+});
+
+module.exports.JSONHeadParserError = WrappedError({
+    type: 'tchannel-json-handler.parse-error.head-failed',
+    message: 'Could not parse head (arg2) argument.\n' +
+        'Expected JSON encoded arg2 for endpoint {endpoint}.\n' +
+        'Got {headStr} instead of JSON.',
+    isSerializationError: true,
+    endpoint: null,
+    direction: null,
+    headStr: null
+});
+
+module.exports.JSONHeadStringifyError = WrappedError({
+    type: 'tchannel-json-handler.stringify-error.head-failed',
+    message: 'Could not stringify head (res1) argument.\n' +
+        'Expected JSON serializable res1 for endpoint {endpoint}.',
+    isSerializationError: true,
+    endpoint: null,
+    head: null,
+    direction: null
 });
 
 module.exports.MaxPendingError = TypedError({

--- a/node/errors.js
+++ b/node/errors.js
@@ -262,6 +262,52 @@ module.exports.TChannelWriteProtocolError = WrappedError({
     localName: null
 });
 
+module.exports.ThriftBodyParserError = WrappedError({
+    type: 'tchannel-thrift-handler.parse-error.body-failed',
+    message: 'Could not parse body (arg3) argument.\n' +
+        'Expected Thrift encoded arg3 for endpoint {endpoint}.\n' +
+        'Got {bodyBuf} instead of Thrift.',
+    isSerializationError: true,
+    endpoint: null,
+    direction: null,
+    ok: null,
+    bodyBuf: null
+});
+
+module.exports.ThriftBodyStringifyError = WrappedError({
+    type: 'tchannel-thrift-handler.stringify-error.body-failed',
+    message: 'Could not stringify body (res2) argument.\n' +
+        'Expected Thrift serializable res2 for endpoint {endpoint}.',
+    isSerializationError: true,
+    endpoint: null,
+    ok: null,
+    body: null,
+    direction: null
+});
+
+module.exports.ThriftHeadParserError = WrappedError({
+    type: 'tchannel-thrift-handler.parse-error.head-failed',
+    message: 'Could not parse head (arg2) argument.\n' +
+        'Expected Thrift encoded arg2 for endpoint {endpoint}.\n' +
+        'Got {headBuf} instead of Thrift.',
+    isSerializationError: true,
+    endpoint: null,
+    ok: null,
+    direction: null,
+    headBuf: null
+});
+
+module.exports.ThriftHeadStringifyError = WrappedError({
+    type: 'tchannel-thrift-handler.stringify-error.head-failed',
+    message: 'Could not stringify head (res1) argument.\n' +
+        'Expected Thrift serializable res1 for endpoint {endpoint}.',
+    isSerializationError: true,
+    endpoint: null,
+    ok: null,
+    head: null,
+    direction: null
+});
+
 module.exports.TimeoutError = TypedError({
     type: 'tchannel.timeout',
     message: 'timed out after {elapsed}ms (limit was {timeout}ms)',

--- a/node/test/anechoic-chamber.thrift
+++ b/node/test/anechoic-chamber.thrift
@@ -20,10 +20,18 @@
 
 exception NoEchoError {
     1: required i32 value
+    2: required string message
+}
+
+exception NoEchoTypedError {
+    1: required i32 value
+    2: required string message
+    3: required string type
 }
 
 service Chamber {
     i32 echo(0: i32 value) throws (
         1: NoEchoError noEcho
+        2: NoEchoTypedError noEchoTyped
     )
 }

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -157,7 +157,7 @@ allocCluster.test('getting a BadRequest frame', {
         assert.equal(err.isErrorFrame, true);
         assert.equal(err.codeName, 'BadRequest');
         assert.equal(err.message,
-            'tchannel-handler.parse-error.head-failed: Could not ' +
+            'tchannel-json-handler.parse-error.head-failed: Could not ' +
                 'parse head (arg2) argument.\n' +
                 'Expected JSON encoded arg2 for endpoint echo.\n' +
                 'Got 123malform instead of JSON.'

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -25,7 +25,6 @@
 var TypedError = require('error/typed');
 
 var TChannelJSON = require('../as/json.js');
-
 var allocCluster = require('./lib/alloc-cluster.js');
 
 allocCluster.test('getting an ok response', {

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -217,7 +217,9 @@ function makeTChannelJSONServer(cluster, opts) {
         opts.networkFailureResponse ? networkFailureHandler :
             networkFailureHandler;
 
-    var tchannelJSON = TChannelJSON();
+    var tchannelJSON = TChannelJSON({
+        logParseFailures: false
+    });
     tchannelJSON.register(server, 'echo', options, fn);
 
     return tchannelJSON;

--- a/node/test/bad-anechoic-chamber.thrift
+++ b/node/test/bad-anechoic-chamber.thrift
@@ -30,7 +30,7 @@ exception NoEchoTypedError {
 }
 
 service Chamber {
-    i32 echo(0: required i32 value) throws (
+    i32 echo(0: required string value) throws (
         1: NoEchoError noEcho
         2: NoEchoTypedError noEchoTyped
     )


### PR DESCRIPTION
This PR adds a bunch of cleanup to bring the
as thrift implementation inline with as json

 - Implement parsing & serializing of arg2 for as thrift
 - Add logging of serialization errors and logging
    of parsing warnings to as/thrift
 - Grabs the logger from tchannel
 - Send a bad request with more details for parsing failures
 - Send back an UnexpectedError for errors in the callback
 - Send back an UnexpectedError for response serialization failure
 - Reconstruct an error object from not ok call responses.

r: @jcorbin @kriskowal