### PR TITLE
Gracefully handle double responses

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -230,7 +230,7 @@ TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
 
         called = true;
 
-        self.popOutReq(res.id, {
+        self.ops.popOutReq(res.id, {
             responseId: res.id,
             code: res.code,
             arg1: Buffer.isBuffer(res.arg1) ?
@@ -249,7 +249,7 @@ TChannelConnection.prototype.onCallError = function onCallError(err) {
         req.res.errorEvent.emit(req.res, err);
     } else {
         // Only popOutReq if there is no call response object yet
-        req = self.popOutReq(err.originalId, {
+        req = self.ops.popOutReq(err.originalId, {
             err: err,
             id: err.originalId,
             info: 'got error frame for unknown id'

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -266,7 +266,18 @@ function onResponseError(err, req) {
         loggingOptions.errMessage = req.res.message;
     }
 
-    self.logger.error('outgoing response has an error', loggingOptions);
+    if ((err.type === 'tchannel.response-already-started' ||
+        err.type === 'tchannel.response-already-done') &&
+        req.timedOut
+    ) {
+        self.logger.info(
+            'error for timed out outgoing response', loggingOptions
+        );
+    } else {
+        self.logger.error(
+            'outgoing response has an error', loggingOptions
+        );
+    }
 };
 
 TChannelConnectionBase.prototype.onReqDone = function onReqDone(req) {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -247,21 +247,32 @@ TChannelConnectionBase.prototype.onResponseError =
 function onResponseError(err, req) {
     var self = this;
 
-    var arg2 = isStringOrBuffer(req.res.arg2) ?
-        req.res.arg2 : 'streaming';
-    var arg3 = isStringOrBuffer(req.res.arg3) ?
-        req.res.arg3 : 'streaming';
-
-    self.logger.error('outgoing response has an error', {
+    var loggingOptions = {
         err: err,
         arg1: String(req.arg1),
         ok: req.res.ok,
         type: req.res.type,
-        bufArg2: arg2.slice(0, 50),
-        arg2: String(arg2).slice(0, 50),
-        bufArg3: arg3.slice(0, 50),
-        arg3: String(arg3).slice(0, 50)
-    });
+        state: req.res.state === States.Done ? 'Done' :
+            req.res.state === States.Error ? 'Error' :
+            'Unknown'
+    };
+
+    if (req.res.state === States.Done) {
+        var arg2 = isStringOrBuffer(req.res.arg2) ?
+            req.res.arg2 : 'streaming';
+        var arg3 = isStringOrBuffer(req.res.arg3) ?
+            req.res.arg3 : 'streaming';
+
+        loggingOptions.bufArg2 = arg2.slice(0, 50);
+        loggingOptions.arg2 = String(arg2).slice(0, 50);
+        loggingOptions.bufArg3 = arg3.slice(0, 50);
+        loggingOptions.arg3 = String(arg3).slice(0, 50);
+    } else if (req.res.state === States.Error) {
+        loggingOptions.codeString = req.res.codeString;
+        loggingOptions.errMessage = req.res.message;
+    }
+
+    self.logger.error('outgoing response has an error', loggingOptions);
 };
 
 TChannelConnectionBase.prototype.onReqDone = function onReqDone(req) {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -141,12 +141,6 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     self.ops.clear();
 };
 
-TChannelConnectionBase.prototype.popOutReq = function popOutReq(id) {
-    var self = this;
-
-    return self.ops.popOutReq(id);
-};
-
 // create a request
 TChannelConnectionBase.prototype.request = function connBaseRequest(options) {
     var self = this;

--- a/node/operations.js
+++ b/node/operations.js
@@ -22,6 +22,8 @@
 
 var errors = require('./errors.js');
 
+var TOMBSTONE_TTL = 5000;
+
 module.exports = Operations;
 
 function Operations(opts) {
@@ -39,6 +41,9 @@ function Operations(opts) {
     self.timer = null;
     self.destroyed = false;
 
+    self.tombstones = {
+        out: []
+    };
     self.requests = {
         in: {},
         out: {}
@@ -48,6 +53,13 @@ function Operations(opts) {
         out: 0
     };
     self.lastTimeoutTime = 0;
+}
+
+function OperationTombstone(id, time) {
+    var self = this;
+
+    self.id = id;
+    self.time = time;
 }
 
 Operations.prototype.startTimeoutTimer =
@@ -104,19 +116,34 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
 
     var req = self.requests.out[id];
     if (!req) {
+        var tombstones = self.tombstones.out;
+        var isStale = false;
+
+        for (var i = 0; i < tombstones.length; i++) {
+            if (tombstones[i].id === id) {
+                isStale = true;
+                break;
+            }
+        }
+
+        // If this id has been timed out then just return
+        if (isStale) {
+            return null;
+        }
+
+        // This could be because of a confused / corrupted server.
         self.logger.info('popOutReq received for unknown or lost id', {
             context: context,
             remoteAddr: self.connection.remoteAddr,
             direction: self.connection.direction
         });
-
-        // TODO else case. We should warn about an incoming response for an
-        // operation we did not send out.  This could be because of a timeout
-        // or could be because of a confused / corrupted server.
         return null;
     }
 
     delete self.requests.out[id];
+    self.tombstones.out.push(new OperationTombstone(
+        req.id, self.timers.now()
+    ));
     self.pending.out--;
 
     return req;
@@ -152,6 +179,7 @@ Operations.prototype.clear = function clear() {
 
     self.pending.in = 0;
     self.pending.out = 0;
+    self.tombstones.out = [];
 };
 
 Operations.prototype.destroy = function destroy() {
@@ -203,6 +231,16 @@ function _onTimeoutCheck() {
 
     self._checkTimeout(self.requests.out, 'out');
     self._checkTimeout(self.requests.in, 'in');
+
+    var now = self.timers.now();
+    for (var i = 0; i < self.tombstones.out.length; i++) {
+        var tombstone = self.tombstones.out[i];
+        if (now >= tombstone.time + TOMBSTONE_TTL) {
+            self.tombstones.out.splice(i, 1);
+            i--;
+        }
+    }
+
     self.startTimeoutTimer();
 };
 
@@ -223,8 +261,12 @@ function _checkTimeout(ops, direction) {
                 direction: direction,
                 id: id
             });
-            delete ops[id];
-            self.pending[direction]--;
+
+            if (direction === 'in') {
+                self.popInReq(id);
+            } else if (direction === 'out') {
+                self.popOutReq(id);
+            }
         } else if (req.checkTimeout()) {
             if (direction === 'out') {
                 if (self.lastTimeoutTime) {
@@ -240,8 +282,11 @@ function _checkTimeout(ops, direction) {
             }
             // else
             //     req.res.sendError // XXX may need to build
-            delete ops[id];
-            self.pending[direction]--;
+            if (direction === 'in') {
+                self.popInReq(id);
+            } else if (direction === 'out') {
+                self.popOutReq(id);
+            }
         }
     }
 };

--- a/node/operations.js
+++ b/node/operations.js
@@ -99,11 +99,17 @@ Operations.prototype.addInReq = function addInReq(req) {
     return req;
 };
 
-Operations.prototype.popOutReq = function popOutReq(id) {
+Operations.prototype.popOutReq = function popOutReq(id, context) {
     var self = this;
 
     var req = self.requests.out[id];
     if (!req) {
+        self.logger.info('popOutReq received for unknown or lost id', {
+            context: context,
+            remoteAddr: self.connection.remoteAddr,
+            direction: self.connection.direction
+        });
+
         // TODO else case. We should warn about an incoming response for an
         // operation we did not send out.  This could be because of a timeout
         // or could be because of a confused / corrupted server.

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -162,7 +162,9 @@ TChannelOutResponse.prototype.sendCallResponseContFrame = function sendCallRespo
         case States.Done:
         case States.Error:
             self.errorEvent.emit(self, errors.ResponseAlreadyDone({
-                attempted: 'call response continuation'
+                attempted: 'call response continuation',
+                state: self.state,
+                method: 'sendCallResponseContFrame'
             }));
     }
 };

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -55,6 +55,9 @@ function TChannelOutResponse(id, options) {
     self.arg2 = null;
     self.arg3 = null;
 
+    self.codeString = null;
+    self.message = null;
+
     self.finishEvent.on(self.onFinish);
 }
 
@@ -184,6 +187,10 @@ TChannelOutResponse.prototype.sendError = function sendError(codeString, message
             self.span.annotate('ss');
         }
         self.state = States.Error;
+
+        self.codeString = codeString;
+        self.message = message;
+
         self._sendError(codeString, message);
         self.finishEvent.emit(self);
     }

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -193,7 +193,9 @@ TChannelOutResponse.prototype.setOk = function setOk(ok) {
     var self = this;
     if (self.state !== States.Initial) {
         self.errorEvent.emit(self, errors.ResponseAlreadyStarted({
-            state: self.state
+            state: self.state,
+            method: 'setOk',
+            ok: ok
         }));
     }
     self.ok = ok;

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -135,7 +135,13 @@ TChannelOutResponse.prototype.sendCallResponseFrame = function sendCallResponseF
         case States.Done:
         case States.Error:
             self.errorEvent.emit(self, errors.ResponseAlreadyDone({
-                attempted: 'call response'
+                attempted: 'call response',
+                state: self.state,
+                method: 'sendCallResponseFrame',
+                bufArg2: args[1].slice(0, 50),
+                arg2: String(args[1]).slice(0, 50),
+                bufArg3: args[2].slice(0, 50),
+                arg3: String(args[2]).slice(0, 50)
             }));
     }
 };

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -174,7 +174,10 @@ TChannelOutResponse.prototype.sendError = function sendError(codeString, message
     if (self.state === States.Done || self.state === States.Error) {
         self.errorEvent.emit(self, errors.ResponseAlreadyDone({
             attempted: 'send error frame: ' + codeString + ': ' + message,
-            currentState: self.state
+            currentState: self.state,
+            method: 'sendError',
+            codeString: codeString,
+            errMessage: message
         }));
     } else {
         if (self.span) {

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -223,6 +223,10 @@ TChannelOutResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
 
 TChannelOutResponse.prototype.send = function send(res1, res2) {
     var self = this;
+
+    self.arg2 = res1;
+    self.arg3 = res2;
+
     self.sendCallResponseFrame([self.arg1, res1, res2], true);
     self.finishEvent.emit(self);
     return self;

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "async": "^0.9.0",
     "chalk": "^1.0.0",
     "child_pty": "^0.5.1",
-    "debug-logtron": "3.2.0",
+    "debug-logtron": "4.0.0",
     "duplexer": "^0.1.1",
     "faucet": "0.0.1",
     "istanbul": "^0.3.13",

--- a/node/self_out_request.js
+++ b/node/self_out_request.js
@@ -66,14 +66,14 @@ function makeInreq(id, options) {
     function onError(err) {
         if (called) return;
         called = true;
-        self.conn.popOutReq(id);
+        self.conn.ops.popOutReq(id);
         self.errorEvent.emit(self, err);
     }
 
     function onResponse(res) {
         if (called) return;
         called = true;
-        self.conn.popOutReq(id);
+        self.conn.ops.popOutReq(id);
         self.responseEvent.emit(self, res);
     }
 };

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -109,14 +109,10 @@ allocCluster.test('getting an UnexpectedError frame', {
     });
     var client = cluster.channels[1];
 
-    var _error = client.logger.error;
-    var messages = [];
-    client.logger.error = function error(msg) {
-        messages.push(msg);
-        if (msg !== 'Got unexpected error in handler') {
-            _error.apply(this, arguments);
-        }
-    };
+    client.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
 
     tchannelJSON.send(client.request({
         serviceName: 'server',
@@ -128,7 +124,7 @@ allocCluster.test('getting an UnexpectedError frame', {
         assert.equal(err.message, 'Unexpected Error');
 
         assert.equal(resp, undefined);
-        assert.equal(messages.length, 1);
+        assert.equal(client.logger.items().length, 1);
 
         assert.end();
     });

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -149,14 +149,10 @@ allocCluster.test('getting an UnexpectedError frame', {
         networkFailureResponse: true
     });
 
-    var _error = client.logger.error;
-    var messages = [];
-    client.logger.error = function error(msg) {
-        messages.push(msg);
-        if (msg !== 'Got unexpected error in handler') {
-            _error.apply(this, arguments);
-        }
-    };
+    client.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
 
     tchannelAsThrift.send(client.request({
         serviceName: 'server'
@@ -169,7 +165,7 @@ allocCluster.test('getting an UnexpectedError frame', {
         assert.equal(err.message, 'Unexpected Error');
 
         assert.equal(resp, undefined);
-        assert.equal(messages.length, 1);
+        assert.equal(client.logger.items().length, 1);
 
         assert.end();
     });

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -621,8 +621,8 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
     });
 
     cluster.logger.whitelist(
-        'error',
-        'outgoing response has an error'
+        'info',
+        'error for timed out outgoing response'
     );
 
     cluster.asThrift.send(cluster.client.request({
@@ -647,7 +647,7 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
 
             assert.equal(record2.fields.state, 'Error');
             assert.equal(record2.fields.msg,
-                'outgoing response has an error');
+                'error for timed out outgoing response');
             assert.equal(record1.fields.arg1, 'DoubleResponse::method');
             assert.equal(record1.fields.ok, true);
             assert.equal(record1.fields.codeString, 'Timeout');
@@ -657,14 +657,12 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
 
             assert.equal(record2.fields.state, 'Error');
             assert.equal(record2.fields.msg,
-                'outgoing response has an error');
+                'error for timed out outgoing response');
             assert.equal(record2.fields.arg1, 'DoubleResponse::method');
             assert.equal(record2.fields.codeString, 'Timeout');
             assert.equal(err2.method, 'sendCallResponseFrame');
             assert.equal(err2.type, 'tchannel.response-already-done');
             assert.ok(err2.arg3.indexOf('foobar') >= 0);
-
-            // assert.ok(false);
 
             assert.end();
         }, 500);

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -1,0 +1,749 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var TypedError = require('error/typed');
+var thriftify = require('thriftify');
+
+var allocCluster = require('./lib/alloc-cluster.js');
+var TChannelAsThrift = require('../as/thrift.js');
+
+var throft = [
+    'struct DoubleResult {',
+    '    1: string value',
+    '}',
+    '',
+    'exception DoubleError {',
+    '    1: string message',
+    '}',
+    '',
+    'service DoubleResponse {',
+    '    DoubleResult method(0: string value) throws (',
+    '        1: DoubleError error',
+    '    )',
+    '}'
+].join('\n');
+
+/*
+
+    BUG: OK OK
+    BUG: OK NOT_OK
+    BUG: OK ERROR_FRAME
+    BUG: NOT_OK OK
+    BUG: NOT_OK NOT_OK
+    BUG: NOT_OK ERROR_FRAME
+    BUG: ERROR_FRAME OK
+    BUG: ERROR_FRAME NOT_OK
+    BUG: ERROR_FRAME ERROR_FRAME
+    OPERATIONAL: TIMEOUT OK
+    OPERATIONAL: TIMEOUT NOT_OK
+    OPERATIONAL: TIMEOUT ERROR_FRAME
+    BUG: INTERNAL_ERRORFRAME OK
+    BUG: INTERNAL_ERRORFRAME NOT_OK
+    BUG: INTERNAL_ERRORFRAME ERROR_FRAME
+
+*/
+
+allocCluster.test('sending OK OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['ok', 'ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.value, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record1.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err1.method, 'setOk');
+            assert.equal(err1.type, 'tchannel.response-already-started');
+            assert.equal(err1.ok, true);
+            assert.equal(record1.fields.ok, true);
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err2.method, 'sendCallResponseFrame');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.ok(err2.arg3.indexOf('foobar') >= 0);
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending OK NOT_OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['ok', 'not ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.value, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record1.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err1.method, 'setOk');
+            assert.equal(err1.type, 'tchannel.response-already-started');
+            assert.equal(err1.ok, false);
+            assert.equal(record1.fields.ok, true);
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err2.method, 'sendCallResponseFrame');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.ok(err2.arg3.indexOf('foobar') >= 0);
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending OK ERROR_FRAME', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['ok', 'error']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+    cluster.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.value, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record1.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record1.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err1.message, 'Error: foobar');
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+            assert.equal(err2.method, 'sendError');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.equal(err2.codeString, 'UnexpectedError');
+            assert.equal(err2.errMessage, 'Unexpected Error');
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending NOT_OK OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['not ok', 'ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.message, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record1.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err1.method, 'setOk');
+            assert.equal(err1.type, 'tchannel.response-already-started');
+            assert.equal(err1.ok, true);
+            assert.equal(record1.fields.ok, false);
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err2.method, 'sendCallResponseFrame');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.ok(err2.arg3.indexOf('foobar') >= 0);
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending NOT_OK NOT_OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['not ok', 'not ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.message, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record1.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err1.method, 'setOk');
+            assert.equal(err1.type, 'tchannel.response-already-started');
+            assert.equal(err1.ok, false);
+            assert.equal(record1.fields.ok, false);
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(err2.method, 'sendCallResponseFrame');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.ok(err2.arg3.indexOf('foobar') >= 0);
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending NOT_OK ERROR_FRAME', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['not ok', 'error']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+    cluster.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.deepEqual(resp.head, {});
+        assert.ok(resp.body);
+
+        assert.equal(resp.body.message, 'foobar');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record1.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record1.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err1.message, 'Error: foobar');
+
+            assert.equal(record2.fields.state, 'Done');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.ok(record2.fields.arg3.indexOf('foobar') >= 0);
+            assert.equal(err2.method, 'sendError');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.equal(err2.codeString, 'UnexpectedError');
+            assert.equal(err2.errMessage, 'Unexpected Error');
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending ERROR_FRAME OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['error', 'ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+    cluster.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ok(err);
+        assert.equal(err.type, 'tchannel.unexpected');
+        assert.equal(err.codeName, 'UnexpectedError');
+        assert.equal(err.message, 'Unexpected Error');
+
+        assert.equal(resp, undefined);
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 3);
+            var record1 = lines[0];
+            var record2 = lines[1];
+            var record3 = lines[2];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+            var err3 = record3.fields.err;
+
+            assert.equal(record1.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record1.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err1.message, 'Error: foobar');
+
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.state, 'Error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record2.fields.codeString, 'UnexpectedError');
+            assert.equal(record2.fields.errMessage, 'Unexpected Error');
+            assert.equal(err2.method, 'setOk');
+            assert.equal(err2.ok, true);
+            assert.equal(err2.type, 'tchannel.response-already-started');
+
+            assert.equal(record3.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record3.fields.state, 'Error');
+            assert.equal(record3.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record3.fields.codeString, 'UnexpectedError');
+            assert.equal(record3.fields.errMessage, 'Unexpected Error');
+            assert.equal(err3.method, 'sendCallResponseFrame');
+            assert.equal(err3.type, 'tchannel.response-already-done');
+            assert.ok(err3.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending ERROR_FRAME NOT_OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['error', 'not ok']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+    cluster.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ok(err);
+        assert.equal(err.type, 'tchannel.unexpected');
+        assert.equal(err.codeName, 'UnexpectedError');
+        assert.equal(err.message, 'Unexpected Error');
+
+        assert.equal(resp, undefined);
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 3);
+            var record1 = lines[0];
+            var record2 = lines[1];
+            var record3 = lines[2];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+            var err3 = record3.fields.err;
+
+            assert.equal(record1.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record1.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err1.message, 'Error: foobar');
+
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.state, 'Error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record2.fields.codeString, 'UnexpectedError');
+            assert.equal(record2.fields.errMessage, 'Unexpected Error');
+            assert.equal(err2.method, 'setOk');
+            assert.equal(err2.ok, false);
+            assert.equal(err2.type, 'tchannel.response-already-started');
+
+            assert.equal(record3.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record3.fields.state, 'Error');
+            assert.equal(record3.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record3.fields.codeString, 'UnexpectedError');
+            assert.equal(record3.fields.errMessage, 'Unexpected Error');
+            assert.equal(err3.method, 'sendCallResponseFrame');
+            assert.equal(err3.type, 'tchannel.response-already-done');
+            assert.ok(err3.arg3.indexOf('foobar') >= 0);
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending ERROR_FRAME ERROR_FRAME', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['error', 'error']
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+    cluster.logger.whitelist(
+        'error',
+        'Got unexpected error in handler'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server'
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ok(err);
+        assert.equal(err.type, 'tchannel.unexpected');
+        assert.equal(err.codeName, 'UnexpectedError');
+        assert.equal(err.message, 'Unexpected Error');
+
+        assert.equal(resp, undefined);
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 3);
+            var record1 = lines[0];
+            var record2 = lines[1];
+            var record3 = lines[2];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+            var err3 = record3.fields.err;
+
+            assert.equal(record1.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record1.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err1.message, 'Error: foobar');
+
+            assert.equal(record2.fields.msg,
+                'Got unexpected error in handler');
+            assert.equal(record2.fields.endpoint, 'DoubleResponse::method');
+            assert.equal(err2.message, 'Error: foobar');
+
+            assert.equal(record3.fields.state, 'Error');
+            assert.equal(record3.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record3.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record3.fields.codeString, 'UnexpectedError');
+            assert.equal(record3.fields.errMessage, 'Unexpected Error');
+            assert.equal(err3.method, 'sendError');
+            assert.equal(err3.type, 'tchannel.response-already-done');
+            assert.equal(err3.codeString, 'UnexpectedError');
+            assert.equal(err3.errMessage, 'Unexpected Error');
+
+            assert.end();
+        }, 100);
+    });
+});
+
+allocCluster.test('sending INTERNAL_TIMEOUT OK', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster = allocThrift(cluster, {
+        messages: ['timeout', 'ok'],
+        timeout: 300
+    });
+
+    cluster.logger.whitelist(
+        'error',
+        'outgoing response has an error'
+    );
+
+    cluster.asThrift.send(cluster.client.request({
+        serviceName: 'server',
+        timeout: 100
+    }), 'DoubleResponse::method', null, {
+        value: 'foobar'
+    }, function onResponse(err, resp) {
+        assert.ok(err);
+        assert.ok(err.type === 'tchannel.request.timeout' ||
+            err.type === 'tchannel.timeout');
+
+        setTimeout(function afterTime() {
+            var lines = cluster.logger.items();
+
+            assert.equal(lines.length, 2);
+            var record1 = lines[0];
+            var record2 = lines[1];
+
+            var err1 = record1.fields.err;
+            var err2 = record2.fields.err;
+
+            assert.equal(record2.fields.state, 'Error');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record1.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record1.fields.ok, true);
+            assert.equal(record1.fields.codeString, 'Timeout');
+            assert.equal(err1.method, 'setOk');
+            assert.equal(err1.type, 'tchannel.response-already-started');
+            assert.equal(err1.ok, true);
+
+            assert.equal(record2.fields.state, 'Error');
+            assert.equal(record2.fields.msg,
+                'outgoing response has an error');
+            assert.equal(record2.fields.arg1, 'DoubleResponse::method');
+            assert.equal(record2.fields.codeString, 'Timeout');
+            assert.equal(err2.method, 'sendCallResponseFrame');
+            assert.equal(err2.type, 'tchannel.response-already-done');
+            assert.ok(err2.arg3.indexOf('foobar') >= 0);
+
+            // assert.ok(false);
+
+            assert.end();
+        }, 500);
+    });
+});
+
+
+function allocThrift(cluster, options) {
+    options = options || {};
+
+    var throftSpec = thriftify.parseSpec(throft);
+    var server = cluster.channels[0].makeSubChannel({
+        serviceName: 'server'
+    });
+    var client = cluster.channels[1].makeSubChannel({
+        serviceName: 'server',
+        peers: [
+            cluster.channels[0].hostPort
+        ]
+    });
+    var DoubleError = TypedError({
+        type: 'double',
+        nameAsThrift: 'error'
+    });
+
+    var handler = options.messages ?
+        messagesHandler : null;
+
+    var tchannelAsThrift = TChannelAsThrift({
+        spec: throftSpec
+    });
+    tchannelAsThrift.register(
+        server, 'DoubleResponse::method', {}, handler
+    );
+
+    cluster.server = server;
+    cluster.client = client;
+    cluster.asThrift = tchannelAsThrift;
+
+    return cluster;
+
+    function messagesHandler(opts, req, head, body, cb) {
+        send(cb, {
+            type: options.messages[0],
+            head: head,
+            body: body
+        });
+
+        setTimeout(function () {
+            send(cb, {
+                type: options.messages[1],
+                head: head,
+                body: body
+            });
+        }, options.timeout || 50);
+    }
+
+    function send(cb, opts) {
+        if (opts.type === 'ok') {
+            return cb(null, {
+                ok: true,
+                head: opts.head,
+                body: opts.body
+            });
+        } else if (opts.type === 'not ok') {
+            return cb(null, {
+                ok: false,
+                head: opts.head,
+                body: DoubleError({
+                    message: opts.body.value
+                })
+            });
+        } else if (opts.type === 'error') {
+            return cb(new Error('Error: ' + opts.body.value));
+        } else if (opts.type === 'timeout') {
+            /* do nothing on purpose*/
+            void 0;
+        } else {
+            throw new Error('unknown testing type: ' + opts.type);
+        }
+    }
+}

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -45,3 +45,5 @@ require('./peer_states.js');
 require('./trace/');
 require('./request-stats.js');
 require('./streaming-resp-err.js');
+require('./double-response.js');
+

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -131,6 +131,10 @@ function allocCluster(opts) {
 }
 
 allocCluster.test = function testCluster(desc, opts, t) {
+    if (opts === undefined) {
+        return test(desc);
+    }
+
     if (typeof opts === 'number') {
         opts = {
             numPeers: opts


### PR DESCRIPTION
This is a WIP branch.

 - Improves errors in out_response
 - Add error printing to connection_base
 - Write tests for edge cases

TODO:

 - [x] more tests
 - [x] handle timeouts

r: @rf @kriskowal