### PR TITLE
node: require minimum requests before marking peer as unhealthy

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -53,6 +53,7 @@ function TChannelPeer(channel, hostPort, options) {
         random: self.channel.random,
         period: self.options.period,
         maxErrorRate: self.options.maxErrorRate,
+        minimumRequests: self.options.minimumRequests,
         probation: self.options.probation,
         stateMachine: self,
         nextHandler: self

--- a/node/states.js
+++ b/node/states.js
@@ -81,6 +81,8 @@ function HealthyState(options) {
     self.okCount = 0;
     self.notOkCount = 0;
     self.totalReqs = 0;
+    self.minimumRequests = typeof options.minimumRequests === 'number' ?
+        options.minimumRequests : 5;
 }
 
 inherits(HealthyState, State);
@@ -102,7 +104,7 @@ HealthyState.prototype.shouldRequest = function shouldRequest(req, options) {
         // Transition to unhealthy state if the success rate dips below the
         // acceptable threshold.
         if (self.notOkCount / totalCount > self.maxErrorRate &&
-            self.totalReqs > 5
+            self.totalReqs > self.minimumRequests
         ) {
             self.stateMachine.setState(UnhealthyState);
             return 0;

--- a/node/states.js
+++ b/node/states.js
@@ -81,8 +81,8 @@ function HealthyState(options) {
     self.okCount = 0;
     self.notOkCount = 0;
     self.totalReqs = 0;
-    self.minimumRequests = typeof options.minimumRequests === 'number' ?
-        options.minimumRequests : 5;
+    self.minRequests = typeof options.minRequests === 'number' ?
+        options.minRequests : 5;
 }
 
 inherits(HealthyState, State);
@@ -104,7 +104,7 @@ HealthyState.prototype.shouldRequest = function shouldRequest(req, options) {
         // Transition to unhealthy state if the success rate dips below the
         // acceptable threshold.
         if (self.notOkCount / totalCount > self.maxErrorRate &&
-            self.totalReqs > self.minimumRequests
+            self.totalReqs > self.minRequests
         ) {
             self.stateMachine.setState(UnhealthyState);
             return 0;

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -225,6 +225,8 @@ function testSetup(desc, testFunc) {
             serviceName: 'tiberius'
         });
         var peer = client.peers.add(cluster.hosts[1]);
+        // manually set minimumRequests requirement to 0
+        peer.state.minimumRequests = 0;
         service.register('glad', function(req, res) {
             res.sendOk('pool', 'party');
         });

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -225,8 +225,8 @@ function testSetup(desc, testFunc) {
             serviceName: 'tiberius'
         });
         var peer = client.peers.add(cluster.hosts[1]);
-        // manually set minimumRequests requirement to 0
-        peer.state.minimumRequests = 0;
+        // manually set minRequests requirement to 0
+        peer.state.minRequests = 0;
         service.register('glad', function(req, res) {
             res.sendOk('pool', 'party');
         });


### PR DESCRIPTION
This peer adds a minimum requests counter ( defaults to 5 )
so a peer only goes unhealthy after some minimum number of requests.

This means 50% of requests have to fail in a 1 second interval
after at least 5 requests for it to go unhealthy.

This makes it easy to author tests and do manual testing where
you send two reqs that fail.

r: @shannili @kriskowal