### PR TITLE
2.0.0-IDEA: Make the cn transport header required

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -117,6 +117,7 @@ function TChannel(options) {
     self.timers = self.options.timers || globalTimers;
     self.initTimeout = self.options.initTimeout || 2000;
     self.requireAs = self.options.requireAs;
+    self.requireCn = self.options.requireCn;
 
     // Filled in by the listen call:
     self.host = null;

--- a/node/connection.js
+++ b/node/connection.js
@@ -46,6 +46,7 @@ function TChannelConnection(channel, socket, direction, remoteAddr) {
         timers: self.channel.timers,
         hostPort: self.channel.hostPort,
         requireAs: self.channel.requireAs,
+        requireCn: self.channel.requireCn,
         tracer: self.tracer,
         connection: self
     };

--- a/node/errors.js
+++ b/node/errors.js
@@ -80,6 +80,11 @@ module.exports.ChecksumError = TypedError({
     actualValue: null
 });
 
+module.exports.CnHeaderRequired = TypedError({
+    type: 'tchannel.handler.incoming-req-cn-header-required',
+    message: 'Expected incoming call request to have "cn" header set.'
+});
+
 module.exports.ConnectionStaleTimeoutError = TypedError({
     type: 'tchannel.connection-stale.timeout',
     message: 'Connection got two timeouts in a row.\n' +
@@ -499,6 +504,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.protocol.write-failed':
         case 'tchannel.unhandled-frame-type':
         case 'tchannel.handler.incoming-req-as-header-required':
+        case 'tchannel.handler.incoming-req-cn-header-required':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -150,7 +150,10 @@ function allocHTTPBridge(opts) {
     var chanOpts = {
         serviceName: serviceName,
         requestDefaults: {
-            serviceName: serviceName
+            serviceName: serviceName,
+            headers: {
+                cn: 'wat'
+            }
         }
     };
 

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -218,7 +218,12 @@ function makeTChannelJSONServer(cluster, opts) {
         serviceName: 'server',
         peers: [
             cluster.channels[0].hostPort
-        ]
+        ],
+        requestDefaults: {
+            headers: {
+                cn: 'wat'
+            }
+        }
     });
 
     var options = {

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -297,7 +297,12 @@ function makeTChannelThriftServer(cluster, opts) {
         serviceName: 'server',
         peers: [
             cluster.channels[0].hostPort
-        ]
+        ],
+        requestDefaults: {
+            headers: {
+                cn: 'wat'
+            }
+        }
     });
 
     var options = {

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -805,7 +805,12 @@ function allocThrift(cluster, options) {
         serviceName: 'server',
         peers: [
             cluster.channels[0].hostPort
-        ]
+        ],
+        requestDefaults: {
+            headers: {
+                cn: 'wat'
+            }
+        }
     });
     var DoubleError = TypedError({
         type: 'double',

--- a/node/test/max_pending.js
+++ b/node/test/max_pending.js
@@ -119,7 +119,8 @@ function testBattle(name, options, expectedErrorTypes) {
                 dumChannel.request({
                     serviceName: 'battle',
                     headers: {
-                        as: 'raw'
+                        as: 'raw',
+                        cn: 'wat'
                     },
                     timeout: 1000
                 }).send('start', '', '', regardless(cb));

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -33,7 +33,8 @@ allocCluster.test('healthy state stays healthy', {
     },
     requestDefaults: {
         headers: {
-            as: 'raw'
+            as: 'raw',
+            cn: 'wat'
         }
     }
 }, function t(cluster, assert) {
@@ -248,7 +249,8 @@ function testSetup(desc, testFunc) {
                     serviceName: 'tiberius', 
                     hasNoParent: true,
                     headers: {
-                        as: 'raw'
+                        as: 'raw',
+                        cn: 'wat'
                     }
                 }).send(op, '', '', onResult);
                 function onResult(err, res, arg2, arg3) {

--- a/node/test/peers.js
+++ b/node/test/peers.js
@@ -35,7 +35,8 @@ allocCluster.test('add a peer and request', {
         serviceName: 'steve',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -78,7 +79,8 @@ allocCluster.test('adding a peer twice', {
         serviceName: 'steve',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -112,7 +114,8 @@ allocCluster.test('removing a peer and request', {
         serviceName: 'steve',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -156,7 +159,8 @@ allocCluster.test('clearing peers and requests', {
         serviceName: 'steve',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -200,7 +204,8 @@ allocCluster.test('delete peer() on top channel', {
         serviceName: 'steve1',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -208,7 +213,8 @@ allocCluster.test('delete peer() on top channel', {
         serviceName: 'steve2',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -282,7 +288,8 @@ allocCluster.test('peers.clear() on top channel', {
         serviceName: 'steve1',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -290,7 +297,8 @@ allocCluster.test('peers.clear() on top channel', {
         serviceName: 'steve2',
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/register.js
+++ b/node/test/register.js
@@ -30,7 +30,8 @@ allocCluster.test('register() with different results', {
         requestDefaults: {
             timeout: 100,
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     }

--- a/node/test/regression-inOps-leak.js
+++ b/node/test/regression-inOps-leak.js
@@ -29,7 +29,8 @@ allocCluster.test('does not leak inOps', {
         serverTimeoutDefault: 100,
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     }

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -50,7 +50,8 @@ allocCluster.test('send relay requests', {
         requestDefaults: {
             serviceName: 'two',
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -91,7 +92,8 @@ allocCluster.test('relay respects ttl', {
         peers: [relay.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -151,7 +153,8 @@ allocCluster.test('relay an error frame', {
         requestDefaults: {
             serviceName: 'two',
             headers: {
-                as: 'raw'
+                as: 'raw',
+cn: 'wat'
             }
         }
     });
@@ -159,7 +162,8 @@ allocCluster.test('relay an error frame', {
     twoClient.request({
         hasNoParent: true,
         headers: {
-            as: 'raw'
+            as: 'raw',
+            cn: 'wat'
         }
     }).send('decline', 'foo', 'bar', function done(err, res, arg2, arg3) {
         assert.equal(err.type, 'tchannel.declined', 'expected declined error');

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -47,7 +47,8 @@ allocCluster.test('emits stats', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -60,7 +60,8 @@ allocCluster.test('emits stats on call success', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -140,7 +141,8 @@ allocCluster.test('emits stats on call failure', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -50,7 +50,8 @@ allocCluster.test('emits response stats with ok', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -133,7 +134,8 @@ allocCluster.test('emits response stats with not ok', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -216,7 +218,8 @@ allocCluster.test('emits response stats with error', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -60,7 +60,8 @@ allocCluster.test('emits stats on response ok', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -134,7 +135,8 @@ allocCluster.test('emits stats on response not ok', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -207,7 +209,8 @@ allocCluster.test('emits stats on response error', {
         peers: [server.hostPort],
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -69,7 +69,8 @@ allocCluster.test('request retries', {
         peers: cluster.hosts,
         requestDefaults: {
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             },
             serviceName: 'tristan'
         }
@@ -180,7 +181,8 @@ allocCluster.test('request application retries', {
         requestDefaults: {
             serviceName: 'tristan',
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });
@@ -304,7 +306,8 @@ allocCluster.test('retryFlags work', {
         requestDefaults: {
             serviceName: 'tristan',
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         }
     });

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -339,7 +339,8 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
         host: one.hostPort,
         hasNoParent: true,
         headers: {
-            'as': 'raw'
+            'as': 'raw',
+            cn: 'wat'
         }
     }).send('foo', '', '', onResponse);
 
@@ -374,7 +375,8 @@ function sendTest(testCase, assert) {
         testCase.opts = testCase.opts || {};
         testCase.opts.hasNoParent = true;
         testCase.opts.headers = {
-            'as': 'raw'
+            'as': 'raw',
+            cn: 'wat'
         };
 
         testCase.channel

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -43,7 +43,8 @@ allocCluster.test('end response with error frame', {
         serviceName: 'stream',
         hasNoParent: true,
         headers: {
-            as: 'raw'
+            as: 'raw',
+            cn: 'wat'
         },
         host: server.hostPort,
         streamed: true

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -104,6 +104,7 @@ function partsTest(testCase, assert) {
         var conn = peer.connect();
         options.headers = options.headers || {};
         options.headers.as = 'raw';
+        options.headers.cn = 'wat';
         var req = conn.request(options);
         conn.on('identified', function onId() {
             var resultReady = Ready();

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -94,7 +94,8 @@ function streamingEchoTest(cluster, state, assert, callback) {
         serviceName: 'test_as_raw',
         hasNoParent: true,
         headers: {
-            as: 'raw'
+            as: 'raw',
+            cn: 'wat'
         },
         streamed: true
     }).sendStreams('streaming_echo', reqHeadStream, reqBodyStream, onResult);

--- a/node/test/timeouts.js
+++ b/node/test/timeouts.js
@@ -49,7 +49,8 @@ allocCluster.test('requests will timeout', {
             serviceName: 'server',
             hasNoParent: true,
             headers: {
-                'as': 'raw'
+                'as': 'raw',
+                cn: 'wat'
             },
             timeout: 1000
         })
@@ -66,7 +67,8 @@ allocCluster.test('requests will timeout', {
                 serviceName: 'server',
                 hasNoParent: true,
                 headers: {
-                    'as': 'raw'
+                    'as': 'raw',
+                    cn: 'wat'
                 },
                 timeout: 1000
             })

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -80,7 +80,8 @@ test('basic tracing test', function (assert) {
                 serviceName: 'subservice',
                 parent: req,
                 headers: {
-                    as: 'raw'
+                    as: 'raw',
+                    cn: 'wat'
                 },
                 trace: true});
             var peers = server.peers.values();
@@ -118,7 +119,8 @@ test('basic tracing test', function (assert) {
             hasNoParent: true,
             trace: true,
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         });
         var peers = client.peers.values();

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -89,7 +89,8 @@ test('basic tracing test', function (assert) {
                     serviceName: 'subservice',
                     parent: req,
                     headers: {
-                        as: 'raw'
+                        as: 'raw',
+                        cn: 'wat'
                     },
                     trace: true
                 }).send('/foobar', 'arg1', 'arg2', function (err, subRes) {
@@ -107,7 +108,8 @@ test('basic tracing test', function (assert) {
                 serviceName: 'subservice',
                 parent: req,
                 headers: {
-                    as: 'raw'
+                    as: 'raw',
+                    cn: 'wat'
                 },
                 trace: true});
             var peers = server.peers.values();
@@ -152,7 +154,8 @@ test('basic tracing test', function (assert) {
             trace: true,
             hasNoParent: true,
             headers: {
-                as: 'raw'
+                as: 'raw',
+                cn: 'wat'
             }
         });
         var peers = client.peers.values();


### PR DESCRIPTION
This makes it a protocol error to not set the cn header.

There is a `requireCn` option to downgrade to a logger.error()

r: @kriskowal @jcorbin