### PR TITLE
Stand by ring semantics for egress nodes

### DIFF
--- a/node/hyperbahn/egress-nodes.js
+++ b/node/hyperbahn/egress-nodes.js
@@ -71,15 +71,7 @@ EgressNodes.prototype.exitsFor = function exitsFor(serviceName) {
     var exitNodes = Object.create(null);
     for (var i = 0; i < k; i++) {
         var shardKey = serviceName + '~' + i;
-
-        // TODO ringpop will return itself if it cannot find
-        // it which is probably the wrong semantics.
         var node = self.ringpop.lookup(shardKey);
-
-        // TODO ringpop can return duplicates. do we want
-        // <= k exitNodes or k exitNodes ?
-        // TODO consider walking the ring instead.
-
         exitNodes[node] = exitNodes[node] || [];
         exitNodes[node].push(shardKey);
     }


### PR DESCRIPTION
If a node is isolated, it becomes egress for all services. Egress nodes must necessarily number >= 1 and <= k, depending on hash collisions and ring sizes near k.