### PR TITLE
package: upgrade to error@6.4.1

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bufrw": "^0.9.24",
     "crc": "^3.2.1",
-    "error": "6.4.1",
+    "error": "^6.4.1",
     "farmhash": "^0.2.0",
     "hexer": "^1.4.5",
     "json-stringify-safe": "^5.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bufrw": "^0.9.24",
     "crc": "^3.2.1",
-    "error": "6.2.0",
+    "error": "6.4.1",
     "farmhash": "^0.2.0",
     "hexer": "^1.4.5",
     "json-stringify-safe": "^5.0.0",

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -99,6 +99,7 @@ allocCluster.test('getting a not ok response', {
             body: {
                 message: 'my error',
                 type: 'my-error',
+                fullType: 'my-error',
                 someField: 'some field',
                 name: 'MyErrorError'
             }

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -799,6 +799,7 @@ function allocThrift(cluster, options) {
     });
     var DoubleError = TypedError({
         type: 'double',
+        message: 'double',
         nameAsThrift: 'error'
     });
 

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -334,6 +334,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
         assert.equal(err.message, 'bye lol');
         assert.deepEqual(err, {
             type: 'tchannel.canceled',
+            fullType: 'tchannel.canceled',
             isErrorFrame: true,
             codeName: 'Cancelled',
             errorCode: 2,

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -66,6 +66,7 @@ CodeNames[Codes.ProtocolError] = 'protocol error';
 var CodeErrors = Object.create(null);
 CodeErrors[Codes.Timeout] = TypedError({
     type: 'tchannel.timeout',
+    message: 'TChannel timeout',
     isErrorFrame: true,
     codeName: 'Timeout',
     errorCode: Codes.Timeout,
@@ -73,6 +74,7 @@ CodeErrors[Codes.Timeout] = TypedError({
 });
 CodeErrors[Codes.Cancelled] = TypedError({
     type: 'tchannel.canceled',
+    message: 'TChannel canceled',
     isErrorFrame: true,
     codeName: 'Cancelled',
     errorCode: Codes.Cancelled,
@@ -80,6 +82,7 @@ CodeErrors[Codes.Cancelled] = TypedError({
 });
 CodeErrors[Codes.Busy] = TypedError({
     type: 'tchannel.busy',
+    message: 'TChannel busy',
     isErrorFrame: true,
     codeName: 'Busy',
     errorCode: Codes.Busy,
@@ -87,6 +90,7 @@ CodeErrors[Codes.Busy] = TypedError({
 });
 CodeErrors[Codes.Declined] = TypedError({
     type: 'tchannel.declined',
+    message: 'TChannel declined',
     isErrorFrame: true,
     codeName: 'Declined',
     errorCode: Codes.Declined,
@@ -94,6 +98,7 @@ CodeErrors[Codes.Declined] = TypedError({
 });
 CodeErrors[Codes.UnexpectedError] = TypedError({
     type: 'tchannel.unexpected',
+    message: 'TChannel unexpected error',
     isErrorFrame: true,
     codeName: 'UnexpectedError',
     errorCode: Codes.UnexpectedError,
@@ -101,6 +106,7 @@ CodeErrors[Codes.UnexpectedError] = TypedError({
 });
 CodeErrors[Codes.BadRequest] = TypedError({
     type: 'tchannel.bad-request',
+    message: 'TChannel bad request',
     isErrorFrame: true,
     codeName: 'BadRequest',
     errorCode: Codes.BadRequest,
@@ -108,6 +114,7 @@ CodeErrors[Codes.BadRequest] = TypedError({
 });
 CodeErrors[Codes.NetworkError] = TypedError({
     type: 'tchannel.network',
+    message: 'TChannel network error',
     isErrorFrame: true,
     codeName: 'NetworkError',
     errorCode: Codes.NetworkError,
@@ -115,6 +122,7 @@ CodeErrors[Codes.NetworkError] = TypedError({
 });
 CodeErrors[Codes.ProtocolError] = TypedError({
     type: 'tchannel.protocol',
+    message: 'TChannel protocol error',
     isErrorFrame: true,
     codeName: 'ProtocolError',
     errorCode: Codes.ProtocolError,


### PR DESCRIPTION
This PR updates error to the latest version; this
includes a couple of features.

 - The `fullType` field on `WrappedError` now contains
    the `fullType` for any wrapped error its wrapping.
    I.e. its now recursive.
 - All instances of `TypedError` now have a `fullType`
    field that is an alias for `type`.
 - All constructor functions from `TypedError` and
    `WrappedError` have a static `type` field that can
    be used to see what type of error it will construct.

r: @kriskowal @rf