### PR TITLE
Fix out req popping for incoming call response

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -235,12 +235,21 @@ TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
 
 TChannelConnection.prototype.onCallError = function onCallError(err) {
     var self = this;
-    var req = self.popOutReq(err.originalId);
-    if (!req) {
-        self.logger.info('error received for unknown or lost operation', err);
-        return;
+
+    var req = self.requests.out[err.originalId];
+
+    if (req && req.res) {
+        req.res.errorEvent.emit(req.res, err);
+    } else {
+        // Only popOutReq if there is no call response object yet
+        req = self.popOutReq(err.originalId);
+        if (!req) {
+            self.logger.info('error received for unknown or lost operation', err);
+            return;
+        }
+
+        req.errorEvent.emit(req, err);
     }
-    req.errorEvent.emit(req, err);
 };
 
 TChannelConnection.prototype.onTimedOut = function onTimedOut(_arg, self) {

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -44,3 +44,4 @@ require('./peers.js');
 require('./peer_states.js');
 require('./trace/');
 require('./request-stats.js');
+require('./streaming-resp-err.js');

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -1,0 +1,68 @@
+'use strict';
+
+var setTimeout = require('timers').setTimeout;
+
+var allocCluster = require('./lib/alloc-cluster.js');
+
+allocCluster.test('end response with error frame', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var client = cluster.channels[0];
+    var server = cluster.channels[1];
+
+    server.makeSubChannel({
+        serviceName: 'stream'
+    }).register('stream', {
+        streamed: true
+    }, streamHandler);
+
+    var req = client.request({
+        serviceName: 'stream',
+        host: server.hostPort,
+        streamed: true
+    });
+
+    req.arg1.end('stream');
+    req.arg2.end();
+    req.arg3.end();
+
+    req.on('response', onResponse);
+    req.on('error', onError);
+
+    function onResponse(resp) {
+        assert.ok(resp);
+
+        resp.on('finish', onResponseFinished);
+        resp.on('error', onResponseError);
+
+        function onResponseFinished() {
+            assert.ok(false, 'expected no finished event');
+        }
+
+        function onResponseError(err) {
+            assert.equal(err.message, 'oops');
+
+            assert.end();
+        }
+    }
+
+    function onError(err) {
+        assert.ifError(err);
+        assert.ok(false, 'expected no req error event');
+    }
+
+    function streamHandler(inreq, buildRes) {
+        var res = buildRes({
+            streamed: true
+        });
+
+        res.arg1.end();
+        res.arg2.end();
+
+        res.arg3.write('a message');
+
+        setTimeout(function datTime() {
+            res.sendError('UnexpectedError', 'oops');
+        }, 500);
+    }
+});

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -1,3 +1,23 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 'use strict';
 
 var setTimeout = require('timers').setTimeout;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -299,12 +299,6 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
     if (id === v2.Frame.NullId) {
         // fatal error not associated with a prior frame
         callback(err);
-    // TODO: unless we fix TChannelConnection#onCallResponse to keep streamed
-    // responses until termination, we need to check here for streaming and
-    // emit errors on the response directly:
-    //     } else if (self.streamingRes[id]) {
-    //         var res = self.streamingRes[id];
-    //         res.errorEvent.emit(res, err);
     } else {
         self.callIncomingErrorEvent.emit(self, err);
         callback();


### PR DESCRIPTION
We had a bunch of false positive around logging
`error received for unknown or lost operation`
because we were not tracking the call req vs incoming call res
data correctly.

This PR cleans up the logic to only pop an out req when an
incoming call response is truly finished

r: @jcorbin @kriskowal