### PR TITLE
2.0.0-IDEA: channel: expose AsThrift and AsJSON

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -40,6 +40,8 @@ var TChannelRequest = require('./request');
 var TChannelServiceNameHandler = require('./service-name-handler');
 var errors = require('./errors');
 
+var TChannelAsThrift = require('./as/thrift');
+var TChannelAsJSON = require('./as/json');
 var TChannelConnection = require('./connection');
 var TChannelPeers = require('./peers');
 var TChannelServices = require('./services');
@@ -180,6 +182,9 @@ function TChannel(options) {
     // lazily created by .getServer (usually from .listen)
     self.serverSocket = null;
     self.serverConnections = null;
+
+    self.TChannelAsThrift = TChannelAsThrift;
+    self.TChannelAsJSON = TChannelAsJSON;
 }
 inherits(TChannel, StatEmitter);
 

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -24,7 +24,6 @@
 
 var TypedError = require('error/typed');
 
-var TChannelJSON = require('../as/json.js');
 var allocCluster = require('./lib/alloc-cluster.js');
 
 allocCluster.test('getting an ok response', {
@@ -220,7 +219,7 @@ function makeTChannelJSONServer(cluster, opts) {
         opts.networkFailureResponse ? networkFailureHandler :
             networkFailureHandler;
 
-    var tchannelJSON = TChannelJSON({
+    var tchannelJSON = cluster.channels[0].TChannelAsJSON({
         logParseFailures: false
     });
     tchannelJSON.register(server, 'echo', options, fn);

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -28,7 +28,6 @@ var TypedError = require('error/typed');
 var fs = require('fs');
 
 var allocCluster = require('./lib/alloc-cluster.js');
-var TChannelAsThrift = require('../as/thrift.js');
 
 var globalThriftText = fs.readFileSync(
     path.join(__dirname, 'anechoic-chamber.thrift'), 'utf8'
@@ -241,7 +240,7 @@ allocCluster.test('send without required fields', {
     makeTChannelThriftServer(cluster, {
         okResponse: true
     });
-    var tchannelAsThrift = TChannelAsThrift({
+    var tchannelAsThrift = client.TChannelAsThrift({
         source: badThriftText
     });
 
@@ -298,7 +297,7 @@ function makeTChannelThriftServer(cluster, opts) {
         opts.networkFailureResponse ? networkFailureHandler :
             networkFailureHandler;
 
-    var tchannelAsThrift = new TChannelAsThrift({
+    var tchannelAsThrift = cluster.channels[0].TChannelAsThrift({
         source: opts.thriftText || globalThriftText,
         logParseFailures: false
     });


### PR DESCRIPTION
This allows us to author "smart client" libraries that
do not depend on a static version of tchannel.

These libraries would take an instance of a sub channel
as an argument and use `channel.TChannelAsThrift` to create
their thrift encoder/decoder.

This allows us to develop applications which only depend
on a single copy of tchannel.

r: @jcorbin @rf @kriskowal