### PR TITLE
Set the call response "as" transport header

### DIFF
--- a/node/as/json.js
+++ b/node/as/json.js
@@ -101,18 +101,28 @@ TChannelJSON.prototype.send = function send(
         }
 
         var v = parseResult.value;
-        var response = null;
+        var response = new TChannelJSONResponse(resp, v);
 
-        if (resp.ok) {
-            response = new TChannelJSONResponse(resp.ok, v.head, v.body);
-        } else {
-            response = new TChannelJSONResponse(
-                resp.ok, v.head, errors.ReconstructedError(v.body)
-            );
-        }
         callback(null, response);
     }
 };
+
+
+function TChannelJSONResponse(response, parseResult) {
+    var self = this;
+
+    self.ok = response.ok;
+    self.head = parseResult.head;
+    self.body = null;
+
+    if (response.ok) {
+        self.body = parseResult.body;
+    } else {
+        self.body = errors.ReconstructedError(parseResult.body);
+    }
+
+    self.headers = response.headers;
+}
 
 TChannelJSON.prototype.register = function register(
     tchannel, arg1, opts, handlerFunc
@@ -285,14 +295,6 @@ TChannelJSON.prototype._parse = function parse(opts) {
         body: bodyR.value
     });
 };
-
-function TChannelJSONResponse(ok, head, body) {
-    var self = this;
-
-    self.ok = ok;
-    self.head = head;
-    self.body = body;
-}
 
 function isTypedError(obj) {
     return isError(obj) &&

--- a/node/as/json.js
+++ b/node/as/json.js
@@ -199,6 +199,7 @@ TChannelJSON.prototype.register = function register(
                     'Could not JSON stringify');
             }
 
+            res.headers.as = 'json';
             res.setOk(respObject.ok);
             res.send(
                 stringifyResult.value.head,

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -122,6 +122,7 @@ function register(channel, name, opts, handle) {
                     'Could not serialize thrift');
             }
 
+            res.headers.as = 'thrift';
             res.setOk(thriftRes.ok);
             res.send(
                 stringifyResult.value.head,

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -181,19 +181,26 @@ function send(request, endpoint, outHead, outBody, callback) {
         }
 
         var v = parseResult.value;
-        var resp;
-
-        if (res.ok) {
-            resp = new TChannelThriftResponse(res.ok, v.head, v.body);
-        } else {
-            resp = new TChannelThriftResponse(
-                res.ok, v.head, errors.ReconstructedError(v.body)
-            );
-        }
+        var resp = new TChannelThriftResponse(res, v);
 
         callback(null, resp);
     }
 };
+
+function TChannelThriftResponse(response, parseResult) {
+    var self = this;
+
+    self.ok = response.ok;
+    self.head = parseResult.head;
+    self.body = null;
+    self.headers = response.headers;
+
+    if (response.ok) {
+        self.body = parseResult.body;
+    } else {
+        self.body = errors.ReconstructedError(parseResult.body);
+    }
+}
 
 TChannelAsThrift.prototype._parse = function parse(opts) {
     var self = this;
@@ -329,13 +336,6 @@ TChannelAsThrift.prototype._stringify = function stringify(opts) {
         body: bodyRes.value
     });
 };
-
-function TChannelThriftResponse(ok, head, body) {
-    var self = this;
-    self.ok = ok;
-    self.head = head;
-    self.body = body;
-}
 
 // TODO proper Thriftify result union that reifies as the selected field.
 function onlyProperty(object) {

--- a/node/in_response.js
+++ b/node/in_response.js
@@ -44,6 +44,7 @@ function TChannelInResponse(id, options) {
     self.id = id || 0;
     self.code = options.code || 0;
     self.checksum = options.checksum || null;
+    self.headers = options.headers || {};
     self.ok = self.code === 0; // TODO: probably okay, but a bit jank
     self.span = options.span || null;
 

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -49,6 +49,9 @@ allocCluster.test('getting an ok response', {
         assert.deepEqual(resp, {
             ok: true,
             head: null,
+            headers: {
+                'as': 'json'
+            },
             body: {
                 opts: {
                     isOptions: true
@@ -90,6 +93,9 @@ allocCluster.test('getting a not ok response', {
         assert.deepEqual(resp, {
             ok: false,
             head: null,
+            headers: {
+                'as': 'json'
+            },
             body: {
                 message: 'my error',
                 type: 'my-error',

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -54,6 +54,7 @@ allocCluster.test('send and receiving an ok', {
         assert.ifError(err);
 
         assert.ok(res.ok);
+        assert.equal(res.headers.as, 'thrift');
         assert.equal(res.body, 10);
         assert.end();
     });

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -506,7 +506,8 @@ TChannelV2Handler.prototype.buildInResponse = function buildInResponse(resFrame)
         timers: self.timers,
         code: resFrame.body.code,
         checksum: new v2.Checksum(resFrame.body.csum.type),
-        streamed: resFrame.body.flags & v2.CallFlags.Fragment
+        streamed: resFrame.body.flags & v2.CallFlags.Fragment,
+        headers: resFrame.body.headers
     };
     if (opts.streamed) {
         return new StreamingInResponse(resFrame.id, opts);


### PR DESCRIPTION
This will make tooling like tcap & tcurl better.

r: @kriskowal @shannili