### PR TITLE
relay: index inreqs by remoteAddr and id

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -45,7 +45,8 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         random: self.channel.random,
         timers: self.channel.timers,
         hostPort: self.channel.hostPort,
-        tracer: self.tracer
+        tracer: self.tracer,
+        connection: self
     };
     // jshint forin:false
     for (var prop in self.options) {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -29,6 +29,7 @@ var errors = require('./errors');
 var States = require('./reqres_states');
 
 var DEFAULT_OUTGOING_REQ_TIMEOUT = 2000;
+var CONNECTION_BASE_IDENTIFIER = 0;
 
 function TChannelConnectionBase(channel, direction, remoteAddr) {
     assert(!channel.destroyed, 'refuse to create connection for destroyed channel');
@@ -64,6 +65,7 @@ function TChannelConnectionBase(channel, direction, remoteAddr) {
     };
 
     self.lastTimeoutTime = 0;
+    self.guid = ++CONNECTION_BASE_IDENTIFIER;
 
     self.startTime = self.timers.now();
     self.startTimeoutTimer();

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -51,6 +51,7 @@ function TChannelInRequest(id, options) {
     self.arg1 = emptyBuffer;
     self.arg2 = emptyBuffer;
     self.arg3 = emptyBuffer;
+    self.connection = options.connection;
 
     if (options.tracer) {
         self.span = options.tracer.setupNewSpan({

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -155,7 +155,10 @@ RelayHandler.prototype.type = 'tchannel.relay-handler';
 
 RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
     var self = this;
-    var rereq = self.reqs[req.id];
+
+    var reqKey = getReqKey(req);
+    var rereq = self.reqs[reqKey];
+
     if (rereq) {
         self.channel.logger.error('relay request already exists for incoming request', {
             inReqId: req.id,
@@ -168,12 +171,16 @@ RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
         return;
     }
     rereq = new RelayRequest(self.channel, req, buildRes);
-    self.reqs[req.id] = rereq;
+    self.reqs[reqKey] = rereq;
     rereq.finishEvent.on(rereqFinished);
     rereq.createOutRequest();
     function rereqFinished() {
-        delete self.reqs[req.id];
+        delete self.reqs[reqKey];
     }
 };
+
+function getReqKey(req) {
+    return req.connection.guid + '~' + req.id;
+}
 
 module.exports = RelayHandler;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -65,6 +65,7 @@ function TChannelV2Handler(options) {
     self.tracer = self.options.tracer;
     self.hostPort = self.options.hostPort;
     self.processName = self.options.processName;
+    self.connection = self.options.connection;
     self.remoteHostPort = null; // filled in by identify message
     self.lastSentFrameId = 0;
     // TODO: GC these... maybe that's up to TChannel itself wrt ops
@@ -487,7 +488,8 @@ TChannelV2Handler.prototype.buildInRequest = function buildInRequest(reqFrame) {
         retryFlags: retryFlags,
         checksum: new v2.Checksum(reqFrame.body.csum.type),
         streamed: reqFrame.body.flags & v2.CallFlags.Fragment,
-        hostPort: self.hostPort // needed for tracing
+        hostPort: self.hostPort, // needed for tracing
+        connection: self.connection
     };
     if (opts.streamed) {
         return new StreamingInRequest(reqFrame.id, opts);


### PR DESCRIPTION
There is an issue in our relay handler implementation
where we were indexing by id rather then by remoteAddr
and id.

r: @kriskowal @shannili