### PR TITLE
Make {req,res}.send/.sendStreams consistent

### DIFF
--- a/node/out_response.js
+++ b/node/out_response.js
@@ -211,6 +211,7 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
     var self = this;
     self.sendCallResponseFrame([self.arg1, res1, res2], true);
     self.finishEvent.emit(self);
+    return self;
 };
 
 module.exports = TChannelOutResponse;

--- a/node/streaming_out_request.js
+++ b/node/streaming_out_request.js
@@ -76,6 +76,7 @@ StreamingOutRequest.prototype.sendStreams = function sendStreams(arg1, arg2, arg
     pipelineStreams(
         [arg1, arg2, arg3],
         [self.arg1, self.arg2, self.arg3]);
+    return self;
 };
 
 module.exports = StreamingOutRequest;

--- a/node/streaming_out_response.js
+++ b/node/streaming_out_response.js
@@ -99,12 +99,29 @@ StreamingOutResponse.prototype.send = function send(res1, res2) {
     return self;
 };
 
-StreamingOutResponse.prototype.sendStreams = function sendStreams(res1, res2) {
+StreamingOutResponse.prototype.sendStreams = function sendStreams(res1, res2, callback) {
     var self = this;
+    var called = false;
+    self.errorEvent.on(onError);
     pipelineStreams(
         [res1, res2],
-        [self.arg2, self.arg3]);
+        [self.arg2, self.arg3],
+        finish);
     return self;
+
+    function onError(err) {
+        if (!called) {
+            called = true;
+            if (callback) callback(err);
+        }
+    }
+
+    function finish() {
+        if (!called) {
+            called = true;
+            if (callback) callback(null);
+        }
+    }
 };
 
 module.exports = StreamingOutResponse;

--- a/node/streaming_out_response.js
+++ b/node/streaming_out_response.js
@@ -96,6 +96,7 @@ StreamingOutResponse.prototype.send = function send(res1, res2) {
     var self = this;
     self.arg2.end(res1);
     self.arg3.end(res2);
+    return self;
 };
 
 StreamingOutResponse.prototype.sendStreams = function sendStreams(res1, res2) {
@@ -103,6 +104,7 @@ StreamingOutResponse.prototype.sendStreams = function sendStreams(res1, res2) {
     pipelineStreams(
         [res1, res2],
         [self.arg2, self.arg3]);
+    return self;
 };
 
 module.exports = StreamingOutResponse;


### PR DESCRIPTION
- return `self` for chaining
- take callbacks

r @kriskowal 