### PR TITLE
add a local close error

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -319,7 +319,7 @@ TChannelConnection.prototype.close = function close(callback) {
         callback();
     } else {
         self.socket.once('close', callback);
-        self.resetAll(errors.SocketClosedError({reason: 'local close'}));
+        self.resetAll(errors.LocalSocketCloseError());
         self.socket.destroy();
     }
 };

--- a/node/errors.js
+++ b/node/errors.js
@@ -195,6 +195,11 @@ module.exports.JSONHeadStringifyError = WrappedError({
     direction: null
 });
 
+module.exports.LocalSocketCloseError = TypedError({
+    type: 'tchannel.socket-local-closed',
+    message: 'tchannel: Connection was manually closed.'
+});
+
 module.exports.MaxPendingError = TypedError({
     type: 'tchannel.max-pending',
     message: 'maximum pending requests exceeded (limit was {pending})',
@@ -331,6 +336,11 @@ module.exports.TChannelListenError = WrappedError({
     message: 'tchannel: {origMessage}',
     requestedPort: null,
     host: null
+});
+
+module.exports.TChannelLocalResetError = WrappedError({
+    type: 'tchannel.local.reset',
+    message: 'tchannel: {causeMessage}'
 });
 
 module.exports.TChannelReadProtocolError = WrappedError({


### PR DESCRIPTION
In preparation for another PR that will cleanup
Errors.classify() I wanted to distinquish between
local close() calls on `Connection` and remote socket
closes.

This PR changes some of the errors to have unique
`type` fields that we can match on to identify whether
a `Connection` died due to a network error/close or
whether it was clean `.closed()`.

r: @kriskowal @rf