### PR TITLE
connection: add more context to connection close errors

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -86,7 +86,12 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
     }
 
     function onSocketClose() {
-        self.resetAll(errors.SocketClosedError({reason: 'remote clossed'}));
+        self.resetAll(errors.SocketClosedError({
+            reason: 'remote closed',
+            remoteAddr: self.remoteAddr,
+            direction: self.direction,
+            remoteName: self.remoteName
+        }));
         if (self.remoteName === '0.0.0.0:0') {
             self.channel.peers.delete(self.remoteAddr);
         }

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -135,7 +135,14 @@ TChannelConnectionBase.prototype.resetAll = function resetAll(err) {
     outOpKeys.forEach(function eachOutOp(id) {
         var req = requests.out[id];
         self.ops.removeReq(id);
-        err = errors.TChannelConnectionResetError(err);
+        err = errors.TChannelConnectionResetError(err, {
+            remoteAddr: self.remoteAddr,
+            direction: self.direction,
+            remoteName: self.remoteName,
+            reqRemoteAddr: req.remoteAddr,
+            serviceName: req.serviceName,
+            outArg1: String(req.arg1)
+        });
         req.errorEvent.emit(req, err);
     });
 


### PR DESCRIPTION
This PR just adds more context to these errors. This makes debugging
the logs easier because we will know which serviceName & remoteAddr
these issues are for.

r: @kriskowal @rf