### PR TITLE
TChannelRequest: no retries when connection is closing

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -198,9 +198,7 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
         var req = self.requests.out[id];
         delete self.requests.out[id];
         
-        err = errors.TChannelConnectionResetError(err, {
-            connection: self
-        });
+        err = errors.TChannelConnectionResetError(err);
 
         req.errorEvent.emit(req, err);
     });

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -197,9 +197,7 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     outOpKeys.forEach(function eachOutOp(id) {
         var req = self.requests.out[id];
         delete self.requests.out[id];
-        
         err = errors.TChannelConnectionResetError(err);
-
         req.errorEvent.emit(req, err);
     });
 

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -197,8 +197,11 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     outOpKeys.forEach(function eachOutOp(id) {
         var req = self.requests.out[id];
         delete self.requests.out[id];
-        err = Object.create(err);
-        err.connectionClosing = true;
+        
+        err = errors.TChannelConnectionResetError(err, {
+            connection: self
+        });
+
         req.errorEvent.emit(req, err);
     });
 

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -197,7 +197,8 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     outOpKeys.forEach(function eachOutOp(id) {
         var req = self.requests.out[id];
         delete self.requests.out[id];
-        // TODO: shared mutable object... use Object.create(err)?
+        err = Object.create(err);
+        err.connectionClosing = true;
         req.errorEvent.emit(req, err);
     });
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -261,8 +261,7 @@ module.exports.TChannelCallResContBeforeInitResError = TypedError({
 
 module.exports.TChannelConnectionResetError = WrappedError({
     type: 'tchannel.connection.reset',
-    message: 'tchannel: {origMessage}',
-    connection: null
+    message: 'tchannel: {origMessage}'
 });
 
 module.exports.TChannelDuplicateInitRequestError = TypedError({

--- a/node/errors.js
+++ b/node/errors.js
@@ -259,6 +259,12 @@ module.exports.TChannelCallResContBeforeInitResError = TypedError({
     message: 'call response cont before init response'
 });
 
+module.exports.TChannelConnectionResetError = WrappedError({
+    type: 'tchannel.connection.reset',
+    message: 'tchannel: {origMessage}',
+    connection: null
+});
+
 module.exports.TChannelDuplicateInitRequestError = TypedError({
     type: 'tchannel.init.duplicate-init-request',
     message: 'tchannel: duplicate init request'

--- a/node/errors.js
+++ b/node/errors.js
@@ -261,7 +261,7 @@ module.exports.TChannelCallResContBeforeInitResError = TypedError({
 
 module.exports.TChannelConnectionResetError = WrappedError({
     type: 'tchannel.connection.reset',
-    message: 'tchannel: {origMessage}'
+    message: 'tchannel: {causeMessage}'
 });
 
 module.exports.TChannelDuplicateInitRequestError = TypedError({

--- a/node/request.js
+++ b/node/request.js
@@ -374,10 +374,6 @@ TChannelRequest.prototype.checkTimeout = function checkTimeout(err, res) {
 TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
     var self = this;
 
-    if (err.connectionClosing) {
-        return false;
-    }
-
     if (self.outReqs.length >= self.limit) {
         return false;
     }
@@ -390,6 +386,7 @@ TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
         switch (err.type) {
             case 'tchannel.bad-request':
             case 'tchannel.canceled':
+            case 'tchannel.connection.reset':
                 return false;
 
             case 'tchannel.busy':

--- a/node/request.js
+++ b/node/request.js
@@ -202,8 +202,6 @@ TChannelRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
 TChannelRequest.prototype.resend = function resend() {
     var self = this;
 
-    if (self.channel.destroyed) return;
-
     if (self.trackPending && self.checkPending()) return;
 
     if (self.checkTimeout()) return;
@@ -375,6 +373,10 @@ TChannelRequest.prototype.checkTimeout = function checkTimeout(err, res) {
 
 TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
     var self = this;
+
+    if (err.connectionClosing) {
+        return false;
+    }
 
     if (self.outReqs.length >= self.limit) {
         return false;


### PR DESCRIPTION
r @jcorbin @Raynos 
cc @kriskowal 

When a connection is closing, TChannelRequest should not do retries.