### PR TITLE
Update Hyperbahn registration system to use peering.

### DIFF
--- a/python/tchannel/tornado/hyperbahn.py
+++ b/python/tchannel/tornado/hyperbahn.py
@@ -21,102 +21,71 @@
 from __future__ import absolute_import
 
 import json
+import logging
 
 import tornado.gen
+import tornado.ioloop
 
 from ..messages.error import ErrorCode
-from .tchannel import TChannel
 
 DEFAULT_TTL = 60  # seconds
 
 
-class HyperbahnClient(object):
-    """Client for talking with the Hyperbahn."""
+log = logging.getLogger('tchannel')
 
-    def __init__(
-        self,
-        service,
-        routers,
-        tchannel=None
-    ):
-        """
-        :param hostport:
-            Address at which this service can be reached. For example,
-            "127.0.0.1:2499".
 
-        :param routers: list of hyperbahn addresses, e.g.,
-            ``["127.0.0.1:21300", "127.0.0.1:21301"]``.
+def advertise(tchannel, service, routers):
+    """Advertise the given TChannel to Hyperbahn using the given name.
 
-        :param tchannel: ``TChannel`` instance to make Hyperbahn requests with.
-        """
-        self.service = service
-        self.tchannel = tchannel or TChannel()
+    This informs Hyperbahn that the given service is hosted at this TChannel
+    at a fixed rate.
 
-        for known_peer in routers:
-            self.tchannel.peers.add(known_peer)
+    It also tells the TChannel about the given Hyperbahn routers.
 
-    @tornado.gen.coroutine
-    def request(
-        self,
-        service,
-        endpoint,
-        body=None,
-        headers=None,
-        protocol_headers=None,
-    ):
-        """Send a request to a service through Hyperbahn.
+    :param tchannel:
+        TChannel to register with Hyperbahn
+    :param service:
+        Name of the service behind this TChannel
+    :param routers:
+        Seed list of addresses of Hyperbahn routers
+    :returns:
+        A future that resolves to the remote server's response after the first
+        advertise is successful.
+    """
 
-        Adds service name semantics and load balancing to regular TChannel
-        request via a Hyperbahn routing mesh.
-
-        :param service: name of service to make request to, eg "ncar".
-
-        :param endpoint: endpoint to make request to, eg "find".
-
-        :param body: body to send with request, eg JSON or Thrift.
-        """
-
-        request = self.tchannel.request(service=service)
-
-        response = yield request.send(
-            arg1=endpoint,
-            arg2=headers,
-            arg3=body,
-            headers=protocol_headers,
-        )
-
-        raise tornado.gen.Return(response)
+    for router in routers:
+        # We use .get here instead of .add because we don't want to fail if a
+        # TChannel already knows about some of the routers.
+        tchannel.peers.get(router)
 
     @tornado.gen.coroutine
-    def register(self, ioloop=None):
-        """Register this service with the Hyperbahn routing mesh."""
-
-        request_params = dict(
-            service="hyperbahn",
-            endpoint="ad",  # advertise
-            body=json.dumps({
-                "services": [
+    def _register():
+        response = yield tchannel.request(service='hyperbahn').send(
+            arg1='ad',  # advertise
+            arg2='',
+            arg3=json.dumps({
+                'services': [
                     {
-                        "serviceName": self.service,
-                        "cost": 0,
-                    },
-                ],
+                        'serviceName': service,
+                        'cost': 0,
+                    }
+                ]
             }),
-            protocol_headers={
-                "as": "json",
-            },
+            headers={'as': 'json'},
         )
-
-        # TODO: it would be nice to have message_type on the Response
-        response = yield self.request(**request_params)
 
         if response.code not in ErrorCode:
             # re-register every ``DEFAULT_TTL`` seconds
-            ioloop = tornado.ioloop.IOLoop.current()
-            ioloop.call_later(
+            tornado.ioloop.IOLoop.current().call_later(
                 delay=DEFAULT_TTL,
-                callback=self.register,
+                callback=_register,
             )
             raise tornado.gen.Return(response)
+        else:
+            log.error('Failed to register with Hyperbahn: %s', response)
+            raise NotImplementedError  # TODO figure out behavior here
 
-        raise NotImplementedError(response)
+    return _register()
+
+
+advertize = advertise  # just in case


### PR DESCRIPTION
This makes it so that we can continue to use the same TChannel object for all
other requests instead of a HyperbahnClient wrapper around it.

A major advantage of this is that we don't have to implement things like
Thrift support twice.