### PR TITLE
Implement TChannel configuration using `with_options`.

### DIFF
--- a/python/tchannel/tornado/tchannel.py
+++ b/python/tchannel/tornado/tchannel.py
@@ -32,11 +32,13 @@ from tornado.netutil import bind_sockets
 
 from enum import IntEnum
 
+from ..errors import TChannelError
 from ..event import EventEmitter
 from ..event import EventRegistrar
 from ..handler import CallableRequestHandler
 from ..net import local_ip
 from .connection import StreamConnection
+from .stream import Stream
 from .peer import PeerGroup
 
 log = logging.getLogger('tchannel')
@@ -46,6 +48,93 @@ class State(IntEnum):
     ready = 0
     closing = 1
     closed = 2
+
+
+class ProxyChannel(object):
+    """A proxy object used to make requests through a TChannel.
+
+    These proxy channels and the root TChannel allow deriving arbitrary
+    levels of objects that remember certain pieces of TChannel configuration.
+
+    For example,
+
+    .. code-block:: python
+
+        tchannel = TChannel()  # root TChannel
+
+        foo = tchannel.with_options(
+            hostport='localhost:4040', service='hello'
+        )
+        # Calls made through foo and any derived channels will not need the
+        # hostport or service specified.
+
+        bar = foo.with_options(headers={'Source': 'x'})
+        # Calls made through bar and any derived channels will not need the
+        # hostport or service specified, and will always include the header
+        # ``Source: x``.
+    """
+
+    __slots__ = ('parent', 'options', '_closed')
+
+    def __init__(self, tchannel, options):
+        self.parent = tchannel
+        self.options = options
+        # We're currently using dictionaries to represent these options. If
+        # performance ever becomes an issue, we can use a namedtuple of all
+        # configuration parameters.
+
+        self._closed = False
+
+        # TODO: Zipkin tracing
+
+    def call(self, **kwargs):
+        """See :py:meth:`TChannel.call`."""
+        # TODO: Check if the channel has been closed?
+
+        opts = self.options.copy()
+        if 'headers' in opts and 'headers' in kwargs:
+            # FIXME: Special casing it like this is hacky. Find better
+            # solution.
+            opts['headers'].update(kwargs.pop('headers'))
+        opts.update(kwargs)
+
+        # TODO assign a Trace to the call
+        return self.parent.call(**opts)
+
+    def with_options(self, **kwargs):
+        """See :py:meth:`TChannel.with_options`."""
+        return ProxyChannel(self, kwargs)
+
+    def close(self):
+        """See :py:meth:`TChannel.close`.
+
+        Closing a proxy channel (or the root TChannel) has the effect of also
+        closing all derived channels.
+        """
+        self._closed = True
+        # The connections don't need to be closed. The root TChannel will take
+        # care of it as necessary.
+
+    @property
+    def closed(self):
+        """Whether this channel has been closed.
+
+        A channel is considered closed if ``.close`` was called on it or one
+        of its parents.
+        """
+        return self._closed or self.parent.closed
+
+    @property
+    def hostport(self):
+        """A host-port to reach this service.
+
+        The service behind this TChannel can be reached at this address.
+        """
+        return self.parent.hostport
+
+    # TODO: host() should respect scheme if specified. Better yet, replace
+    # host() with register() to register individual endpoints and make that
+    # respect the scheme.
 
 
 class TChannel(object):
@@ -67,6 +156,7 @@ class TChannel(object):
             A list of host-ports at which already known peers can be reached.
             Defaults to an empty list.
         """
+        # TODO: handle Zipkin in here
         self._state = State.ready
         self.peers = PeerGroup(self)
 
@@ -92,12 +182,32 @@ class TChannel(object):
             for peer_hostport in known_peers:
                 self.peers.add(peer_hostport)
 
+    def with_options(self, **kwargs):
+        """Create a proxy to this TChannel that remembers the given settings.
+
+        For example,
+
+        .. code-block:: python
+
+            tchannel = TChannel()
+            foo_channel = tchannel.with_options(service='foo')
+            # All requests made through foo_channel will have service=foo
+            # unless otherwise specified
+        """
+        # TODO: Document params
+        return ProxyChannel(self, kwargs)
+
     @property
     def closed(self):
+        """Whether this TChannel was closed."""
         return self._state == State.closed
 
     @tornado.gen.coroutine
     def close(self):
+        """Close this TChannel.
+
+        All connections to all known peers will be disconnected.
+        """
         if self._state in [State.closed, State.closing]:
             raise tornado.gen.Return(None)
 
@@ -109,6 +219,7 @@ class TChannel(object):
 
     @property
     def hostport(self):
+        """The host-port at which this TChannel can be reached."""
         return "%s:%d" % (self._host, self._port)
 
     def request(self, hostport=None, service=None, **kwargs):
@@ -121,6 +232,30 @@ class TChannel(object):
             Service being called. Defaults to an empty string.
         """
         return self.peers.request(hostport=hostport, service=service, **kwargs)
+
+    def call(self, service, args, headers=None, hostport=None, scheme=None,
+             **kwargs):
+        # NOTE: headers are TRANSPORT HEADERS.
+        # APPLICATION HEADERS go inside args[1]
+        headers = headers or {}
+        arg1, arg2, arg3 = args
+        if scheme:
+            headers['as'] = scheme.type()
+            try:
+                if not isinstance(arg2, Stream):
+                    arg2 = scheme.serialize_header(arg2)
+                if not isinstance(arg3, Stream):
+                    arg3 = scheme.serialize_body(arg3)
+            except Exception as e:
+                raise TChannelError(e.message)
+
+        return self.request(hostport=hostport, service=service).send(
+            arg1=arg1,
+            arg2=arg2,
+            arg3=arg3,
+            traceflag=False,  # TODO
+            headers=headers,
+        )
 
     def host(self, handler):
         """Specify the RequestHandler to handle incoming requests.


### PR DESCRIPTION
This will allow us to build `as_json`, `as_thrift`, on top of it.

The `TChannel.call` method will replace the `.request.send` chain but for now
it's just calling `.request.send`.

After I add the `as_*` methods, client-side arg-scheme story will change from:

    ArgSchemeBroker(JsonArgSchema()).send(
         tchannel.request(service='foo', hostport='localhost:4040'), arg1, arg2, arg3
     )

To any of:

    tchannel.as_json(service='foo', hostport='localhost:4040').call(args=(arg1, arg2, arg3))
    tchannel.as_json().call(args=(arg1, arg2, arg3), service='foo', hostport='localhost:4040')
    tchannel.as_json(service='foo').call(args=(arg1, arg2, arg3), hostport='localhost:4040')

Where the object returned by `as_json` is re-usable. Note that `as_json(**foo)` will just be shorthand for `with_options(scheme=JsonArgScheme(), **foo)`.

These proxy objects will track Zipkin information and be re-used for
server-side code (that currently uses its own custom proxy type).

Note that a caveat of this approach is that `.call` requires keyword parameters. We can make that go away if we specialize `.call` to have only the `arg{1,2,3}` arguments and require everything else to use `.with_options` or the corresponding `.as_*` function.

----

Tested manually against example server.

Right now, this PR is mostly to gather opinions from @blampe, @breerly, and @junchaowu. I'll update it with tests, the zipkin stuff, and the server-side stuff once I have some feedback.