### PR TITLE
Emit stats for outbound call requests

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -61,6 +61,7 @@ function TChannel(options) {
     self.listeningEvent = self.defineEvent('listening');
     self.connectionEvent = self.defineEvent('connection');
     self.requestEvent = self.defineEvent('request');
+    self.statEvent = self.defineEvent('stat');
 
     self.options = extend({
         timeoutCheckInterval: 1000,
@@ -68,6 +69,9 @@ function TChannel(options) {
         // TODO: maybe we should always add pid to user-supplied?
         processName: format('%s[%s]', process.title, process.pid)
     }, options);
+
+    // must have 'app', 'host', 'cluster', 'version'
+    self.statTags = self.options.statTags || {};
 
     self.requestDefaults = extend({
         timeout: TChannelRequest.defaultTimeout
@@ -437,6 +441,20 @@ TChannel.prototype.close = function close(callback) {
             }
         }
     }
+};
+
+TChannel.prototype.emitStat = function emitStat(stat) {
+    var self = this;
+
+    var commonTags = self.statTags;
+    var commonKeys = Object.keys(self.statTags);
+
+    var localTags = stat.tags;
+    for (var i = 0; i < commonKeys.length; i++) {
+        localTags[commonKeys[i]] = commonTags[commonKeys[i]];
+    }
+
+    self.statEvent.emit(stat);
 };
 
 module.exports = TChannel;

--- a/node/channel.js
+++ b/node/channel.js
@@ -455,6 +455,10 @@ TChannel.prototype.emitStat = function emitStat(stat) {
     }
 
     self.statEvent.emit(stat);
+
+    if (self.topChannel) {
+        self.topChannel.statEvent.emit(stat);
+    }
 };
 
 module.exports = TChannel;

--- a/node/request.js
+++ b/node/request.js
@@ -141,6 +141,29 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
         if (called) return;
         called = true;
         res.withArg23(function gotArg23(err, arg2, arg3) {
+            if (res.ok) {
+                self.channel.emitStat(new Stat.Counter(
+                    'outbound.calls.success', 1, {
+                        'target-service': self.serviceName,
+                        'service': self.headers.cn,
+                        // TODO should always be buffer
+                        'target-endpoint': String(self.arg1)
+                    }
+                ));
+            } else {
+                self.channel.emitStat(new Stat.Counter(
+                    'outbound.calls.app-errors', 1, {
+                        'target-service': self.serviceName,
+                        'service': self.headers.cn,
+                        // TODO should always be buffer
+                        'target-endpoint': String(self.arg1),
+                        // TODO define transport header
+                        // for application error type
+                        'application-error-type': 'unknown'
+                    }
+                ));
+            }
+
             callback(err, res, arg2, arg3);
         });
     }

--- a/node/request.js
+++ b/node/request.js
@@ -111,6 +111,29 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
     function onError(err) {
         if (called) return;
         called = true;
+
+        if (err.isErrorFrame) {
+            self.channel.emitStat(new Stat.Counter(
+                'outbound.calls.systems-errors', 1, {
+                    'target-service': self.serviceName,
+                    'service': self.headers.cn,
+                    // TODO should always be buffer
+                    'target-endpoint': String(self.arg1),
+                    'error-type': err.codeName
+                }
+            ));
+        } else {
+            self.channel.emitStat(new Stat.Counter(
+                'outbound.calls.operational-errors', 1, {
+                    'target-service': self.serviceName,
+                    'service': self.headers.cn,
+                    // TODO should always be buffer
+                    'target-endpoint': String(self.arg1),
+                    'error-type': err.type || 'unknown'
+                }
+            ));
+        }
+
         callback(err, null, null, null);
     }
 

--- a/node/request.js
+++ b/node/request.js
@@ -231,6 +231,16 @@ TChannelRequest.prototype.resend = function resend() {
                 'target-endpoint': String(outReq.arg1)
             }
         ));
+    } else {
+        self.channel.emitStat(new Stat.Counter(
+            'outbound.calls.retries', 1, {
+                'target-service': outReq.serviceName,
+                'service': outReq.headers.cn,
+                // TODO should always be buffer
+                'target-endpoint': String(outReq.arg1),
+                'retry-count': self.outReqs.length - 1
+            }
+        ));
     }
 
     self.triedRemoteAddrs[outReq.remoteAddr] = (self.triedRemoteAddrs[outReq.remoteAddr] || 0) + 1;

--- a/node/request.js
+++ b/node/request.js
@@ -165,8 +165,6 @@ TChannelRequest.prototype.resend = function resend() {
         return;
     }
 
-    if (self.checkTimeout()) return;
-
     var opts = {};
     var keys = Object.keys(self.options);
     for (var i = 0; i < keys.length; i++) {

--- a/node/request.js
+++ b/node/request.js
@@ -134,6 +134,8 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
             ));
         }
 
+        emitLatency();
+
         callback(err, null, null, null);
     }
 
@@ -164,8 +166,23 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
                 ));
             }
 
+            emitLatency();
+
             callback(err, res, arg2, arg3);
         });
+    }
+
+    function emitLatency() {
+        var latency = self.end - self.start;
+
+        self.channel.emitStat(new Stat.Timer(
+            'outbound.calls.latency', latency, {
+                'target-service': self.serviceName,
+                'service': self.headers.cn,
+                // TODO should always be buffer
+                'target-endpoint': String(self.arg1)
+            }
+        ));
     }
 
     return self;

--- a/node/scripts/xlang_test.js
+++ b/node/scripts/xlang_test.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2015 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/node/stat.js
+++ b/node/stat.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var Stat = {
-    Counter: Counter
+    Counter: Counter,
+    Timer: Timer
 };
 
 module.exports = Stat;
@@ -10,6 +11,15 @@ function Counter(name, value, tags) {
     var self = this;
 
     self.type = 'counter';
+    self.name = name;
+    self.value = value;
+    self.tags = tags;
+}
+
+function Timer(name, value, tags) {
+    var self = this;
+
+    self.type = 'timer';
     self.name = name;
     self.value = value;
     self.tags = tags;

--- a/node/stat.js
+++ b/node/stat.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var Stat = {
+    Counter: Counter
+};
+
+module.exports = Stat;
+
+function Counter(name, value, tags) {
+    var self = this;
+
+    self.type = 'counter';
+    self.name = name;
+    self.value = value;
+    self.tags = tags;
+}

--- a/node/stat.js
+++ b/node/stat.js
@@ -1,3 +1,23 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 'use strict';
 
 var Stat = {

--- a/node/test/run_server.js
+++ b/node/test/run_server.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2015 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is a first pass at emitting outbound call request
stats. It adds an `emitStat()` helper to the channel
and wires up all the stats.

 - Implement all outbound stats except for request sizes
    and response sizes.
 - Added non-standard operational error stat

I plan to add connection stats in a seperate PR.

r: @jcorbin @kriskowal @mmihic