### PR TITLE
2.0.0-IDEA: Make calling .register() and .request() illegal on top channel

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -404,14 +404,8 @@ TChannel.prototype.request = function channelRequest(options) {
     assert(!self.destroyed, 'cannot request() to destroyed tchannel');
     var opts = self.requestOptions(options);
 
-    if (!self.serviceName && !opts.host) {
-        if (opts.serviceName &&
-            self.subChannels &&
-            self.subChannels[opts.serviceName]) {
-            return self.subChannels[opts.serviceName].request(opts);
-        } else {
-            throw errors.TopLevelRequestError();
-        }
+    if (!self.topChannel) {
+        throw errors.TopLevelRequestError();
     }
 
     var req = null;

--- a/node/errors.js
+++ b/node/errors.js
@@ -419,8 +419,8 @@ module.exports.TopLevelRegisterError = TypedError({
 
 module.exports.TopLevelRequestError = TypedError({
     type: 'tchannel.top-level-request',
-    message: 'Cannot make request() on top level tchannel without service or host.\n' +
-        'Must provide either a known service, a direct host, or use a sub channel directly.'
+    message: 'Cannot make request() on top level tchannel.\n' +
+        'Must use a sub channel directly.'
 });
 
 module.exports.UnimplementedMethod = TypedError({

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -30,11 +30,11 @@ var allocCluster = require('./lib/alloc-cluster.js');
 allocCluster.test('getting an ok response', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelJSON = makeTChannelJSONServer(cluster, {
         okResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
@@ -72,11 +72,11 @@ allocCluster.test('getting an ok response', {
 allocCluster.test('getting a not ok response', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelJSON = makeTChannelJSONServer(cluster, {
         notOkResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
@@ -114,7 +114,8 @@ allocCluster.test('getting an UnexpectedError frame', {
     var tchannelJSON = makeTChannelJSONServer(cluster, {
         networkFailureResponse: true
     });
-    var client = cluster.channels[1];
+
+    var client = cluster.channels[1].subChannels.server;
 
     client.logger.whitelist(
         'error',
@@ -143,7 +144,8 @@ allocCluster.test('getting a BadRequest frame', {
     makeTChannelJSONServer(cluster, {
         networkFailureResponse: true
     });
-    var client = cluster.channels[1];
+
+    var client = cluster.channels[1].subChannels.server;
 
     client.request({
         serviceName: 'server',
@@ -177,7 +179,8 @@ allocCluster.test('sending without as header', {
     makeTChannelJSONServer(cluster, {
         networkFailureResponse: true
     });
-    var client = cluster.channels[1];
+
+    var client = cluster.channels[1].subChannels.server;
 
     client.request({
         serviceName: 'server',

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -40,11 +40,11 @@ var badThriftText = fs.readFileSync(
 allocCluster.test('send and receiving an ok', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
         okResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'
@@ -63,11 +63,11 @@ allocCluster.test('send and receiving an ok', {
 allocCluster.test('send and receive a not ok', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
         notOkResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'
@@ -88,11 +88,11 @@ allocCluster.test('send and receive a not ok', {
 allocCluster.test('send and receive a typed not ok', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
         notOkTypedResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'
@@ -113,11 +113,11 @@ allocCluster.test('send and receive a typed not ok', {
 allocCluster.test('sending and receiving headers', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
         okResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'
@@ -142,11 +142,10 @@ allocCluster.test('sending and receiving headers', {
 allocCluster.test('getting an UnexpectedError frame', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
-
     var tchannelAsThrift = makeTChannelThriftServer(cluster, {
         networkFailureResponse: true
     });
+    var client = cluster.channels[1].subChannels.server;
 
     client.logger.whitelist(
         'error',
@@ -176,7 +175,8 @@ allocCluster.test('getting a BadRequest frame', {
     makeTChannelThriftServer(cluster, {
         networkFailureResponse: true
     });
-    var client = cluster.channels[1];
+
+    var client = cluster.channels[1].subChannels.server;
 
     client.request({
         serviceName: 'server',
@@ -212,7 +212,8 @@ allocCluster.test('sending without as header', {
     makeTChannelThriftServer(cluster, {
         networkFailureResponse: true
     });
-    var client = cluster.channels[1];
+
+    var client = cluster.channels[1].subChannels.server;
 
     client.request({
         serviceName: 'server',
@@ -236,7 +237,6 @@ allocCluster.test('sending without as header', {
 allocCluster.test('send without required fields', {
     numPeers: 2
 }, function t(cluster, assert) {
-    var client = cluster.channels[1];
 
     makeTChannelThriftServer(cluster, {
         okResponse: true
@@ -244,6 +244,8 @@ allocCluster.test('send without required fields', {
     var tchannelAsThrift = TChannelAsThrift({
         source: badThriftText
     });
+
+    var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -35,7 +35,7 @@ allocCluster.test('register() with different results', {
     var one = cluster.channels[0];
     var two = cluster.channels[1];
 
-    two.makeSubChannel({
+    var twoSub = two.makeSubChannel({
         serviceName: 'server',
         peers: [one.hostPort]
     });
@@ -85,42 +85,42 @@ allocCluster.test('register() with different results', {
     });
 
     parallel({
-        'errorCall': sendCall.bind(null, two, {
+        'errorCall': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/error'),
-        'errorFrameCall': sendCall.bind(null, two, {
+        'errorFrameCall': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/error-frame'),
 
-        'bufferHead': sendCall.bind(null, two, {
+        'bufferHead': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/buffer-head'),
-        'stringHead': sendCall.bind(null, two, {
+        'stringHead': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/string-head'),
-        'objectHead': sendCall.bind(null, two, {
+        'objectHead': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/object-head'),
-        'nullHead': sendCall.bind(null, two, {
+        'nullHead': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/null-head'),
-        'undefHead': sendCall.bind(null, two, {
+        'undefHead': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/undef-head'),
 
-        'bufferBody': sendCall.bind(null, two, {
+        'bufferBody': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/buffer-body'),
-        'stringBody': sendCall.bind(null, two, {
+        'stringBody': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/string-body'),
-        'objectBody': sendCall.bind(null, two, {
+        'objectBody': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/object-body'),
-        'nullBody': sendCall.bind(null, two, {
+        'nullBody': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/null-body'),
-        'undefBody': sendCall.bind(null, two, {
+        'undefBody': sendCall.bind(null, twoSub, {
             serviceName: 'server'
         }, '/undef-body')
     }, onResults);

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -32,7 +32,7 @@ allocCluster.test('does not leak inOps', {
     var one = cluster.channels[0];
     var two = cluster.channels[1];
 
-    two.makeSubChannel({
+    var subTwo = two.makeSubChannel({
         serviceName: 'server',
         peers: [one.hostPort]
     });
@@ -42,7 +42,7 @@ allocCluster.test('does not leak inOps', {
     }).register('/timeout', timeout);
 
     two.timeoutCheckInterval = 99999;
-    two
+    subTwo
         .request({
             serviceName: 'server',
             timeout: 100

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -41,7 +41,7 @@ allocCluster.test('emits stats', {
         app: 'client',
         host: os.hostname()
     };
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'server',
         peers: [server.hostPort]
     });
@@ -50,7 +50,7 @@ allocCluster.test('emits stats', {
         stats.push(stat);
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'server',
         headers: {
             cn: 'client'

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -54,12 +54,12 @@ allocCluster.test('emits stats on call success', {
         version: '1.0'
     };
     client.channelStatsd = new TChannelStatsd(client, statsd);
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'reservoir',
         headers: {
             cn: 'inPipe'
@@ -127,12 +127,12 @@ allocCluster.test('emits stats on call failure', {
         version: '1.0'
     };
     client.channelStatsd = new TChannelStatsd(client, statsd);
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'reservoir',
         headers: {
             cn: 'inPipe'

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -44,12 +44,12 @@ allocCluster.test('emits response stats with ok', {
         stats.push(stat);
     });
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'server',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'server',
         headers: {
             cn: 'client'
@@ -120,12 +120,12 @@ allocCluster.test('emits response stats with not ok', {
         stats.push(stat);
     });
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'server',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'server',
         headers: {
             cn: 'client'
@@ -197,12 +197,12 @@ allocCluster.test('emits response stats with error', {
         stats.push(stat);
     });
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'server',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'server',
         headers: {
             cn: 'client'

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -54,12 +54,12 @@ allocCluster.test('emits stats on response ok', {
     };
     server.channelStatsd = new TChannelStatsd(server, statsd);
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'reservoir',
         headers: {
             cn: 'inPipe'
@@ -121,12 +121,12 @@ allocCluster.test('emits stats on response not ok', {
     };
     server.channelStatsd = new TChannelStatsd(server, statsd);
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'reservoir',
         headers: {
             cn: 'inPipe'
@@ -188,12 +188,12 @@ allocCluster.test('emits stats on response error', {
     };
     server.channelStatsd = new TChannelStatsd(server, statsd);
 
-    client.makeSubChannel({
+    var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
         peers: [server.hostPort]
     });
 
-    client.request({
+    clientChan.request({
         serviceName: 'reservoir',
         headers: {
             cn: 'inPipe'

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -37,7 +37,9 @@ allocCluster.test('end response with error frame', {
         streamed: true
     }, streamHandler);
 
-    var req = client.request({
+    var req = client.makeSubChannel({
+        serviceName: 'stream'
+    }).request({
         serviceName: 'stream',
         host: server.hostPort,
         streamed: true

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -39,12 +39,12 @@ allocCluster.test('requests will timeout', {
     sub.register('/normal-proxy', normalProxy);
     sub.register('/timeout', timeout);
 
-    two.makeSubChannel({
+    var twoSub = two.makeSubChannel({
         serviceName: 'server',
         peers: [one.hostPort]
     });
 
-    two
+    twoSub
         .request({
             serviceName: 'server',
             timeout: 1000
@@ -57,7 +57,7 @@ allocCluster.test('requests will timeout', {
         assert.equal(String(arg2), 'h');
         assert.equal(String(arg3), 'b');
 
-        two
+        twoSub
             .request({
                 serviceName: 'server',
                 timeout: 1000

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -23,7 +23,6 @@ var DebugLogtron = require('debug-logtron');
 var test = require('tape');
 
 var TChannel = require('../../channel.js');
-var EndpointHandler = require('../../endpoint-handler.js');
 
 var logger = DebugLogtron('tchannel');
 

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -23,7 +23,6 @@ var DebugLogtron = require('debug-logtron');
 var test = require('tape');
 
 var TChannel = require('../../channel.js');
-var EndpointHandler = require('../../endpoint-handler.js');
 
 var logger = DebugLogtron('tchannel');
 


### PR DESCRIPTION
It's mandatory for every call request to have a `service` field; This means
for the server we really should use the ServiceNameHandler and we should
use sub channels with their own unique endpoint handlers to handle stuff on
the server.

I've made calling `register()` on a top level channel illegal.

For making outgoing requests; we really should use the hyperbahn client
to create sub channels for outgoing requests and call `request()` on them.

I've made calling `request()` on the top level channel illegal as it allows
people to make mistakes and accidentally make requests that end up at the
wrong peer.

I've personally been bitten by making outgoing requests on the wrong
channel before.

cc @jcorbin @kriskowal