### PR TITLE
errors: fully classify all errors

### DIFF
--- a/node/benchmarks/multi_bench.js
+++ b/node/benchmarks/multi_bench.js
@@ -118,8 +118,7 @@ Test.prototype.newClient = function (id, callback) {
                         self.readyLatency.update(Date.now() - newClient.createTime);
                         callback();
                     });
-            })
-            
+            });
     });
 };
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -462,6 +462,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel-thrift-handler.parse-error.head-failed':
         case 'tchannel.checksum':
         case 'tchannel.duplicate-header-key':
+        case 'tchannel.null-key':
             return 'BadRequest';
 
         case 'tchannel.init.call-request-before-init-request':
@@ -480,7 +481,6 @@ module.exports.classify = function classify(err) {
         case 'tchannel.invalid-error-code':
         case 'tchannel.invalid-frame-type':
         case 'tchannel.missing-init-header':
-        case 'tchannel.null-key':
         case 'tchannel.protocol.read-failed':
         case 'tchannel.protocol.write-failed':
         case 'tchannel.unhandled-frame-type':

--- a/node/errors.js
+++ b/node/errors.js
@@ -411,7 +411,6 @@ module.exports.ThriftHeadStringifyError = WrappedError({
     direction: null
 });
 
-
 module.exports.TopLevelRegisterError = TypedError({
     type: 'tchannel.top-level-register',
     message: 'Cannot register endpoints points on top-level channel.\n' +
@@ -445,21 +444,46 @@ module.exports.classify = function classify(err) {
         case 'tchannel.max-pending-for-service':
             return 'Declined';
 
-        case 'tchannel.timeout':
+        case 'tchannel.socket-local-closed':
+        case 'tchannel.local.reset':
+            return 'Cancelled';
+
         case 'tchannel.request.timeout':
         case 'tchannel.connection.timeout':
         case 'tchannel.connection-stale.timeout':
             return 'Timeout';
 
-        case 'tchannel-handler.parse-error.body-failed':
-        case 'tchannel-handler.parse-error.head-failed':
+        case 'tchannel.init.call-request-before-init-request':
+        case 'tchannel.init.call-request-cont-before-init-request':
+        case 'tchannel.init.call-response-before-init-response':
+        case 'tchannel.init.call-response-cont-before-init-response':
+        case 'tchannel-handler.json.invalid-body':
+        case 'tchannel-json-handler.parse-error.body-failed':
+        case 'tchannel-json-handler.stringify-error.body-failed':
+        case 'tchannel-json-handler.parse-error.head-failed':
+        case 'tchannel-json-handler.stringify-error.head-failed':
+        case 'tchannel-thrift-handler.stringify-error.body-failed':
+        case 'tchannel-thrift-handler.stringify-error.head-failed':
+        case 'tchannel.request-frame-state':
+        case 'tchannel.request-already-done':
+        case 'tchannel.response-already-done':
+        case 'tchannel.response-already-started':
+        case 'tchannel.response-frame-state':
+        case 'tchannel-thrift-handler.parse-error.body-failed':
+        case 'tchannel-thrift-handler.parse-error.head-failed':
         case 'tchannel.checksum':
         case 'tchannel.duplicate-header-key':
             return 'BadRequest';
 
+        case 'tchannel.init.duplicate-init-request':
+        case 'tchannel.init.duplicate-init-response':
+        case 'tchannel.init.send-call-request-before-indentified':
+        case 'tchannel.init.send-call-request-cont-before-indentified':
+        case 'tchannel.init.send-call-response-before-indentified':
+        case 'tchannel.init.send-call-response-cont-before-indentified':
+        case 'tchannel.arg1-over-length-limit':
         case 'tchannel.arg-chunk.gap':
         case 'tchannel.arg-chunk.out-of-order':
-        case 'tchannel.invalid-code-string':
         case 'tchannel.invalid-error-code':
         case 'tchannel.invalid-frame-type':
         case 'tchannel.missing-init-header':
@@ -469,9 +493,21 @@ module.exports.classify = function classify(err) {
         case 'tchannel.unhandled-frame-type':
             return 'ProtocolError';
 
+        case 'tchannel.connection.close':
+        case 'tchannel.connection.reset':
         case 'tchannel.socket':
         case 'tchannel.socket-closed':
             return 'NetworkError';
+
+        case 'tchannel.invalid-argument':
+        case 'tchannel.invalid-handler':
+        case 'tchannel.invalid-handler.for-registration':
+        case 'tchannel.hydrated-error.default-type':
+        case 'tchannel.server.listen-failed':
+        case 'tchannel.top-level-register':
+        case 'tchannel.top-level-request':
+        case 'tchannel.unimplemented-method':
+            return 'UnexpectedError';
 
         default:
             return null;

--- a/node/errors.js
+++ b/node/errors.js
@@ -463,6 +463,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.checksum':
         case 'tchannel.duplicate-header-key':
         case 'tchannel.null-key':
+        case 'tchannel.arg1-over-length-limit':
             return 'BadRequest';
 
         case 'tchannel.init.call-request-before-init-request':
@@ -475,7 +476,6 @@ module.exports.classify = function classify(err) {
         case 'tchannel.init.send-call-request-cont-before-indentified':
         case 'tchannel.init.send-call-response-before-indentified':
         case 'tchannel.init.send-call-response-cont-before-indentified':
-        case 'tchannel.arg1-over-length-limit':
         case 'tchannel.arg-chunk.gap':
         case 'tchannel.arg-chunk.out-of-order':
         case 'tchannel.invalid-error-code':

--- a/node/errors.js
+++ b/node/errors.js
@@ -455,16 +455,9 @@ module.exports.classify = function classify(err) {
 
         case 'tchannel-handler.json.invalid-body':
         case 'tchannel-json-handler.parse-error.body-failed':
-        case 'tchannel-json-handler.stringify-error.body-failed':
         case 'tchannel-json-handler.parse-error.head-failed':
-        case 'tchannel-json-handler.stringify-error.head-failed':
-        case 'tchannel-thrift-handler.stringify-error.body-failed':
-        case 'tchannel-thrift-handler.stringify-error.head-failed':
         case 'tchannel.request-frame-state':
         case 'tchannel.request-already-done':
-        case 'tchannel.response-already-done':
-        case 'tchannel.response-already-started':
-        case 'tchannel.response-frame-state':
         case 'tchannel-thrift-handler.parse-error.body-failed':
         case 'tchannel-thrift-handler.parse-error.head-failed':
         case 'tchannel.checksum':
@@ -499,6 +492,13 @@ module.exports.classify = function classify(err) {
         case 'tchannel.socket-closed':
             return 'NetworkError';
 
+        case 'tchannel-json-handler.stringify-error.body-failed':
+        case 'tchannel-json-handler.stringify-error.head-failed':
+        case 'tchannel-thrift-handler.stringify-error.body-failed':
+        case 'tchannel-thrift-handler.stringify-error.head-failed':
+        case 'tchannel.response-already-done':
+        case 'tchannel.response-already-started':
+        case 'tchannel.response-frame-state':
         case 'tchannel.invalid-argument':
         case 'tchannel.invalid-handler':
         case 'tchannel.invalid-handler.for-registration':

--- a/node/errors.js
+++ b/node/errors.js
@@ -453,10 +453,6 @@ module.exports.classify = function classify(err) {
         case 'tchannel.connection-stale.timeout':
             return 'Timeout';
 
-        case 'tchannel.init.call-request-before-init-request':
-        case 'tchannel.init.call-request-cont-before-init-request':
-        case 'tchannel.init.call-response-before-init-response':
-        case 'tchannel.init.call-response-cont-before-init-response':
         case 'tchannel-handler.json.invalid-body':
         case 'tchannel-json-handler.parse-error.body-failed':
         case 'tchannel-json-handler.stringify-error.body-failed':
@@ -475,6 +471,10 @@ module.exports.classify = function classify(err) {
         case 'tchannel.duplicate-header-key':
             return 'BadRequest';
 
+        case 'tchannel.init.call-request-before-init-request':
+        case 'tchannel.init.call-request-cont-before-init-request':
+        case 'tchannel.init.call-response-before-init-response':
+        case 'tchannel.init.call-response-cont-before-init-response':
         case 'tchannel.init.duplicate-init-request':
         case 'tchannel.init.duplicate-init-response':
         case 'tchannel.init.send-call-request-before-indentified':

--- a/node/package.json
+++ b/node/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "bufrw": "^0.9.24",
     "crc": "^3.2.1",
-    "error": "^7.0.0",
+    "error": "^7.0.1",
     "farmhash": "^0.2.0",
     "hexer": "^1.4.5",
     "json-stringify-safe": "^5.0.0",


### PR DESCRIPTION
The `classify()` method was not exhaustive. It now is and
there are tests to ensure that it will always be exhaustive

This will be used for improving retries in hyperbahn/handler
and for improving error logging in relay_handler.

r: @kriskowal @rf