### PR TITLE
Move outbound call stats into OutRequest

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -392,10 +392,13 @@ TChannel.prototype.request = function channelRequest(options) {
         }
     }
 
+    opts.channel = self;
+
     var req = null;
     if (opts.host || // retries are only between hosts
         opts.streamed // streaming retries not yet implemented
     ) {
+        opts.retryCount = 0;
         req = self.peers.request(null, opts);
     } else {
         req = new TChannelRequest(self, opts);

--- a/node/channel.js
+++ b/node/channel.js
@@ -392,8 +392,6 @@ TChannel.prototype.request = function channelRequest(options) {
         }
     }
 
-    opts.channel = self;
-
     var req = null;
     if (opts.host || // retries are only between hosts
         opts.streamed // streaming retries not yet implemented

--- a/node/connection.js
+++ b/node/connection.js
@@ -228,7 +228,7 @@ TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
         res.span = req.span;
     }
 
-    req.responseEvent.emit(req, res);
+    req.emitResponse(res);
 
     function popOutReq() {
         if (called) {

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -165,6 +165,8 @@ TChannelConnectionBase.prototype.request = function connBaseRequest(options) {
     if (!options) options = {};
     options.remoteAddr = self.remoteAddr;
 
+    options.channel = self.channel;
+
     // TODO: use this to protect against >4Mi outstanding messages edge case
     // (e.g. zombie operation bug, incredible throughput, or simply very long
     // timeout

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -117,6 +117,7 @@ TChannelOutRequest.prototype.onError = function onError(err, self) {
 
     if (self.logical === false) {
         self.emitErrorStat(err);
+        self.emitLatency();
     }
 };
 
@@ -128,6 +129,7 @@ TChannelOutRequest.prototype.onResponse = function onResponse(res, self) {
 
     if (self.logical === false) {
         self.emitResponseStat(res);
+        self.emitLatency();
     }
 };
 
@@ -191,6 +193,18 @@ function emitPerAttemptLatency() {
         'target-endpoint': String(self.arg1),
         'peer': self.remoteAddr,
         'retry-count': self.retryCount
+    });
+};
+
+TChannelOutRequest.prototype.emitLatency = function emitLatency() {
+    var self = this;
+
+    var latency = self.end - self.start;
+    self.channel.outboundCallsLatencyStat.add(latency, {
+        'target-service': self.serviceName,
+        'service': self.headers.cn,
+        // TODO should always be buffer
+        'target-endpoint': String(self.arg1)
     });
 };
 

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -143,6 +143,12 @@ TChannelOutRequest.prototype.emitError = function emitError(err) {
     self.errorEvent.emit(self, err);
 };
 
+TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
+    var self = this;
+
+    self.responseEvent.emit(self, res);
+};
+
 TChannelOutRequest.prototype.sendParts = function sendParts(parts, isLast) {
     var self = this;
     switch (self.state) {

--- a/node/request.js
+++ b/node/request.js
@@ -87,6 +87,7 @@ TChannelRequest.prototype.emitError = function emitError(err) {
     self.err = err;
 
     TChannelOutRequest.prototype.emitErrorStat.call(self, err);
+    TChannelOutRequest.prototype.emitLatency.call(self);
 
     self.services.onRequestError(self);
     self.errorEvent.emit(self, err);
@@ -98,6 +99,7 @@ TChannelRequest.prototype.emitResponse = function emitResponse(res) {
     self.res = res;
 
     TChannelOutRequest.prototype.emitResponseStat.call(self, res);
+    TChannelOutRequest.prototype.emitLatency.call(self);
 
     self.services.onRequestResponse(self);
     self.responseEvent.emit(self, res);
@@ -121,8 +123,6 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
         if (called) return;
         called = true;
 
-        emitLatency();
-
         callback(err, null, null, null);
     }
 
@@ -130,19 +130,7 @@ TChannelRequest.prototype.hookupCallback = function hookupCallback(callback) {
         if (called) return;
         called = true;
         res.withArg23(function gotArg23(err, arg2, arg3) {
-            emitLatency();
-
             callback(err, res, arg2, arg3);
-        });
-    }
-
-    function emitLatency() {
-        var latency = self.end - self.start;
-        self.channel.outboundCallsLatencyStat.add(latency, {
-            'target-service': self.serviceName,
-            'service': self.headers.cn,
-            // TODO should always be buffer
-            'target-endpoint': String(self.arg1)
         });
     }
 

--- a/node/request.js
+++ b/node/request.js
@@ -243,17 +243,11 @@ TChannelRequest.prototype.onIdentified = function onIdentified(peer, perAttemptS
         opts[key] = self.options[key];
     }
     opts.timeout = self.timeout - self.elapsed;
+    opts.retryCount = self.outReqs.length;
     var outReq = peer.request(opts);
     self.outReqs.push(outReq);
 
-    if (self.outReqs.length === 1) {
-        self.channel.outboundCallsSentStat.increment(1, {
-            'target-service': outReq.serviceName,
-            'service': outReq.headers.cn,
-            // TODO should always be buffer
-            'target-endpoint': String(self.arg1)
-        });
-    } else {
+    if (self.outReqs.length !== 1) {
         self.channel.outboundCallsRetriesStat.increment(1, {
             'target-service': outReq.serviceName,
             'service': outReq.headers.cn,

--- a/node/self_out_request.js
+++ b/node/self_out_request.js
@@ -74,7 +74,7 @@ function makeInreq(id, options) {
         if (called) return;
         called = true;
         self.conn.ops.popOutReq(id);
-        self.responseEvent.emit(self, res);
+        self.emitResponse(res);
     }
 };
 

--- a/node/self_out_response.js
+++ b/node/self_out_response.js
@@ -93,7 +93,7 @@ function passError(codeString, message) {
     process.nextTick(emitError);
 
     function emitError() {
-        self.inreq.outreq.errorEvent.emit(self, err);
+        self.inreq.outreq.errorEvent.emit(self.inreq.outreq, err);
     }
 };
 


### PR DESCRIPTION
This PR moves a lot of the stats code out of request.js and
directly into out_request.js instead.

It still preserves the semantics of only emitting stats
for a application driven request and not emitting stats
for retries.

This means we get stats for relay handler and for peer to peer
requests like ringpop.

r: @shannili @kriskowal