### PR TITLE
TODO: mishandling of streaming responses (and especially their erros) between handler and connnection

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -190,6 +190,9 @@ TChannelConnection.prototype.handleReadFrame = function handleReadFrame(frame) {
 
 TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
     var self = this;
+    // TODO: only pop req if res is done/error, otherwise it's streaming and we
+    // should need to register finish / error event handlers to .popOutReq only
+    // once the call is done
     var req = self.popOutReq(res.id);
     if (!req) {
         self.logger.info('response received for unknown or lost operation', {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -284,6 +284,12 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
     if (id === v2.Frame.NullId) {
         // fatal error not associated with a prior frame
         callback(err);
+    // TODO: unless we fix TChannelConnection#onCallResponse to keep streamed
+    // responses until termination, we need to check here for streaming and
+    // emit errors on the response directly:
+    //     } else if (self.streamingRes[id]) {
+    //         var res = self.streamingRes[id];
+    //         res.errorEvent.emit(res, err);
     } else {
         self.callIncomingErrorEvent.emit(self, err);
         callback();


### PR DESCRIPTION
This bug will be especially insidious if we ever have a streamed call req/res that lasts for longer than it takes to cycle frame id space (~4 billion calls on a connection).  However (un)likely this is for any single service, such a probability is compounded for a forwarding entity.

I discovered this bug while reviewing #542 while considering the response arg1 too large error handling path.

cc @ShanniLi @kriskowal 