### PR TITLE
Improve timeout specificity

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -110,7 +110,7 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     self.handler.callIncomingRequestEvent.on(onCallRequest);
     self.handler.callIncomingResponseEvent.on(onCallResponse);
     self.handler.callIncomingErrorEvent.on(onCallError);
-    self.timedOutEvent.on(self.onTimedOut);
+    self.timedOutEvent.on(onTimedOut);
 
     // TODO: restore dumping from old:
     // var stream = self.socket;
@@ -131,6 +131,10 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     // stream = stream
     //     .pipe(self.socket)
     //     ;
+
+    function onTimedOut(err) {
+        self.onTimedOut(err);
+    }
 
     function onWriteError(err) {
         self.onWriteError(err);
@@ -157,7 +161,9 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     }
 };
 
-TChannelConnection.prototype.onTimedOut = function onTimedOut(err, self) {
+TChannelConnection.prototype.onTimedOut = function onTimedOut(err) {
+    var self = this;
+
     self.logger.warn(self.channel.hostPort + ' destroying socket from timeouts');
     self.resetAll(err);
     self.socket.destroy();

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -113,14 +113,6 @@ TChannelConnectionBase.prototype.onTimeoutCheck = function onTimeoutCheck() {
         return;
     }
 
-    if (self.lastTimeoutTime) {
-        var err = errors.ConnectionStaleTimeoutError({
-            lastTimeoutTime: self.lastTimeoutTime
-        });
-        self.timedOutEvent.emit(self, err);
-        return;
-    }
-
     var elapsed = self.timers.now() - self.startTime;
     if (!self.remoteName && elapsed >= self.channel.initTimeout) {
         self.timedOutEvent.emit(self, errors.ConnectionTimeoutError({
@@ -155,10 +147,18 @@ TChannelConnectionBase.prototype.checkTimeout = function checkTimeout(ops, direc
             self.pending[direction]--;
         } else if (req.checkTimeout()) {
             if (direction === 'out') {
+                if (self.lastTimeoutTime) {
+                    var err = errors.ConnectionStaleTimeoutError({
+                        lastTimeoutTime: self.lastTimeoutTime
+                    });
+                    self.timedOutEvent.emit(self, err);
+                    return;
+                }
+
                 self.lastTimeoutTime = self.timers.now();
-            // } else {
-            //     req.res.sendError // XXX may need to build
             }
+            // else
+            //     req.res.sendError // XXX may need to build
             delete ops[id];
             self.pending[direction]--;
         }

--- a/node/errors.js
+++ b/node/errors.js
@@ -74,6 +74,23 @@ module.exports.ChecksumError = TypedError({
     actualValue: null
 });
 
+module.exports.ConnectionStaleTimeoutError = TypedError({
+    type: 'tchannel.connection-stale.timeout',
+    message: 'Connection got two timeouts in a row.\n' +
+        'Connection has been marked as stale and will be timed out',
+    lastTimeoutTime: null
+});
+
+module.exports.ConnectionTimeoutError = TypedError({
+    type: 'tchannel.connection.timeout',
+    message: 'connection timed out after {elapsed}ms ' +
+        '(limit was {timeout}ms)',
+    id: null,
+    start: null,
+    elapsed: null,
+    timeout: null
+});
+
 module.exports.DuplicateHeaderKeyError = TypedError({
     type: 'tchannel.duplicate-header-key',
     message: 'duplicate header key {key}',
@@ -234,6 +251,16 @@ module.exports.RequestFrameState = TypedError({
     state: null
 });
 
+module.exports.RequestTimeoutError = TypedError({
+    type: 'tchannel.request.timeout',
+    message: 'request timed out after {elapsed}ms ' +
+        '(limit was {timeout}ms)',
+    id: null,
+    start: null,
+    elapsed: null,
+    timeout: null
+});
+
 module.exports.ResponseAlreadyDone = TypedError({
     type: 'tchannel.response-already-done',
     message: 'cannot send {attempted}, response already done ' +
@@ -374,14 +401,6 @@ module.exports.ThriftHeadStringifyError = WrappedError({
     direction: null
 });
 
-module.exports.TimeoutError = TypedError({
-    type: 'tchannel.timeout',
-    message: 'timed out after {elapsed}ms (limit was {timeout}ms)',
-    id: null,
-    start: null,
-    elapsed: null,
-    timeout: null
-});
 
 module.exports.TopLevelRegisterError = TypedError({
     type: 'tchannel.top-level-register',
@@ -417,6 +436,9 @@ module.exports.classify = function classify(err) {
             return 'Declined';
 
         case 'tchannel.timeout':
+        case 'tchannel.request.timeout':
+        case 'tchannel.connection.timeout':
+        case 'tchannel.connection-stale.timeout':
             return 'Timeout';
 
         case 'tchannel-handler.parse-error.body-failed':

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -108,7 +108,7 @@ TChannelInRequest.prototype.checkTimeout = function checkTimeout() {
             // TODO: emit error on self.res instead / in additon to?
             // TODO: should cancel any pending handler
             process.nextTick(function deferInReqTimeoutErrorEmit() {
-                self.errorEvent.emit(self, errors.TimeoutError({
+                self.errorEvent.emit(self, errors.RequestTimeoutError({
                     id: self.id,
                     start: self.start,
                     elapsed: elapsed,

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -263,7 +263,7 @@ TChannelOutRequest.prototype.checkTimeout = function checkTimeout() {
             self.end = now;
             self.timedOut = true;
             process.nextTick(function deferOutReqTimeoutErrorEmit() {
-                self.errorEvent.emit(self, errors.TimeoutError({
+                self.errorEvent.emit(self, errors.RequestTimeoutError({
                     id: self.id,
                     start: self.start,
                     elapsed: elapsed,

--- a/node/request.js
+++ b/node/request.js
@@ -352,7 +352,7 @@ TChannelRequest.prototype.checkTimeout = function checkTimeout(err, res) {
             self.emitResponse(res);
         }
     } else if (!self.err) {
-        self.emitError(errors.TimeoutError({
+        self.emitError(errors.RequestTimeoutError({
             start: self.start,
             elapsed: self.elapsed,
             timeout: self.timeout
@@ -384,6 +384,8 @@ TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
                 return true;
 
             case 'tchannel.timeout':
+            case 'tchannel.request.timeout':
+            case 'tchannel.connection.timeout':
                 return !!self.options.retryFlags.onTimeout;
 
             case 'tchannel.socket':

--- a/node/test/max_pending.js
+++ b/node/test/max_pending.js
@@ -36,7 +36,8 @@ testBattle('cap maximum pending requests', {
         }
     }
 }, [
-    'tchannel.timeout',
+    // TODO wtf please no connection timeout
+    'tchannel.connection.timeout',
     'tchannel.max-pending'
 ]);
 
@@ -51,7 +52,7 @@ testBattle('cap maximum pending requests per service', {
         }
     }
 }, [
-    'tchannel.timeout',
+    'tchannel.connection.timeout',
     'tchannel.max-pending-for-service'
 ]);
 
@@ -67,7 +68,7 @@ testBattle('channel-scoped max pending supercedes per-service', {
         }
     }
 }, [
-    'tchannel.timeout',
+    'tchannel.connection.timeout',
     'tchannel.max-pending'
 ]);
 
@@ -79,8 +80,8 @@ testBattle('do not opt-in for pending request tracking', {
         random: lucky
     }
 }, [
-    'tchannel.timeout',
-    'tchannel.timeout'
+    'tchannel.connection.timeout',
+    'tchannel.connection.timeout'
 ]);
 
 function testBattle(name, options, expectedErrorTypes) {

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -50,7 +50,12 @@ allocCluster.test('does not leak inOps', {
         .send('/timeout', 'h', 'b', onTimeout);
 
     function onTimeout(err) {
-        assert.equal(err && err.type, 'tchannel.timeout', 'expected timeout error');
+        var type = err && err.type;
+        assert.ok(
+            type === 'tchannel.request.timeout' ||
+            type === 'tchannel.timeout',
+            'expected timeout error'
+        );
         one.peers.get(two.hostPort).connections[0].onTimeoutCheck();
         cluster.assertCleanState(assert, {
             channels: [{

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -82,7 +82,7 @@ allocCluster.test('requests will timeout', {
     }
 
     function onTimeout(err) {
-        assert.equal(err && err.type, 'tchannel.timeout', 'expected timeout error');
+        assert.equal(err && err.type, 'tchannel.request.timeout', 'expected timeout error');
         // one.peers.get(two.hostPort).connections[0].onTimeoutCheck();
         cluster.assertCleanState(assert, {
             channels: [{


### PR DESCRIPTION
This PR takes on two things

 - refactor the TimeoutError base class into three
    base classes for the three different cases
 - Fix the `lastTimeoutTime` check to be more JIT.

r: @shannili @kriskowal