### PR TITLE
remove connection on close

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -199,10 +199,15 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
         self.connections.unshift(conn);
     }
     conn.errorEvent.on(onConnectionError);
+    conn.closeEvent.on(onConnectionClose);
     return conn;
 
     function onConnectionError(/* err */) {
         // TODO: log?
+        self.removeConnection(conn);
+    }
+
+    function onConnectionClose() {
         self.removeConnection(conn);
     }
 };


### PR DESCRIPTION
We leak memory in autobahn; I think this is one of the causes.
There may be more.

 - [ ] TODO: add helpers to alloc-cluster to assert that
    there are no more connections / request objects in memory.

r: @kriskowal @shannili