### PR TITLE
2.0.0-IDEA: Make the "as" transport header mandatory

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -389,11 +389,31 @@ TChannel.prototype.requestOptions = function requestOptions(options) {
     var opts = {};
     // jshint forin:false
     for (prop in self.requestDefaults) {
+        if (prop === 'headers') {
+            continue;
+        }
+
         opts[prop] = self.requestDefaults[prop];
     }
+    opts.headers = {};
+    if (self.requestDefaults.headers) {
+        for (prop in self.requestDefaults.headers) {
+            opts.headers[prop] = self.requestDefaults.headers[prop];
+        }
+    }
+
     if (options) {
         for (prop in options) {
+            if (prop === 'headers') {
+                continue;
+            }
             opts[prop] = options[prop];
+        }
+    }
+    if (options && options.headers) {
+        opts.headers = opts.headers;
+        for (prop in options.headers) {
+            opts.headers[prop] = options.headers[prop];
         }
     }
     // jshint forin:true

--- a/node/channel.js
+++ b/node/channel.js
@@ -116,7 +116,7 @@ function TChannel(options) {
     self.random = self.options.random || globalRandom;
     self.timers = self.options.timers || globalTimers;
     self.initTimeout = self.options.initTimeout || 2000;
-    self.forceAs = self.options.forceAs;
+    self.requireAs = self.options.requireAs;
 
     // Filled in by the listen call:
     self.host = null;

--- a/node/channel.js
+++ b/node/channel.js
@@ -116,6 +116,7 @@ function TChannel(options) {
     self.random = self.options.random || globalRandom;
     self.timers = self.options.timers || globalTimers;
     self.initTimeout = self.options.initTimeout || 2000;
+    self.forceAs = self.options.forceAs;
 
     // Filled in by the listen call:
     self.host = null;

--- a/node/connection.js
+++ b/node/connection.js
@@ -45,6 +45,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         random: self.channel.random,
         timers: self.channel.timers,
         hostPort: self.channel.hostPort,
+        forceAs: self.channel.forceAs,
         tracer: self.tracer,
         connection: self
     };

--- a/node/connection.js
+++ b/node/connection.js
@@ -45,7 +45,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         random: self.channel.random,
         timers: self.channel.timers,
         hostPort: self.channel.hostPort,
-        forceAs: self.channel.forceAs,
+        requireAs: self.channel.requireAs,
         tracer: self.tracer,
         connection: self
     };

--- a/node/errors.js
+++ b/node/errors.js
@@ -46,6 +46,11 @@ module.exports.ArgChunkOutOfOrderError = TypedError({
     got: null
 });
 
+module.exports.AsHeaderRequired = TypedError({
+    type: 'tchannel.handler.incoming-req-as-header-required',
+    message: 'Expected incoming call request to have "as" header set.'
+});
+
 module.exports.CallReqBeforeInitReqError = TypedError({
     type: 'tchannel.init.call-request-before-init-request',
     message: 'call request before init request'
@@ -492,6 +497,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.protocol.read-failed':
         case 'tchannel.protocol.write-failed':
         case 'tchannel.unhandled-frame-type':
+        case 'tchannel.handler.incoming-req-as-header-required':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/errors.js
+++ b/node/errors.js
@@ -48,7 +48,8 @@ module.exports.ArgChunkOutOfOrderError = TypedError({
 
 module.exports.AsHeaderRequired = TypedError({
     type: 'tchannel.handler.incoming-req-as-header-required',
-    message: 'Expected incoming call request to have "as" header set.'
+    message: 'Expected incoming call {frame} to have "as" header set.',
+    frame: null
 });
 
 module.exports.CallReqBeforeInitReqError = TypedError({

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -117,6 +117,7 @@ RelayRequest.prototype.onResponse = function onResponse(res) {
 
     if (!self.createOutResponse({
         streamed: self.inres.streamed,
+        headers: self.inres.headers,
         code: self.inres.code
     })) return;
 

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -188,7 +188,10 @@ allocCluster.test('sending without as header', {
     client.request({
         serviceName: 'server',
         timeout: 1500,
-        hasNoParent: true
+        hasNoParent: true,
+        headers: {
+            as: 'lol'
+        },
     }).send('echo', '123malformed json', null, onResponse);
 
     function onResponse(err, resp) {

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -223,6 +223,9 @@ allocCluster.test('sending without as header', {
     client.request({
         serviceName: 'server',
         hasNoParent: true,
+        headers: {
+            as: 'lol'
+        },
         timeout: 1500
     }).send('Chamber::echo', null, null, onResponse);
 

--- a/node/test/max_pending.js
+++ b/node/test/max_pending.js
@@ -118,6 +118,9 @@ function testBattle(name, options, expectedErrorTypes) {
             return function sendChallenge(cb) {
                 dumChannel.request({
                     serviceName: 'battle',
+                    headers: {
+                        as: 'raw'
+                    },
                     timeout: 1000
                 }).send('start', '', '', regardless(cb));
             };

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -30,6 +30,11 @@ allocCluster.test('healthy state stays healthy', {
     channelOptions: {
         timers: MockTimers(Date.now()),
         random: winning
+    },
+    requestDefaults: {
+        headers: {
+            as: 'raw'
+        }
     }
 }, function t(cluster, assert) {
     var one = cluster.channels[0];
@@ -228,6 +233,7 @@ function testSetup(desc, testFunc) {
         // manually set minRequests requirement to 0
         peer.state.minRequests = 0;
         service.register('glad', function(req, res) {
+            res.headers.as = 'raw';
             res.sendOk('pool', 'party');
         });
         service.register('sad', function(req, res) {
@@ -240,7 +246,10 @@ function testSetup(desc, testFunc) {
             return function runSendTest(callback) {
                 client.request({
                     serviceName: 'tiberius', 
-                    hasNoParent: true
+                    hasNoParent: true,
+                    headers: {
+                        as: 'raw'
+                    }
                 }).send(op, '', '', onResult);
                 function onResult(err, res, arg2, arg3) {
                     callback(null, {

--- a/node/test/peers.js
+++ b/node/test/peers.js
@@ -32,7 +32,12 @@ allocCluster.test('add a peer and request', {
 
     setupEcho(steve, 'steve');
     bob = bob.makeSubChannel({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob.request({
@@ -70,7 +75,12 @@ allocCluster.test('adding a peer twice', {
 
     setupEcho(steve, 'steve');
     bob = bob.makeSubChannel({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob.peers.add(steve.hostPort);
@@ -99,7 +109,12 @@ allocCluster.test('removing a peer and request', {
 
     setupEcho(steve, 'steve');
     bob = bob.makeSubChannel({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob.peers.add(steve.hostPort);
@@ -138,7 +153,12 @@ allocCluster.test('clearing peers and requests', {
     setupEcho(steve1, 'steve');
     setupEcho(steve2, 'steve');
     bob = bob.makeSubChannel({
-        serviceName: 'steve'
+        serviceName: 'steve',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob.peers.add(steve1.hostPort);
@@ -177,10 +197,20 @@ allocCluster.test('delete peer() on top channel', {
     setupEcho(steve, 'steve1');
     setupEcho(steve, 'steve2');
     var bob1 = bob.makeSubChannel({
-        serviceName: 'steve1'
+        serviceName: 'steve1',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
     var bob2 = bob.makeSubChannel({
-        serviceName: 'steve2'
+        serviceName: 'steve2',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob1.peers.add(steve.hostPort);
@@ -249,10 +279,20 @@ allocCluster.test('peers.clear() on top channel', {
     setupEcho(steve, 'steve1');
     setupEcho(steve, 'steve2');
     var bob1 = bob.makeSubChannel({
-        serviceName: 'steve1'
+        serviceName: 'steve1',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
     var bob2 = bob.makeSubChannel({
-        serviceName: 'steve2'
+        serviceName: 'steve2',
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     bob1.peers.add(steve.hostPort);
@@ -317,6 +357,7 @@ function setupEcho(channel, serviceName) {
         serviceName: serviceName
     });
     c.register('echo', function echo(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
         res.sendOk(arg2, arg3);
     });
 }

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -28,7 +28,10 @@ allocCluster.test('register() with different results', {
     numPeers: 2,
     channelOptions: {
         requestDefaults: {
-            timeout: 100
+            timeout: 100,
+            headers: {
+                as: 'raw'
+            }
         }
     }
 }, function t(cluster, assert) {
@@ -45,42 +48,54 @@ allocCluster.test('register() with different results', {
     });
 
     oneSub.register('/error', function error(req, res) {
+        res.headers.as = 'raw';
         res.sendNotOk(null, 'abc');
     });
 
     oneSub.register('/error-frame', function errorFrame(req, res) {
+        res.headers.as = 'raw';
         res.sendError('Busy', 'some message');
     });
 
     oneSub.register('/buffer-head', function buffer(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(new Buffer('abc'), null);
     });
     oneSub.register('/string-head', function string(req, res) {
+        res.headers.as = 'raw';
         res.sendOk('abc', null);
     });
     oneSub.register('/object-head', function object(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(JSON.stringify({ value: 'abc' }), null);
     });
     oneSub.register('/null-head', function nullH(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, null);
     });
     oneSub.register('/undef-head', function undefH(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(undefined, null);
     });
 
     oneSub.register('/buffer-body', function buffer(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, new Buffer('abc'));
     });
     oneSub.register('/string-body', function string(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, 'abc');
     });
     oneSub.register('/object-body', function object(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, JSON.stringify({ value: 'abc' }));
     });
     oneSub.register('/null-body', function nullB(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, null);
     });
     oneSub.register('/undef-body', function undefB(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, undefined);
     });
 

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -26,7 +26,12 @@ allocCluster.test('does not leak inOps', {
     numPeers: 2,
     channelOptions: {
         timeoutCheckInterval: 100,
-        serverTimeoutDefault: 100
+        serverTimeoutDefault: 100,
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     }
 }, function t(cluster, assert) {
     var one = cluster.channels[0];

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -48,7 +48,10 @@ allocCluster.test('send relay requests', {
         serviceName: 'two',
         peers: [one.hostPort],
         requestDefaults: {
-            serviceName: 'two'
+            serviceName: 'two',
+            headers: {
+                as: 'raw'
+            }
         }
     });
 
@@ -79,12 +82,18 @@ allocCluster.test('relay respects ttl', {
         serviceName: 'dest'
     });
     destChan.register('echoTTL', function echoTTL(req, res) {
+        res.headers.as = 'raw';
         res.sendOk(null, String(req.ttl));
     });
 
     var sourceChan = source.makeSubChannel({
         serviceName: 'dest',
-        peers: [relay.hostPort]
+        peers: [relay.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     sourceChan.request({
@@ -140,12 +149,18 @@ allocCluster.test('relay an error frame', {
         serviceName: 'two',
         peers: [one.hostPort, four.hostPort],
         requestDefaults: {
-            serviceName: 'two'
+            serviceName: 'two',
+            headers: {
+                as: 'raw'
+            }
         }
     });
 
     twoClient.request({
-        hasNoParent: true
+        hasNoParent: true,
+        headers: {
+            as: 'raw'
+        }
     }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');
 
@@ -158,5 +173,6 @@ allocCluster.test('relay an error frame', {
 });
 
 function echo(req, res, arg2, arg3) {
+    res.headers.as = 'raw';
     res.sendOk(arg2, arg3);
 }

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -34,6 +34,7 @@ allocCluster.test('emits stats', {
     server.makeSubChannel({
         serviceName: 'server'
     }).register('echo', function echo(req, res, h, b) {
+        res.headers.as = 'raw';
         res.sendOk(h, b);
     });
 
@@ -43,7 +44,12 @@ allocCluster.test('emits stats', {
     };
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     client.on('stat', function onStat(stat) {
@@ -54,7 +60,8 @@ allocCluster.test('emits stats', {
         serviceName: 'server',
         hasNoParent: true,
         headers: {
-            cn: 'client'
+            cn: 'client',
+            as: 'raw'
         }
     }).send('echo', 'a', 'b', onResponse);
 

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -42,6 +42,7 @@ allocCluster.test('emits stats on call success', {
         serviceName: 'reservoir'
     }).register('Reservoir::get', function get(req, res, h, b) {
         timers.setTimeout(function onSend() {
+            res.headers.as = 'raw';
             res.sendOk(h, b);
         }, 500);
         timers.advance(500);
@@ -56,7 +57,12 @@ allocCluster.test('emits stats on call success', {
     client.channelStatsd = new TChannelStatsd(client, statsd);
     var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({
@@ -116,6 +122,7 @@ allocCluster.test('emits stats on call failure', {
         serviceName: 'reservoir'
     }).register('Reservoir::get', function get(req, res, h, b) {
         timers.setTimeout(function onSend() {
+            res.headers.as = 'raw';
             res.sendNotOk(h, '0');
         }, 500);
         timers.advance(500);
@@ -130,7 +137,12 @@ allocCluster.test('emits stats on call failure', {
     client.channelStatsd = new TChannelStatsd(client, statsd);
     var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -34,6 +34,7 @@ allocCluster.test('emits response stats with ok', {
     server.makeSubChannel({
         serviceName: 'server'
     }).register('echo', function echo(req, res, h, b) {
+        res.headers.as = 'raw';
         res.sendOk(h, b);
     });
     server.statTags = server.options.statTags = {
@@ -46,7 +47,12 @@ allocCluster.test('emits response stats with ok', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({
@@ -111,6 +117,7 @@ allocCluster.test('emits response stats with not ok', {
     server.makeSubChannel({
         serviceName: 'server'
     }).register('echo', function echo(req, res, h, b) {
+        res.headers.as = 'raw';
         res.sendNotOk('failure', 'busy');
     });
     server.statTags = server.options.statTags = {
@@ -123,7 +130,12 @@ allocCluster.test('emits response stats with not ok', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({
@@ -201,7 +213,12 @@ allocCluster.test('emits response stats with error', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -42,6 +42,7 @@ allocCluster.test('emits stats on response ok', {
         serviceName: 'reservoir'
     }).register('Reservoir::get', function get(req, res, h, b) {
         timers.setTimeout(function onSend() {
+            res.headers.as = 'raw';
             res.sendOk(h, b);
         }, 500);
         timers.advance(500);
@@ -56,7 +57,12 @@ allocCluster.test('emits stats on response ok', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({
@@ -110,6 +116,7 @@ allocCluster.test('emits stats on response not ok', {
         serviceName: 'reservoir'
     }).register('Reservoir::get', function get(req, res, h, b) {
         timers.setTimeout(function onSend() {
+            res.headers.as = 'raw';
             res.sendNotOk('failure', 'busy');
         }, 500);
         timers.advance(500);
@@ -124,7 +131,12 @@ allocCluster.test('emits stats on response not ok', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({
@@ -192,7 +204,12 @@ allocCluster.test('emits stats on response error', {
 
     var clientChan = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: [server.hostPort]
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw'
+            }
+        }
     });
 
     clientChan.request({

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -54,6 +54,7 @@ allocCluster.test('request retries', {
             } else {
                 var str = String(arg3);
                 str = str.toUpperCase();
+                res.headers.as = 'raw';
                 res.sendOk('served by ' + n, str);
             }
         });
@@ -67,6 +68,9 @@ allocCluster.test('request retries', {
         serviceName: 'tristan',
         peers: cluster.hosts,
         requestDefaults: {
+            headers: {
+                as: 'raw'
+            },
             serviceName: 'tristan'
         }
     });
@@ -157,6 +161,7 @@ allocCluster.test('request application retries', {
         });
         chan.register('foo', function foo(req, res, arg2, arg3) {
             var rand = random();
+            res.headers.as = 'raw';
             if (rand) {
                 res.sendNotOk('meh', 'lol');
             } else {
@@ -173,7 +178,10 @@ allocCluster.test('request application retries', {
         serviceName: 'tristan',
         peers: cluster.hosts,
         requestDefaults: {
-            serviceName: 'tristan'
+            serviceName: 'tristan',
+            headers: {
+                as: 'raw'
+            }
         }
     });
 
@@ -273,6 +281,7 @@ allocCluster.test('retryFlags work', {
         });
         chan.register('foo', function foo(req, res, arg2, arg3) {
             var rand = random();
+            res.headers.as = 'raw';
             if (rand >= 0.9) {
                 res.sendError('Busy', 'nop');
             } else if (rand >= 0.5) {
@@ -293,7 +302,10 @@ allocCluster.test('retryFlags work', {
         serviceName: 'tristan',
         peers: cluster.hosts,
         requestDefaults: {
-            serviceName: 'tristan'
+            serviceName: 'tristan',
+            headers: {
+                as: 'raw'
+            }
         }
     });
 

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -42,6 +42,7 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
     }).register('foo', function foo(req, res, arg2, arg3) {
         assert.ok(Buffer.isBuffer(arg2), 'handler got an arg2 buffer');
         assert.ok(Buffer.isBuffer(arg3), 'handler got an arg3 buffer');
+        res.headers.as = 'raw';
         res.sendOk(arg2, arg3);
     });
 
@@ -209,6 +210,7 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
         var chanNum = i + 1;
         chan.handler = EndpointHandler();
         chan.handler.register('foo', function foo(req, res, arg2, arg3) {
+            res.headers.as = 'raw';
             res.sendOk(arg2, arg3 + ' served by ' + chanNum);
         });
         channel.peers.add(chan.hostPort);
@@ -281,11 +283,13 @@ allocCluster.test('request().send() to self', 1, function t(cluster, assert) {
     subOne.handler.register('foo', function foo(req, res, arg2, arg3) {
         assert.ok(typeof arg2 === 'string', 'handler got an arg2 string');
         assert.ok(typeof arg3 === 'string', 'handler got an arg3 string');
+        res.headers.as = 'raw';
         res.sendOk(arg2, arg3);
     });
     subOne.handler.register('bar', function bar(req, res, arg2, arg3) {
         assert.ok(typeof arg2 === 'string', 'handler got an arg2 string');
         assert.ok(typeof arg3 === 'string', 'handler got an arg3 string');
+        res.headers.as = 'raw';
         res.sendNotOk(arg2, arg3);
     });
 
@@ -333,7 +337,10 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
 
     subOne.request({
         host: one.hostPort,
-        hasNoParent: true
+        hasNoParent: true,
+        headers: {
+            'as': 'raw'
+        }
     }).send('foo', '', '', onResponse);
 
     function onResponse(err) {
@@ -366,6 +373,9 @@ function sendTest(testCase, assert) {
     return function runSendTest(callback) {
         testCase.opts = testCase.opts || {};
         testCase.opts.hasNoParent = true;
+        testCase.opts.headers = {
+            'as': 'raw'
+        };
 
         testCase.channel
             .request(testCase.opts)

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -42,6 +42,9 @@ allocCluster.test('end response with error frame', {
     }).request({
         serviceName: 'stream',
         hasNoParent: true,
+        headers: {
+            as: 'raw'
+        },
         host: server.hostPort,
         streamed: true
     });
@@ -87,6 +90,7 @@ allocCluster.test('end response with error frame', {
             streamed: true
         });
 
+        res.headers.as = 'raw';
         res.arg1.end();
         res.arg2.end();
 

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -102,6 +102,8 @@ function partsTest(testCase, assert) {
 
         var peer = testCase.channel.peers.choosePeer(null, options);
         var conn = peer.connect();
+        options.headers = options.headers || {};
+        options.headers.as = 'raw';
         var req = conn.request(options);
         conn.on('identified', function onId() {
             var resultReady = Ready();
@@ -152,6 +154,7 @@ function echoHandler() {
     var handler = EndpointHandler();
     function foo(req, buildRes) {
         var res = buildRes({streamed: true});
+        res.headers.as = 'raw';
         res.setOk(true);
 
         req.arg2.on('data', function onArg2Data(chunk) {

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -48,6 +48,9 @@ allocCluster.test('requests will timeout', {
         .request({
             serviceName: 'server',
             hasNoParent: true,
+            headers: {
+                'as': 'raw'
+            },
             timeout: 1000
         })
         .send('/normal-proxy', 'h', 'b', onResp);
@@ -62,6 +65,9 @@ allocCluster.test('requests will timeout', {
             .request({
                 serviceName: 'server',
                 hasNoParent: true,
+                headers: {
+                    'as': 'raw'
+                },
                 timeout: 1000
             })
             .send('/timeout', 'h', 'b', onTimeout);
@@ -105,6 +111,7 @@ allocCluster.test('requests will timeout', {
     }
 
     function normalProxy(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
         res.sendOk(arg2, arg3);
     }
     function timeout(/* head, body, hostInfo, cb */) {

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -67,6 +67,7 @@ test('basic tracing test', function (assert) {
 
     subChan.register('/foobar', function (req, res) {
         logger.debug("subserv sr");
+        res.headers.as = 'raw';
         res.sendOk('result', 'success');
     });
 
@@ -78,6 +79,9 @@ test('basic tracing test', function (assert) {
                 host: '127.0.0.1:4042',
                 serviceName: 'subservice',
                 parent: req,
+                headers: {
+                    as: 'raw'
+                },
                 trace: true});
             var peers = server.peers.values();
             var ready = new CountedReadySignal(peers.length);
@@ -91,6 +95,7 @@ test('basic tracing test', function (assert) {
             ready(function send() {
                 servReq.send('/foobar', 'arg1', 'arg2', function response(err, subRes) {
                     logger.debug('top level recv from subservice');
+                    res.headers.as = 'raw';
                     if (err) return res.sendOk('error', err);
                     res.sendOk('result', 'success: ' + subRes);
                 });
@@ -111,7 +116,10 @@ test('basic tracing test', function (assert) {
             host: '127.0.0.1:4040',
             serviceName: 'server',
             hasNoParent: true,
-            trace: true
+            trace: true,
+            headers: {
+                as: 'raw'
+            }
         });
         var peers = client.peers.values();
         var ready = new CountedReadySignal(peers.length);

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -67,11 +67,13 @@ test('basic tracing test', function (assert) {
 
     subChan.register('/foobar', function (req, res) {
         logger.debug("subserv sr");
+        res.headers.as = 'raw';
         res.sendOk('result', 'success');
     });
 
     subChan.register('/barbaz', function (req, res) {
         logger.debug("subserv 2 sr");
+        res.headers.as = 'raw';
         res.sendOk('result', 'success');
     });
 
@@ -86,9 +88,13 @@ test('basic tracing test', function (assert) {
                     host: '127.0.0.1:4042',
                     serviceName: 'subservice',
                     parent: req,
+                    headers: {
+                        as: 'raw'
+                    },
                     trace: true
                 }).send('/foobar', 'arg1', 'arg2', function (err, subRes) {
                     logger.debug("top level recv from subservice: " + subRes);
+                    res.headers.as = 'raw';
                     if (err) return res.sendOk('error', err);
 
                     serverRequestsDone.signal();
@@ -100,6 +106,9 @@ test('basic tracing test', function (assert) {
                 host: '127.0.0.1:4042',
                 serviceName: 'subservice',
                 parent: req,
+                headers: {
+                    as: 'raw'
+                },
                 trace: true});
             var peers = server.peers.values();
             var ready = new CountedReadySignal(peers.length);
@@ -113,6 +122,7 @@ test('basic tracing test', function (assert) {
             ready(function send() {
                 servReq.send('/barbaz', 'arg1', 'arg2', function (err, subRes) {
                     logger.debug("top level recv from subservice: " + subRes);
+                    res.headers.as = 'raw';
                     if (err) return res.sendOk('error', err);
 
                     serverRequestsDone.signal();
@@ -121,6 +131,7 @@ test('basic tracing test', function (assert) {
         });
 
         serverRequestsDone(function () {
+            res.headers.as = 'raw';
             res.sendOk('result', 'success');
         });
 
@@ -139,7 +150,10 @@ test('basic tracing test', function (assert) {
             host: '127.0.0.1:4040',
             serviceName: 'server',
             trace: true,
-            hasNoParent: true
+            hasNoParent: true,
+            headers: {
+                as: 'raw'
+            }
         });
         var peers = client.peers.values();
         var ready = new CountedReadySignal(peers.length);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -74,7 +74,7 @@ function TChannelV2Handler(options) {
     self.streamingRes = Object.create(null);
     self.writeBuffer = new Buffer(v2.Frame.MaxSize);
 
-    self.forceAs = self.options.forceAs === false ? false : true;
+    self.requireAs = self.options.requireAs === false ? false : true;
 }
 
 util.inherits(TChannelV2Handler, EventEmitter);
@@ -191,7 +191,7 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         !reqFrame.body.headers ||
         !reqFrame.body.headers.as
     ) {
-        if (self.forceAs) {
+        if (self.requireAs) {
             var err = errors.AsHeaderRequired({
                 frame: 'request'
             });
@@ -242,7 +242,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
         !resFrame.body.headers ||
         !resFrame.body.headers.as
     ) {
-        if (self.forceAs) {
+        if (self.requireAs) {
             var err = errors.AsHeaderRequired({
                 frame: 'response'
             });
@@ -422,7 +422,7 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
         flags, req.ttl, req.tracing, req.serviceName, req.headers,
         req.checksum.type, args);
 
-    if (self.forceAs) {
+    if (self.requireAs) {
         assert(req.headers && req.headers.as,
             'Expected the "as" transport header to be set for request');
     } else {
@@ -446,7 +446,7 @@ TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFra
         flags, code, res.tracing, res.headers,
         res.checksum.type, args);
 
-    if (self.forceAs) {
+    if (self.requireAs) {
         assert(res.headers && res.headers.as,
             'Expected the "as" transport header to be set for response');
     } else {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -202,7 +202,9 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         } else {
             self.logger.error('Expected "as" header for incoming req', {
                 arg1: String(reqFrame.body.args[0]),
-                serviceName: reqFrame.body.serviceName
+                serviceName: reqFrame.body.serviceName,
+                callerName: reqFrame.body.headers.cn,
+                remoteHostPort: self.remoteHostPort
             });
         }
     }
@@ -249,7 +251,9 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
             return callback(err);
         } else {
             self.logger.error('Expected "as" for incoming response', {
-                code: resFrame.body.code
+                code: resFrame.body.code,
+                remoteHostPort: self.remoteHostPort,
+                endpoint: String(resFrame.body.args[0])
             });
         }
     }
@@ -428,6 +432,8 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
     } else {
         self.logger.error('Expected "as" header to be set for request', {
             arg1: String(args[0]),
+            callerName: req.headers && req.headers.cn,
+            remoteHostPort: self.remoteHostPort,
             serviceName: req.serviceName
         });
     }
@@ -451,7 +457,9 @@ TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFra
             'Expected the "as" transport header to be set for response');
     } else {
         self.logger.error('Expected "as" header to be set for response', {
-            code: code
+            code: code,
+            remoteHostPort: self.remoteHostPort,
+            arg1: String(args[0])
         });
     }
 


### PR DESCRIPTION
This is another breaking change. All outgoing requests must
set the "as" header on the way out.

I also fixed a seperate bug in connection about making
assumptions on the `err` object.

I added a bonus commit to reject incoming call requests without
the "as" transport header; however thats a binary breaking change
so I probably want to roll it back as we have no agreement or
concensus on it and it requires everyone in the team to agree.

cc @jcorbin @kriskowal