### PR TITLE
Error on incoming call req/res frame before init res frame is sent

### DIFF
--- a/node/errors.js
+++ b/node/errors.js
@@ -235,6 +235,12 @@ module.exports.SocketClosedError = TypedError({
     reason: null
 });
 
+module.exports.TChannelInitProtocolError = TypedError({
+    type: 'tchannel.init.protocol-error',
+    message: 'tchannel: {reason}',
+    reason: null
+});
+
 module.exports.TChannelListenError = WrappedError({
     type: 'tchannel.server.listen-failed',
     message: 'tchannel: {origMessage}',

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -143,7 +143,8 @@ TChannelV2Handler.prototype.handleFrame = function handleFrame(frame, callback) 
 TChannelV2Handler.prototype.handleInitRequest = function handleInitRequest(reqFrame, callback) {
     var self = this;
     if (self.remoteHostPort !== null) {
-        return callback(new Error('duplicate init request')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'duplicate init request'}));
     }
     /* jshint camelcase:false */
     var headers = reqFrame.body.headers;
@@ -152,16 +153,17 @@ TChannelV2Handler.prototype.handleInitRequest = function handleInitRequest(reqFr
         processName: headers.process_name
     };
     /* jshint camelcase:true */
+    self.sendInitResponse(reqFrame);
     self.remoteHostPort = init.hostPort;
     self.initRequestEvent.emit(self, init);
-    self.sendInitResponse(reqFrame);
     callback();
 };
 
 TChannelV2Handler.prototype.handleInitResponse = function handleInitResponse(resFrame, callback) {
     var self = this;
     if (self.remoteHostPort !== null) {
-        return callback(new Error('duplicate init response')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'duplicate init response'}));
     }
     /* jshint camelcase:false */
     var headers = resFrame.body.headers;
@@ -178,7 +180,8 @@ TChannelV2Handler.prototype.handleInitResponse = function handleInitResponse(res
 TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFrame, callback) {
     var self = this;
     if (self.remoteHostPort === null) {
-        return callback(new Error('call request before init request')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'call request before init request'}));
     }
     var req = self.buildInRequest(reqFrame);
     if (reqFrame.body.args && reqFrame.body.args[0] &&
@@ -208,7 +211,8 @@ TChannelV2Handler.prototype.callRequestFrameHandled = function callRequestFrameH
 TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(resFrame, callback) {
     var self = this;
     if (self.remoteHostPort === null) {
-        return callback(new Error('call response before init response')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'call response before init response'}));
     }
     var res = self.buildInResponse(resFrame);
     if (resFrame.body.args && resFrame.body.args[0] &&
@@ -245,7 +249,8 @@ TChannelV2Handler.prototype.handleCancel = function handleCancel(frame, callback
 TChannelV2Handler.prototype.handleCallRequestCont = function handleCallRequestCont(reqFrame, callback) {
     var self = this;
     if (self.remoteHostPort === null) {
-        return callback(new Error('call request cont before init request')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'call request cont before init request'}));
     }
     var id = reqFrame.id;
     var req = self.streamingReq[id];
@@ -258,7 +263,8 @@ TChannelV2Handler.prototype.handleCallRequestCont = function handleCallRequestCo
 TChannelV2Handler.prototype.handleCallResponseCont = function handleCallResponseCont(resFrame, callback) {
     var self = this;
     if (self.remoteHostPort === null) {
-        return callback(new Error('call response cont before init response')); // TODO typed error
+        return callback(errors.TChannelInitProtocolError(
+            {reason: 'call response cont before init response'}));
     }
     var id = resFrame.id;
     var res = self.streamingRes[id];


### PR DESCRIPTION
cc: @jcorbin @Raynos 

Separate the none breaking logic and do a merge first.
1. handle the issue by moving self.sendInitResponse up.
2. did a little refinement adding the typed error: TChannelInitProtocolError