### PR TITLE
Add a waitForIdentified method + friends

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -366,6 +366,13 @@ TChannel.prototype.requestOptions = function requestOptions(options) {
     return opts;
 };
 
+TChannel.prototype.waitForIdentified =
+function waitForIdentified(options, callback) {
+    var self = this;
+
+    self.peers.waitForIdentified(options, callback);
+};
+
 TChannel.prototype.request = function channelRequest(options) {
     var self = this;
     assert(!self.destroyed, 'cannot request() to destroyed tchannel');

--- a/node/channel.js
+++ b/node/channel.js
@@ -71,7 +71,7 @@ function TChannel(options) {
     self.outboundCallsPerAttemptLatencyStat = self.defineTiming('outbound.calls.per-attempt-latency');
 
     self.options = extend({
-        timeoutCheckInterval: 1000,
+        timeoutCheckInterval: 100,
         timeoutFuzz: 100,
         // TODO: maybe we should always add pid to user-supplied?
         processName: format('%s[%s]', process.title, process.pid)

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -192,7 +192,7 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
         outPending: self.pending.out
     };
 
-    if (err.type.lastIndexOf('tchannel.socket', 0) < 0) {
+    if (err.type && err.type.lastIndexOf('tchannel.socket', 0) < 0) {
         self.logger.warn('resetting connection', logInfo);
         self.errorEvent.emit(self, err);
     } else if (err.type !== 'tchannel.socket-closed') {

--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -214,7 +214,8 @@ function sendRelayAdvertise(hostPort, services, callback) {
 
             self.tchannelJSON.send(self.channel.request({
                 host: hostPort,
-                serviceName: 'hyperbahn'
+                serviceName: 'hyperbahn',
+                timeout: 100
             }), 'relay-ad', null, {
                 services: services
             }, onResponse);

--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -203,12 +203,22 @@ function sendRelayAdvertise(hostPort, services, callback) {
     function tryRequest() {
         attempts++;
 
-        self.tchannelJSON.send(self.channel.request({
-            host: hostPort,
-            serviceName: 'hyperbahn'
-        }), 'relay-ad', null, {
-            services: services
-        }, onResponse);
+        self.channel.waitForIdentified({
+            host: hostPort
+        }, onIdentified);
+
+        function onIdentified(err) {
+            if (err) {
+                return onResponse(err);
+            }
+
+            self.tchannelJSON.send(self.channel.request({
+                host: hostPort,
+                serviceName: 'hyperbahn'
+            }), 'relay-ad', null, {
+                services: services
+            }, onResponse);
+        }
 
         function onResponse(err, response) {
             if (response && response.ok) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -152,6 +152,16 @@ TChannelPeers.prototype.delete = function del(hostPort) {
     return peer;
 };
 
+TChannelPeers.prototype.waitForIdentified =
+function waitForIdentified(options, callback) {
+    var self = this;
+
+    assert(typeof options.host === 'string', 'options.host is required');
+
+    var peer = self.add(options.host);
+    peer.waitForIdentified(callback);
+};
+
 TChannelPeers.prototype.request = function peersRequest(req, options) {
     var self = this;
     var peer = self.choosePeer(req, options);

--- a/node/request.js
+++ b/node/request.js
@@ -223,28 +223,13 @@ TChannelRequest.prototype.resend = function resend() {
 
     var perAttemptStart = self.timers.now();
 
-    var conn = peer.connect();
+    peer.waitForIdentified(onIdentified);
 
-    if (conn.closing) {
-        onConnectionClose(conn.closeError);
-    } else {
-        conn.closeEvent.on(onConnectionClose);
-
-        if (!peer.isConnected() && conn.handler) {
-            conn.identifiedEvent.on(onIdentified);
-            return;
-        } else {
-            onIdentified();
+    function onIdentified(err) {
+        if (err) {
+            return self.emitError(err);
         }
-    }
 
-    function onConnectionClose(err) {
-        conn.closeEvent.removeListener(onConnectionClose);
-        self.emitError(err || errors.TChannelConnectionCloseError());
-    }
-
-    function onIdentified() {
-        conn.closeEvent.removeListener(onConnectionClose);
         self.onIdentified(peer, perAttemptStart);
     }
 };


### PR DESCRIPTION
This PR adds:

 - waitForIdentified method; used by other libraries that want
    to do direct peer to peer requests without using `node/request.js` 
 - Fix a bug in connection.js
 - Fix hyperbahn to wait for identification
 - Add a timeout to hyperbahn
 - Change the timeout reaper in tchannel to use 100ms

r: @kriskowal @shannili @rf