### PR TITLE
Make tracing tests silent by default

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "test": "npm run lint -s && npm run cover -s",
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmark` directly' >&2; node benchmarks",
     "take-benchmark": "./benchmarks/take.sh",
-    "cover": "istanbul cover --report html --print none test/index.js | faucet && istanbul report text && istanbul check-coverage",
+    "cover": "istanbul cover --report html --print none test/index.js -- --color | faucet && istanbul report text && istanbul check-coverage",
     "check-cover": "istanbul check-coverage",
     "view-cover": "opn coverage/index.html",
     "check-licence": "uber-licence --dry",

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -36,7 +36,7 @@ test('basic tracing test', function (assert) {
 
     function traceReporter(span) {
         spans.push(span);
-        console.log(span.toString());
+        logger.info(span.toString());
     }
 
     var subservice = new TChannel({
@@ -62,13 +62,13 @@ test('basic tracing test', function (assert) {
     });
 
     subservice.handler.register('/foobar', function (req, res) {
-        console.log("subserv sr");
+        logger.info("subserv sr");
         res.sendOk('result', 'success');
     });
 
     // normal response
     server.handler.register('/top_level_endpoint', function (req, res) {
-        console.log("top level sending to subservice");
+        logger.info("top level sending to subservice");
         setTimeout(function () {
             server
                 .request({
@@ -77,7 +77,7 @@ test('basic tracing test', function (assert) {
                     parentSpan: req.span,
                     trace: true
                 }).send('/foobar', 'arg1', 'arg2', function (err, subRes) {
-                    console.log("top level recv from subservice");
+                    logger.info("top level recv from subservice");
                     if (err) return res.sendOk('error', err);
                     res.sendOk('result', 'success: ' + subRes);
                 });
@@ -92,11 +92,11 @@ test('basic tracing test', function (assert) {
             throw err;
         }
 
-        console.log("client making req");
+        logger.info("client making req");
         client
             .request({host: '127.0.0.1:4040', serviceName: 'server', trace: true})
             .send('/top_level_endpoint', "arg 1", "arg 2", function (err, res) {
-                console.log("client recv from top level: " + res);
+                logger.info("client recv from top level: " + res);
                 requestsDone.signal();
             });
 

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -36,7 +36,7 @@ test('basic tracing test', function (assert) {
 
     function traceReporter(span) {
         spans.push(span);
-        console.log(span.toString());
+        logger.info(span.toString());
     }
 
     var subservice = new TChannel({
@@ -62,18 +62,18 @@ test('basic tracing test', function (assert) {
     });
 
     subservice.handler.register('/foobar', function (req, res) {
-        console.log("subserv sr");
+        logger.info("subserv sr");
         res.sendOk('result', 'success');
     });
 
     subservice.handler.register('/barbaz', function (req, res) {
-        console.log("subserv 2 sr");
+        logger.info("subserv 2 sr");
         res.sendOk('result', 'success');
     });
 
     // normal response
     server.handler.register('/top_level_endpoint', function (req, res) {
-        console.log("top level sending to subservice");
+        logger.info("top level sending to subservice");
         var serverRequestsDone = CountedReadySignal(2);
 
         setTimeout(function () {
@@ -84,7 +84,7 @@ test('basic tracing test', function (assert) {
                     parentSpan: req.span,
                     trace: true
                 }).send('/foobar', 'arg1', 'arg2', function (err, subRes) {
-                    console.log("top level recv from subservice: " + subRes);
+                    logger.info("top level recv from subservice: " + subRes);
                     if (err) return res.sendOk('error', err);
 
                     serverRequestsDone.signal();
@@ -99,7 +99,7 @@ test('basic tracing test', function (assert) {
                     parentSpan: req.span,
                     trace: true
                 }).send('/barbaz', 'arg1', 'arg2', function (err, subRes) {
-                    console.log("top level recv from subservice: " + subRes);
+                    logger.info("top level recv from subservice: " + subRes);
                     if (err) return res.sendOk('error', err);
 
                     serverRequestsDone.signal();
@@ -120,11 +120,11 @@ test('basic tracing test', function (assert) {
             throw err;
         }
 
-        console.log("client making req");
+        logger.info("client making req");
         client
             .request({host: '127.0.0.1:4040', serviceName: 'server', trace: true})
             .send('/top_level_endpoint', "arg 1", "arg 2", function (err, res) {
-                console.log("client recv from top level: " + res);
+                logger.info("client recv from top level: " + res);
                 requestsDone.signal();
             });
 


### PR DESCRIPTION
Our tests should be silent by default and only output
TAP to work nicely with tap workflows.

For example: using `grep` to parse out TAP output

```
$ node test/index.js | grep -v '^ok \|^#'
TAP version 13
TCHANNEL WARN: localhost:37892 destroying socket from timeouts ~ null
TCHANNEL WARN: mismatched onReqDone callback ~ { hostPort: 'localhost:42207', hasInReq: false, id: 1 }
TCHANNEL WARN: mismatched onReqDone callback ~ { hostPort: 'localhost:38391', hasInReq: false, id: 2 }

1..2194
```

I will fix the warnings in seperate PRs

r: @rf @kriskowal