### PR TITLE
2.0.0-IDEA: Make tracing required

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -167,7 +167,8 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
     // TODO: more http state machine integration
 
     var options = tchannel.requestOptions({
-        streamed: true
+        streamed: true,
+        topLevelRequest: true
     });
     var peer = tchannel.peers.choosePeer(null, options);
     if (!peer) {

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -168,7 +168,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
 
     var options = tchannel.requestOptions({
         streamed: true,
-        topLevelRequest: true
+        hasNoParent: true
     });
     var peer = tchannel.peers.choosePeer(null, options);
     if (!peer) {

--- a/node/channel.js
+++ b/node/channel.js
@@ -173,7 +173,7 @@ function TChannel(options) {
         self.tracer = new TracingAgent({
             logger: self.logger,
             forceTrace: self.options.forceTrace,
-            serviceName: self.options.tracingServiceName,
+            serviceName: self.options.serviceNameOverwrite,
             reporter: self.options.traceReporter
         });
 

--- a/node/channel.js
+++ b/node/channel.js
@@ -166,7 +166,10 @@ function TChannel(options) {
     self.listening = false;
     self.destroyed = false;
 
-    if (self.options.trace) {
+    var trace = typeof self.options.trace === 'boolean' ?
+        self.options.trace : true;
+
+    if (trace) {
         self.tracer = new TracingAgent({
             logger: self.logger,
             forceTrace: self.options.forceTrace,

--- a/node/errors.js
+++ b/node/errors.js
@@ -240,9 +240,9 @@ module.exports.NullKeyError = TypedError({
 module.exports.ParentSpanRequired = TypedError({
     type: 'tchannel.tracer.parent-span-required',
     message: 'parent span not specified for outgoing call req.\n' +
-        'Expected either a parent span or topLevelRequest.\n',
+        'Expected either a parent span or hasNoParent.\n',
     parentSpan: null,
-    topLevelRequest: null
+    hasNoParent: null
 });
 
 module.exports.ReconstructedError = TypedError({

--- a/node/errors.js
+++ b/node/errors.js
@@ -237,6 +237,14 @@ module.exports.NullKeyError = TypedError({
     endOffset: null
 });
 
+module.exports.ParentSpanRequired = TypedError({
+    type: 'tchannel.tracer.parent-span-required',
+    message: 'parent span not specified for outgoing call req.\n' +
+        'Expected either a parent span or topLevelRequest.\n',
+    parentSpan: null,
+    topLevelRequest: null
+});
+
 module.exports.ReconstructedError = TypedError({
     type: 'tchannel.hydrated-error.default-type',
     message: 'TChannel json hydrated error;' +
@@ -507,6 +515,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.top-level-register':
         case 'tchannel.top-level-request':
         case 'tchannel.unimplemented-method':
+        case 'tchannel.tracer.parent-span-required':
             return 'UnexpectedError';
 
         default:

--- a/node/errors.js
+++ b/node/errors.js
@@ -237,10 +237,10 @@ module.exports.NullKeyError = TypedError({
     endOffset: null
 });
 
-module.exports.ParentSpanRequired = TypedError({
-    type: 'tchannel.tracer.parent-span-required',
-    message: 'parent span not specified for outgoing call req.\n' +
-        'Expected either a parent span or hasNoParent.\n',
+module.exports.ParentRequired = TypedError({
+    type: 'tchannel.tracer.parent-required',
+    message: 'parent not specified for outgoing call req.\n' +
+        'Expected either a parent or hasNoParent.\n',
     parentSpan: null,
     hasNoParent: null
 });
@@ -515,7 +515,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.top-level-register':
         case 'tchannel.top-level-request':
         case 'tchannel.unimplemented-method':
-        case 'tchannel.tracer.parent-span-required':
+        case 'tchannel.tracer.parent-required':
             return 'UnexpectedError';
 
         default:

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -67,7 +67,7 @@ function TChannelOutRequest(id, options) {
         self.span = options.tracer.setupNewSpan({
             outgoing: true,
             parentSpan: options.parentSpan,
-            topLevelRequest: options.topLevelRequest,
+            hasNoParent: options.hasNoParent,
             spanid: null,
             traceid: null,
             parentid: null,

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -44,6 +44,8 @@ function TChannelOutRequest(id, options) {
     self.retryCount = options.retryCount;
     self.channel = options.channel;
     self.logical = !!options.logical;
+    self.parent = options.parent;
+    self.hasNoParent = options.hasNoParent;
 
     self.start = 0;
     self.end = 0;
@@ -66,7 +68,7 @@ function TChannelOutRequest(id, options) {
         // new span with new ids
         self.span = options.tracer.setupNewSpan({
             outgoing: true,
-            parentSpan: options.parentSpan,
+            parentSpan: options.parent && options.parent.span,
             hasNoParent: options.hasNoParent,
             spanid: null,
             traceid: null,

--- a/node/package.json
+++ b/node/package.json
@@ -41,6 +41,7 @@
     "debug-logtron": "4.0.0",
     "duplexer": "^0.1.1",
     "faucet": "0.0.1",
+    "format-stack": "4.0.0",
     "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
     "ldjson-stream": "^1.2.1",

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -55,7 +55,7 @@ RelayRequest.prototype.createOutRequest = function createOutRequest() {
     self.outreq = self.channel.request({
         streamed: self.inreq.streamed,
         timeout: self.inreq.ttl - elapsed,
-        parentSpan: self.inreq.span,
+        parent: self.inreq,
         serviceName: self.inreq.serviceName,
         headers: self.inreq.headers,
         retryFlags: self.inreq.retryFlags

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -55,6 +55,7 @@ RelayRequest.prototype.createOutRequest = function createOutRequest() {
     self.outreq = self.channel.request({
         streamed: self.inreq.streamed,
         timeout: self.inreq.ttl - elapsed,
+        parentSpan: self.inreq.span,
         serviceName: self.inreq.serviceName,
         headers: self.inreq.headers,
         retryFlags: self.inreq.retryFlags

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -37,6 +37,7 @@ allocCluster.test('getting an ok response', {
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
+        topLevelRequest: true,
         timeout: 1500
     }), 'echo', {
         some: 'head'
@@ -79,7 +80,8 @@ allocCluster.test('getting a not ok response', {
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
-        timeout: 1500
+        timeout: 1500,
+        topLevelRequest: true
     }), 'echo', {
         some: 'head'
     }, {
@@ -123,7 +125,8 @@ allocCluster.test('getting an UnexpectedError frame', {
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
-        timeout: 1500
+        timeout: 1500,
+        topLevelRequest: true
     }), 'echo', null, null, function onResponse(err, resp) {
         assert.ok(err);
         assert.equal(err.isErrorFrame, true);
@@ -151,7 +154,8 @@ allocCluster.test('getting a BadRequest frame', {
         timeout: 1500,
         headers: {
             as: 'json'
-        }
+        },
+        topLevelRequest: true
     }).send('echo', '123malformed json', null, onResponse);
 
     function onResponse(err, resp) {
@@ -183,7 +187,8 @@ allocCluster.test('sending without as header', {
 
     client.request({
         serviceName: 'server',
-        timeout: 1500
+        timeout: 1500,
+        topLevelRequest: true
     }).send('echo', '123malformed json', null, onResponse);
 
     function onResponse(err, resp) {

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -37,7 +37,7 @@ allocCluster.test('getting an ok response', {
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         timeout: 1500
     }), 'echo', {
         some: 'head'
@@ -81,7 +81,7 @@ allocCluster.test('getting a not ok response', {
     tchannelJSON.send(client.request({
         serviceName: 'server',
         timeout: 1500,
-        topLevelRequest: true
+        hasNoParent: true
     }), 'echo', {
         some: 'head'
     }, {
@@ -126,7 +126,7 @@ allocCluster.test('getting an UnexpectedError frame', {
     tchannelJSON.send(client.request({
         serviceName: 'server',
         timeout: 1500,
-        topLevelRequest: true
+        hasNoParent: true
     }), 'echo', null, null, function onResponse(err, resp) {
         assert.ok(err);
         assert.equal(err.isErrorFrame, true);
@@ -155,7 +155,7 @@ allocCluster.test('getting a BadRequest frame', {
         headers: {
             as: 'json'
         },
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', '123malformed json', null, onResponse);
 
     function onResponse(err, resp) {
@@ -188,7 +188,7 @@ allocCluster.test('sending without as header', {
     client.request({
         serviceName: 'server',
         timeout: 1500,
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', '123malformed json', null, onResponse);
 
     function onResponse(err, resp) {

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -47,7 +47,7 @@ allocCluster.test('send and receiving an ok', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -71,7 +71,7 @@ allocCluster.test('send and receive a not ok', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -97,7 +97,7 @@ allocCluster.test('send and receive a typed not ok', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -123,7 +123,7 @@ allocCluster.test('sending and receiving headers', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', {
         headerA: 'headerA',
         headerB: 'headerB'
@@ -157,7 +157,7 @@ allocCluster.test('getting an UnexpectedError frame', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, resp) {
@@ -184,7 +184,7 @@ allocCluster.test('getting a BadRequest frame', {
 
     client.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         timeout: 1500,
         headers: {
             as: 'thrift'
@@ -222,7 +222,7 @@ allocCluster.test('sending without as header', {
 
     client.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         timeout: 1500
     }).send('Chamber::echo', null, null, onResponse);
 
@@ -255,7 +255,7 @@ allocCluster.test('send without required fields', {
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server',
-        topLevelRequest: true
+        hasNoParent: true
     }), 'Chamber::echo', null, {
         value: 'lol'
     }, function onResponse(err, res) {

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -46,7 +46,8 @@ allocCluster.test('send and receiving an ok', {
     var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -69,7 +70,8 @@ allocCluster.test('send and receive a not ok', {
     var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -94,7 +96,8 @@ allocCluster.test('send and receive a typed not ok', {
     var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, res) {
@@ -119,7 +122,8 @@ allocCluster.test('sending and receiving headers', {
     var client = cluster.channels[1].subChannels.server;
 
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', {
         headerA: 'headerA',
         headerB: 'headerB'
@@ -152,7 +156,8 @@ allocCluster.test('getting an UnexpectedError frame', {
     );
 
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', null, {
         value: 10
     }, function onResponse(err, resp) {
@@ -179,6 +184,7 @@ allocCluster.test('getting a BadRequest frame', {
 
     client.request({
         serviceName: 'server',
+        topLevelRequest: true,
         timeout: 1500,
         headers: {
             as: 'thrift'
@@ -216,6 +222,7 @@ allocCluster.test('sending without as header', {
 
     client.request({
         serviceName: 'server',
+        topLevelRequest: true,
         timeout: 1500
     }).send('Chamber::echo', null, null, onResponse);
 
@@ -240,14 +247,15 @@ allocCluster.test('send without required fields', {
     makeTChannelThriftServer(cluster, {
         okResponse: true
     });
+
+    var client = cluster.channels[1].subChannels.server;
     var tchannelAsThrift = client.TChannelAsThrift({
         source: badThriftText
     });
 
-    var client = cluster.channels[1].subChannels.server;
-
     tchannelAsThrift.send(client.request({
-        serviceName: 'server'
+        serviceName: 'server',
+        topLevelRequest: true
     }), 'Chamber::echo', null, {
         value: 'lol'
     }, function onResponse(err, res) {

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -74,7 +74,7 @@ allocCluster.test('sending OK OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -132,7 +132,7 @@ allocCluster.test('sending OK NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -194,7 +194,7 @@ allocCluster.test('sending OK ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -249,7 +249,7 @@ allocCluster.test('sending NOT_OK OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -307,7 +307,7 @@ allocCluster.test('sending NOT_OK NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -369,7 +369,7 @@ allocCluster.test('sending NOT_OK ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -428,7 +428,7 @@ allocCluster.test('sending ERROR_FRAME OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -499,7 +499,7 @@ allocCluster.test('sending ERROR_FRAME NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -570,7 +570,7 @@ allocCluster.test('sending ERROR_FRAME ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -634,7 +634,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {
@@ -692,7 +692,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {
@@ -754,7 +754,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -74,6 +74,7 @@ allocCluster.test('sending OK OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -131,6 +132,7 @@ allocCluster.test('sending OK NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -192,6 +194,7 @@ allocCluster.test('sending OK ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -246,6 +249,7 @@ allocCluster.test('sending NOT_OK OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -303,6 +307,7 @@ allocCluster.test('sending NOT_OK NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -364,6 +369,7 @@ allocCluster.test('sending NOT_OK ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -422,6 +428,7 @@ allocCluster.test('sending ERROR_FRAME OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -492,6 +499,7 @@ allocCluster.test('sending ERROR_FRAME NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -562,6 +570,7 @@ allocCluster.test('sending ERROR_FRAME ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server'
     }), 'DoubleResponse::method', null, {
         value: 'foobar'
@@ -625,6 +634,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {
@@ -682,6 +692,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT NOT_OK', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {
@@ -743,6 +754,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT ERROR_FRAME', {
     );
 
     cluster.asThrift.send(cluster.client.request({
+        topLevelRequest: true,
         serviceName: 'server',
         timeout: 100
     }), 'DoubleResponse::method', null, {

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -239,7 +239,8 @@ function testSetup(desc, testFunc) {
         cluster.send = function send(op) {
             return function runSendTest(callback) {
                 client.request({
-                    serviceName: 'tiberius'
+                    serviceName: 'tiberius', 
+                    topLevelRequest: true
                 }).send(op, '', '', onResult);
                 function onResult(err, res, arg2, arg3) {
                     callback(null, {

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -240,7 +240,7 @@ function testSetup(desc, testFunc) {
             return function runSendTest(callback) {
                 client.request({
                     serviceName: 'tiberius', 
-                    topLevelRequest: true
+                    hasNoParent: true
                 }).send(op, '', '', onResult);
                 function onResult(err, res, arg2, arg3) {
                     callback(null, {

--- a/node/test/peers.js
+++ b/node/test/peers.js
@@ -37,7 +37,7 @@ allocCluster.test('add a peer and request', {
 
     bob.request({
         serviceName: 'steve',
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err) {
@@ -48,7 +48,7 @@ allocCluster.test('add a peer and request', {
         bob.peers.add(steve.hostPort);
         bob.request({
             serviceName: 'steve',
-            topLevelRequest: true
+            hasNoParent: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -77,7 +77,7 @@ allocCluster.test('adding a peer twice', {
     bob.peers.add(steve.hostPort);
     bob.request({
         serviceName: 'steve',
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', 'a', 'b', onResponse2);
 
     function onResponse2(err, res) {
@@ -105,7 +105,7 @@ allocCluster.test('removing a peer and request', {
     bob.peers.add(steve.hostPort);
     bob.request({
         serviceName: 'steve',
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err, res) {
@@ -115,7 +115,7 @@ allocCluster.test('removing a peer and request', {
         bob.peers.delete(steve.hostPort);
         bob.request({
             serviceName: 'steve',
-            topLevelRequest: true
+            hasNoParent: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -145,7 +145,7 @@ allocCluster.test('clearing peers and requests', {
     bob.peers.add(steve2.hostPort);
     bob.request({
         serviceName: 'steve',
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err, res) {
@@ -155,7 +155,7 @@ allocCluster.test('clearing peers and requests', {
         bob.peers.clear();
         bob.request({
             serviceName: 'steve',
-            topLevelRequest: true
+            hasNoParent: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -189,11 +189,11 @@ allocCluster.test('delete peer() on top channel', {
     parallel([
         thunkSend(bob1, {
             serviceName: 'steve1',
-            topLevelRequest: true
+            hasNoParent: true
         }, 'echo', 'a', 'b'),
         thunkSend(bob2, {
             serviceName: 'steve2',
-            topLevelRequest: true
+            hasNoParent: true
         }, 'echo', 'a', 'b')
     ], onResponses);
 
@@ -209,11 +209,11 @@ allocCluster.test('delete peer() on top channel', {
         parallel([
             thunkSend(bob1, {
                 serviceName: 'steve1',
-                topLevelRequest: true
+                hasNoParent: true
             }, 'echo', 'a', 'b'),
             thunkSend(bob2, {
                 serviceName: 'steve2',
-                topLevelRequest: true
+                hasNoParent: true
             }, 'echo', 'a', 'b')
         ], onResponses2);
     }
@@ -261,11 +261,11 @@ allocCluster.test('peers.clear() on top channel', {
     parallel([
         thunkSend(bob1, {
             serviceName: 'steve1',
-            topLevelRequest: true
+            hasNoParent: true
         }, 'echo', 'a', 'b'),
         thunkSend(bob2, {
             serviceName: 'steve2',
-            topLevelRequest: true
+            hasNoParent: true
         }, 'echo', 'a', 'b')
     ], onResponses);
 
@@ -281,11 +281,11 @@ allocCluster.test('peers.clear() on top channel', {
         parallel([
             thunkSend(bob1, {
                 serviceName: 'steve1',
-                topLevelRequest: true
+                hasNoParent: true
             }, 'echo', 'a', 'b'),
             thunkSend(bob2, {
                 serviceName: 'steve2',
-                topLevelRequest: true
+                hasNoParent: true
             }, 'echo', 'a', 'b')
         ], onResponses2);
     }

--- a/node/test/peers.js
+++ b/node/test/peers.js
@@ -36,7 +36,8 @@ allocCluster.test('add a peer and request', {
     });
 
     bob.request({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        topLevelRequest: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err) {
@@ -46,7 +47,8 @@ allocCluster.test('add a peer and request', {
 
         bob.peers.add(steve.hostPort);
         bob.request({
-            serviceName: 'steve'
+            serviceName: 'steve',
+            topLevelRequest: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -74,7 +76,8 @@ allocCluster.test('adding a peer twice', {
     bob.peers.add(steve.hostPort);
     bob.peers.add(steve.hostPort);
     bob.request({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        topLevelRequest: true
     }).send('echo', 'a', 'b', onResponse2);
 
     function onResponse2(err, res) {
@@ -101,7 +104,8 @@ allocCluster.test('removing a peer and request', {
 
     bob.peers.add(steve.hostPort);
     bob.request({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        topLevelRequest: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err, res) {
@@ -110,7 +114,8 @@ allocCluster.test('removing a peer and request', {
 
         bob.peers.delete(steve.hostPort);
         bob.request({
-            serviceName: 'steve'
+            serviceName: 'steve',
+            topLevelRequest: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -139,7 +144,8 @@ allocCluster.test('clearing peers and requests', {
     bob.peers.add(steve1.hostPort);
     bob.peers.add(steve2.hostPort);
     bob.request({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        topLevelRequest: true
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err, res) {
@@ -148,7 +154,8 @@ allocCluster.test('clearing peers and requests', {
 
         bob.peers.clear();
         bob.request({
-            serviceName: 'steve'
+            serviceName: 'steve',
+            topLevelRequest: true
         }).send('echo', 'a', 'b', onResponse2);
     }
 
@@ -181,10 +188,12 @@ allocCluster.test('delete peer() on top channel', {
 
     parallel([
         thunkSend(bob1, {
-            serviceName: 'steve1'
+            serviceName: 'steve1',
+            topLevelRequest: true
         }, 'echo', 'a', 'b'),
         thunkSend(bob2, {
-            serviceName: 'steve2'
+            serviceName: 'steve2',
+            topLevelRequest: true
         }, 'echo', 'a', 'b')
     ], onResponses);
 
@@ -199,10 +208,12 @@ allocCluster.test('delete peer() on top channel', {
 
         parallel([
             thunkSend(bob1, {
-                serviceName: 'steve1'
+                serviceName: 'steve1',
+                topLevelRequest: true
             }, 'echo', 'a', 'b'),
             thunkSend(bob2, {
-                serviceName: 'steve2'
+                serviceName: 'steve2',
+                topLevelRequest: true
             }, 'echo', 'a', 'b')
         ], onResponses2);
     }
@@ -249,10 +260,12 @@ allocCluster.test('peers.clear() on top channel', {
 
     parallel([
         thunkSend(bob1, {
-            serviceName: 'steve1'
+            serviceName: 'steve1',
+            topLevelRequest: true
         }, 'echo', 'a', 'b'),
         thunkSend(bob2, {
-            serviceName: 'steve2'
+            serviceName: 'steve2',
+            topLevelRequest: true
         }, 'echo', 'a', 'b')
     ], onResponses);
 
@@ -267,10 +280,12 @@ allocCluster.test('peers.clear() on top channel', {
 
         parallel([
             thunkSend(bob1, {
-                serviceName: 'steve1'
+                serviceName: 'steve1',
+                topLevelRequest: true
             }, 'echo', 'a', 'b'),
             thunkSend(bob2, {
-                serviceName: 'steve2'
+                serviceName: 'steve2',
+                topLevelRequest: true
             }, 'echo', 'a', 'b')
         ], onResponses2);
     }

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -220,7 +220,7 @@ allocCluster.test('register() with different results', {
 });
 
 function sendCall(channel, opts, op, cb) {
-    opts.topLevelRequest = true;
+    opts.hasNoParent = true;
 
     channel
         .request(opts)

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -220,6 +220,8 @@ allocCluster.test('register() with different results', {
 });
 
 function sendCall(channel, opts, op, cb) {
+    opts.topLevelRequest = true;
+
     channel
         .request(opts)
         .send(op, null, null, onResult);

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -45,6 +45,7 @@ allocCluster.test('does not leak inOps', {
     subTwo
         .request({
             serviceName: 'server',
+            topLevelRequest: true,
             timeout: 100
         })
         .send('/timeout', 'h', 'b', onTimeout);

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -45,7 +45,7 @@ allocCluster.test('does not leak inOps', {
     subTwo
         .request({
             serviceName: 'server',
-            topLevelRequest: true,
+            hasNoParent: true,
             timeout: 100
         })
         .send('/timeout', 'h', 'b', onTimeout);

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -53,7 +53,7 @@ allocCluster.test('send relay requests', {
     });
 
     twoClient.request({
-        topLevelRequest: true
+        hasNoParent: true
     }).send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.ifError(err, 'no unexpected error');
         assert.equal(String(arg2), 'foo', 'expected arg2');
@@ -89,7 +89,7 @@ allocCluster.test('relay respects ttl', {
 
     sourceChan.request({
         serviceName: 'dest',
-        topLevelRequest: true,
+        hasNoParent: true,
         timeout: 250
     }).send('echoTTL', null, null, onResponse);
 
@@ -145,7 +145,7 @@ allocCluster.test('relay an error frame', {
     });
 
     twoClient.request({
-        topLevelRequest: true
+        hasNoParent: true
     }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');
 

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -52,7 +52,9 @@ allocCluster.test('send relay requests', {
         }
     });
 
-    twoClient.request().send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request({
+        topLevelRequest: true
+    }).send('echo', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.ifError(err, 'no unexpected error');
         assert.equal(String(arg2), 'foo', 'expected arg2');
         assert.equal(String(arg3), 'bar', 'expected arg3');
@@ -87,6 +89,7 @@ allocCluster.test('relay respects ttl', {
 
     sourceChan.request({
         serviceName: 'dest',
+        topLevelRequest: true,
         timeout: 250
     }).send('echoTTL', null, null, onResponse);
 
@@ -141,7 +144,9 @@ allocCluster.test('relay an error frame', {
         }
     });
 
-    twoClient.request().send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
+    twoClient.request({
+        topLevelRequest: true
+    }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');
 
         assert.end();

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -52,6 +52,7 @@ allocCluster.test('emits stats', {
 
     clientChan.request({
         serviceName: 'server',
+        topLevelRequest: true,
         headers: {
             cn: 'client'
         }

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -52,7 +52,7 @@ allocCluster.test('emits stats', {
 
     clientChan.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'client'
         }

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -61,7 +61,7 @@ allocCluster.test('emits stats on call success', {
 
     clientChan.request({
         serviceName: 'reservoir',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'inPipe'
         }
@@ -135,7 +135,7 @@ allocCluster.test('emits stats on call failure', {
 
     clientChan.request({
         serviceName: 'reservoir',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'inPipe'
         }

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -61,6 +61,7 @@ allocCluster.test('emits stats on call success', {
 
     clientChan.request({
         serviceName: 'reservoir',
+        topLevelRequest: true,
         headers: {
             cn: 'inPipe'
         }
@@ -134,6 +135,7 @@ allocCluster.test('emits stats on call failure', {
 
     clientChan.request({
         serviceName: 'reservoir',
+        topLevelRequest: true,
         headers: {
             cn: 'inPipe'
         }

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -51,7 +51,7 @@ allocCluster.test('emits response stats with ok', {
 
     clientChan.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'client'
         }
@@ -128,7 +128,7 @@ allocCluster.test('emits response stats with not ok', {
 
     clientChan.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'client'
         }
@@ -206,7 +206,7 @@ allocCluster.test('emits response stats with error', {
 
     clientChan.request({
         serviceName: 'server',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'client'
         }

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -51,6 +51,7 @@ allocCluster.test('emits response stats with ok', {
 
     clientChan.request({
         serviceName: 'server',
+        topLevelRequest: true,
         headers: {
             cn: 'client'
         }
@@ -127,6 +128,7 @@ allocCluster.test('emits response stats with not ok', {
 
     clientChan.request({
         serviceName: 'server',
+        topLevelRequest: true,
         headers: {
             cn: 'client'
         }
@@ -204,6 +206,7 @@ allocCluster.test('emits response stats with error', {
 
     clientChan.request({
         serviceName: 'server',
+        topLevelRequest: true,
         headers: {
             cn: 'client'
         }

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -61,7 +61,7 @@ allocCluster.test('emits stats on response ok', {
 
     clientChan.request({
         serviceName: 'reservoir',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'inPipe'
         }
@@ -129,7 +129,7 @@ allocCluster.test('emits stats on response not ok', {
 
     clientChan.request({
         serviceName: 'reservoir',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'inPipe'
         }
@@ -197,7 +197,7 @@ allocCluster.test('emits stats on response error', {
 
     clientChan.request({
         serviceName: 'reservoir',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             cn: 'inPipe'
         }

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -61,6 +61,7 @@ allocCluster.test('emits stats on response ok', {
 
     clientChan.request({
         serviceName: 'reservoir',
+        topLevelRequest: true,
         headers: {
             cn: 'inPipe'
         }
@@ -128,6 +129,7 @@ allocCluster.test('emits stats on response not ok', {
 
     clientChan.request({
         serviceName: 'reservoir',
+        topLevelRequest: true,
         headers: {
             cn: 'inPipe'
         }
@@ -195,6 +197,7 @@ allocCluster.test('emits stats on response error', {
 
     clientChan.request({
         serviceName: 'reservoir',
+        topLevelRequest: true,
         headers: {
             cn: 'inPipe'
         }

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -72,6 +72,7 @@ allocCluster.test('request retries', {
     });
 
     var req = chan.request({
+        topLevelRequest: true,
         timeout: 100
     });
     req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
@@ -178,6 +179,7 @@ allocCluster.test('request application retries', {
 
     var req = chan.request({
         timeout: 100,
+        topLevelRequest: true,
         shouldApplicationRetry: function shouldApplicationRetry(req, res, retry, done) {
             if (res.streamed) {
                 res.arg2.onValueReady(function arg2ready(err, arg2) {
@@ -299,6 +301,7 @@ allocCluster.test('retryFlags work', {
 
         function defaultToNotRetryingTimeout(next) {
             var req = chan.request({
+                topLevelRequest: true,
                 timeout: 100
             });
             req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
@@ -310,6 +313,7 @@ allocCluster.test('retryFlags work', {
 
         function canRetryTimeout(next) {
             var req = chan.request({
+                topLevelRequest: true,
                 retryFlags: {
                     never: false,
                     onConnectionError: true,
@@ -337,6 +341,7 @@ allocCluster.test('retryFlags work', {
 
         function canOptOutFully(next) {
             var req = chan.request({
+                topLevelRequest: true,
                 timeout: 100,
                 retryFlags: {
                     never: true,

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -72,7 +72,7 @@ allocCluster.test('request retries', {
     });
 
     var req = chan.request({
-        topLevelRequest: true,
+        hasNoParent: true,
         timeout: 100
     });
     req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
@@ -179,7 +179,7 @@ allocCluster.test('request application retries', {
 
     var req = chan.request({
         timeout: 100,
-        topLevelRequest: true,
+        hasNoParent: true,
         shouldApplicationRetry: function shouldApplicationRetry(req, res, retry, done) {
             if (res.streamed) {
                 res.arg2.onValueReady(function arg2ready(err, arg2) {
@@ -301,7 +301,7 @@ allocCluster.test('retryFlags work', {
 
         function defaultToNotRetryingTimeout(next) {
             var req = chan.request({
-                topLevelRequest: true,
+                hasNoParent: true,
                 timeout: 100
             });
             req.send('foo', '', 'hi', function done(err, res, arg2, arg3) {
@@ -313,7 +313,7 @@ allocCluster.test('retryFlags work', {
 
         function canRetryTimeout(next) {
             var req = chan.request({
-                topLevelRequest: true,
+                hasNoParent: true,
                 retryFlags: {
                     never: false,
                     onConnectionError: true,
@@ -341,7 +341,7 @@ allocCluster.test('retryFlags work', {
 
         function canOptOutFully(next) {
             var req = chan.request({
-                topLevelRequest: true,
+                hasNoParent: true,
                 timeout: 100,
                 retryFlags: {
                     never: true,

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -333,7 +333,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
 
     subOne.request({
         host: one.hostPort,
-        topLevelRequest: true
+        hasNoParent: true
     }).send('foo', '', '', onResponse);
 
     function onResponse(err) {
@@ -365,7 +365,7 @@ function randSeq(seq) {
 function sendTest(testCase, assert) {
     return function runSendTest(callback) {
         testCase.opts = testCase.opts || {};
-        testCase.opts.topLevelRequest = true;
+        testCase.opts.hasNoParent = true;
 
         testCase.channel
             .request(testCase.opts)

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -332,7 +332,8 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
     });
 
     subOne.request({
-        host: one.hostPort
+        host: one.hostPort,
+        topLevelRequest: true
     }).send('foo', '', '', onResponse);
 
     function onResponse(err) {
@@ -363,6 +364,9 @@ function randSeq(seq) {
 
 function sendTest(testCase, assert) {
     return function runSendTest(callback) {
+        testCase.opts = testCase.opts || {};
+        testCase.opts.topLevelRequest = true;
+
         testCase.channel
             .request(testCase.opts)
             .send(testCase.op, testCase.reqHead, testCase.reqBody, onResult);

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -41,7 +41,7 @@ allocCluster.test('end response with error frame', {
         serviceName: 'stream'
     }).request({
         serviceName: 'stream',
-        topLevelRequest: true,
+        hasNoParent: true,
         host: server.hostPort,
         streamed: true
     });

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -41,6 +41,7 @@ allocCluster.test('end response with error frame', {
         serviceName: 'stream'
     }).request({
         serviceName: 'stream',
+        topLevelRequest: true,
         host: server.hostPort,
         streamed: true
     });

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -96,7 +96,8 @@ allocCluster.test('streaming echo w/ streaming callback', 2, function t(cluster,
 function partsTest(testCase, assert) {
     return function runSendTest(callback) {
         var options = extend({
-            streamed: true
+            streamed: true,
+            topLevelRequest: true
         }, testCase.opts);
 
         var peer = testCase.channel.peers.choosePeer(null, options);

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -97,7 +97,7 @@ function partsTest(testCase, assert) {
     return function runSendTest(callback) {
         var options = extend({
             streamed: true,
-            topLevelRequest: true
+            hasNoParent: true
         }, testCase.opts);
 
         var peer = testCase.channel.peers.choosePeer(null, options);

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -92,7 +92,7 @@ function streamingEchoTest(cluster, state, assert, callback) {
 
     cluster.testRawClient.request({
         serviceName: 'test_as_raw',
-        topLevelRequest: true,
+        hasNoParent: true,
         headers: {
             as: 'raw'
         },

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -92,6 +92,7 @@ function streamingEchoTest(cluster, state, assert, callback) {
 
     cluster.testRawClient.request({
         serviceName: 'test_as_raw',
+        topLevelRequest: true,
         headers: {
             as: 'raw'
         },

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -47,7 +47,7 @@ allocCluster.test('requests will timeout', {
     twoSub
         .request({
             serviceName: 'server',
-            topLevelRequest: true,
+            hasNoParent: true,
             timeout: 1000
         })
         .send('/normal-proxy', 'h', 'b', onResp);
@@ -61,7 +61,7 @@ allocCluster.test('requests will timeout', {
         twoSub
             .request({
                 serviceName: 'server',
-                topLevelRequest: true,
+                hasNoParent: true,
                 timeout: 1000
             })
             .send('/timeout', 'h', 'b', onTimeout);

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -47,6 +47,7 @@ allocCluster.test('requests will timeout', {
     twoSub
         .request({
             serviceName: 'server',
+            topLevelRequest: true,
             timeout: 1000
         })
         .send('/normal-proxy', 'h', 'b', onResp);
@@ -60,6 +61,7 @@ allocCluster.test('requests will timeout', {
         twoSub
             .request({
                 serviceName: 'server',
+                topLevelRequest: true,
                 timeout: 1000
             })
             .send('/timeout', 'h', 'b', onTimeout);

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -77,7 +77,7 @@ test('basic tracing test', function (assert) {
             var servReq = serverChan.request({
                 host: '127.0.0.1:4042',
                 serviceName: 'subservice',
-                parentSpan: req.span,
+                parent: req,
                 trace: true});
             var peers = server.peers.values();
             var ready = new CountedReadySignal(peers.length);

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -110,7 +110,7 @@ test('basic tracing test', function (assert) {
         var req = clientChan.request({
             host: '127.0.0.1:4040',
             serviceName: 'server',
-            topLevelRequest: true,
+            hasNoParent: true,
             trace: true
         });
         var peers = client.peers.values();

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -105,13 +105,13 @@ test('basic tracing test', function (assert) {
         if (err) {
             throw err;
         }
-        
+
         logger.debug('client making req');
         var req = clientChan.request({
             host: '127.0.0.1:4040',
             serviceName: 'server',
-            trace: true,
-            topLevelRequest: true
+            topLevelRequest: true,
+            trace: true
         });
         var peers = client.peers.values();
         var ready = new CountedReadySignal(peers.length);

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -85,7 +85,7 @@ test('basic tracing test', function (assert) {
                 .request({
                     host: '127.0.0.1:4042',
                     serviceName: 'subservice',
-                    parentSpan: req.span,
+                    parent: req,
                     trace: true
                 }).send('/foobar', 'arg1', 'arg2', function (err, subRes) {
                     logger.debug("top level recv from subservice: " + subRes);
@@ -99,7 +99,7 @@ test('basic tracing test', function (assert) {
             var servReq = serverChan.request({
                 host: '127.0.0.1:4042',
                 serviceName: 'subservice',
-                parentSpan: req.span,
+                parent: req,
                 trace: true});
             var peers = server.peers.values();
             var ready = new CountedReadySignal(peers.length);

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -139,7 +139,7 @@ test('basic tracing test', function (assert) {
             host: '127.0.0.1:4040',
             serviceName: 'server',
             trace: true,
-            topLevelRequest: true
+            hasNoParent: true
         });
         var peers = client.peers.values();
         var ready = new CountedReadySignal(peers.length);

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -44,7 +44,9 @@ function Agent(options) {
     // incoming reuqests
     self.serviceName = options.serviceName || null;
 
-    self.reporter = options.reporter || nullReporter;
+    if (options.reporter) {
+        self.reporter = options.reporter;
+    }
 }
 
 function compareBufs(buf1, buf2) {
@@ -121,5 +123,5 @@ Agent.prototype.report = function report(span) {
     }
 };
 
-function nullReporter() {}
+Agent.prototype.reporter = function nullReporter() {};
 

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -92,10 +92,10 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
     });
 
     var parentSpan = options.parentSpan;
-    if (options.outgoing && !parentSpan && !options.topLevelRequest) {
+    if (options.outgoing && !parentSpan && !options.hasNoParent) {
         throw errors.ParentSpanRequired({
             parentSpan: parentSpan,
-            topLevelRequest: options.topLevelRequest
+            hasNoParent: options.hasNoParent
         });
     }
 

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var Span = require('./span');
+var errors = require('../errors.js');
 
 module.exports = Agent;
 
@@ -92,8 +93,10 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var parentSpan = options.parentSpan;
     if (options.outgoing && !parentSpan && !options.topLevelRequest) {
-        self.logger.warn("TChannel tracer: parent span not specified " +
-            "for outgoing request!", options);
+        throw errors.ParentSpanRequired({
+            parentSpan: parentSpan,
+            topLevelRequest: options.topLevelRequest
+        });
     }
 
     if (parentSpan && (!options.parentid && !options.traceid)) {

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -93,7 +93,7 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
 
     var parentSpan = options.parentSpan;
     if (options.outgoing && !parentSpan && !options.hasNoParent) {
-        throw errors.ParentSpanRequired({
+        throw errors.ParentRequired({
             parentSpan: parentSpan,
             hasNoParent: options.hasNoParent
         });

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -43,7 +43,7 @@ function Agent(options) {
     // incoming reuqests
     self.serviceName = options.serviceName || null;
 
-    self.reporter = options.reporter || self.reporter;
+    self.reporter = options.reporter || nullReporter;
 }
 
 function compareBufs(buf1, buf2) {
@@ -118,11 +118,5 @@ Agent.prototype.report = function report(span) {
     }
 };
 
-// Default reporter, just logs.
-Agent.prototype.reporter = function (span) {
-    var self = this;
-
-    // TODO: actual reporting
-    self.logger.info('got span: ' + span.toString());
-};
+function nullReporter() {}
 


### PR DESCRIPTION
 - Defaults tracing to true; tracing is opt out
 - Make the parentSpan propagation required
 - Fix relay handler to propagate tracing
 - Default trace agent to be silent.

For zipkin and tracing infrastructure to work we need
tracing always on. It should be opt out not opt in.

For tracing to work at all; we need application developers
to manually propagate parent spans. The only way we can
garantuee that they will propagate spans is to make it
a programmer error if they fail to do so. (it used to be
a warning).

cc @jcorbin @kriskowal