### PR TITLE
2.0.0-IDEA: pass in thriftText instead of spec

### DIFF
--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -23,6 +23,7 @@
 var assert = require('assert');
 var bufrw = require('bufrw');
 var Result = require('bufrw/result');
+var thriftify = require('thriftify');
 
 var errors = require('../errors.js');
 
@@ -37,8 +38,10 @@ function TChannelAsThrift(opts) {
 
     var self = this;
 
-    assert(opts && opts.spec, 'TChannelAsThrift expected spec');
-    self.spec = opts.spec;
+    assert(opts && typeof opts.source === 'string',
+        'must pass source as an argument');
+
+    self.spec = thriftify.parseSpec(opts.source);
 
     // Pulled off of things in `.register` and `.send` rather than passed in
     self.logger = null;

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -25,16 +25,16 @@
 
 var path = require('path');
 var TypedError = require('error/typed');
-var thriftify = require('thriftify');
+var fs = require('fs');
 
 var allocCluster = require('./lib/alloc-cluster.js');
 var TChannelAsThrift = require('../as/thrift.js');
 
-var globalSpec = thriftify.readSpecSync(
-    path.join(__dirname, 'anechoic-chamber.thrift')
+var globalThriftText = fs.readFileSync(
+    path.join(__dirname, 'anechoic-chamber.thrift'), 'utf8'
 );
-var badSpec = thriftify.readSpecSync(
-    path.join(__dirname, 'bad-anechoic-chamber.thrift')
+var badThriftText = fs.readFileSync(
+    path.join(__dirname, 'bad-anechoic-chamber.thrift'), 'utf8'
 );
 
 allocCluster.test('send and receiving an ok', {
@@ -244,7 +244,7 @@ allocCluster.test('send without required fields', {
         okResponse: true
     });
     var tchannelAsThrift = TChannelAsThrift({
-        spec: badSpec
+        source: badThriftText
     });
 
     tchannelAsThrift.send(client.request({
@@ -302,7 +302,7 @@ function makeTChannelThriftServer(cluster, opts) {
             networkFailureHandler;
 
     var tchannelAsThrift = new TChannelAsThrift({
-        spec: opts.spec || globalSpec,
+        source: opts.thriftText || globalThriftText,
         logParseFailures: false
     });
     tchannelAsThrift.register(server, 'Chamber::echo', options, fn);

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var TypedError = require('error/typed');
-var thriftify = require('thriftify');
 
 var allocCluster = require('./lib/alloc-cluster.js');
 var TChannelAsThrift = require('../as/thrift.js');
@@ -787,7 +786,6 @@ allocCluster.test('sending INTERNAL_TIMEOUT ERROR_FRAME', {
 function allocThrift(cluster, options) {
     options = options || {};
 
-    var throftSpec = thriftify.parseSpec(throft);
     var server = cluster.channels[0].makeSubChannel({
         serviceName: 'server'
     });
@@ -807,7 +805,7 @@ function allocThrift(cluster, options) {
         messagesHandler : null;
 
     var tchannelAsThrift = TChannelAsThrift({
-        spec: throftSpec
+        source: throft
     });
     tchannelAsThrift.register(
         server, 'DoubleResponse::method', {}, handler


### PR DESCRIPTION
Breaking change: You must pass in the thrift idl as a raw string
instead of passing a thriftify spec object.

To avoid having two copies of `thriftify` or having drift between
their versions and implementations I've changed the as/thrift
interface to pass in the thrift IDL as text.

I've avoided the `thriftFile` approach; the new interface
encourages people to call `fs.readFileSync()` at startup time
and then instantiate tchannelAsThrift later.

```js
// clients/index.js

var fs = require('fs');
var path = require('path');
var TChannelAsThrift = require('tchannel/as/thrift');

var thriftText = fs.readFileSync(
  path.join(__dirname, '..', 'thrift, 'app.thrift'),
  'utf8'
);

module.exports = ApplicationClients;

function ApplicationClients() {
  this.appThrift = TChannelAsThrift({
    thriftText: thriftText
  });
}
```

cc @kriskowal @jcorbin