### PR TITLE
Change go argument interface to use a ReadCloser/WriteCloser

### DIFF
--- a/golang/arguments.go
+++ b/golang/arguments.go
@@ -118,7 +118,7 @@ func (out JSONOutput) WriteTo(w io.Writer) error {
 	return e.Encode(out.data)
 }
 
-// WriteArg is a helper that writes an argument to an argument WriteCloser.
+// WriteArg writes an argument to an io.WriteCloser.
 func WriteArg(argWriter io.WriteCloser, arg Output) error {
 	if err := arg.WriteTo(argWriter); err != nil {
 		return err
@@ -126,7 +126,7 @@ func WriteArg(argWriter io.WriteCloser, arg Output) error {
 	return argWriter.Close()
 }
 
-// ReadArg is a helper that reads an argument from the given ReadCloser.
+// ReadArg reads an argument from an io.ReadCloser.
 func ReadArg(argReader io.ReadCloser, arg Input) error {
 	if err := arg.ReadFrom(argReader); err != nil {
 		return err

--- a/golang/arguments.go
+++ b/golang/arguments.go
@@ -117,3 +117,20 @@ func (out JSONOutput) WriteTo(w io.Writer) error {
 	e := json.NewEncoder(w)
 	return e.Encode(out.data)
 }
+
+// WriteArg is a helper that writes an argument to an argument WriteCloser.
+func WriteArg(argWriter io.WriteCloser, arg Output) error {
+	if err := arg.WriteTo(argWriter); err != nil {
+		return err
+	}
+	return argWriter.Close()
+}
+
+// ReadArg is a helper that reads an argument from the given ReadCloser.
+func ReadArg(argReader io.ReadCloser, arg Input) error {
+	if err := arg.ReadFrom(argReader); err != nil {
+		return err
+	}
+
+	return argReader.Close()
+}

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -69,7 +69,10 @@ func (e *echoSaver) echo(t *testing.T, ctx context.Context, call *InboundCall) {
 	require.NoError(t, call.ReadArg2(&inArg2))
 	require.NoError(t, call.ReadArg3(&inArg3))
 	require.NoError(t, call.Response().WriteArg2(BytesOutput(inArg2)))
-	require.NoError(t, call.Response().WriteArg3(BytesOutput(inArg3)))
+
+	arg3Writer, err := call.Response().Arg3Writer()
+	require.NoError(t, err)
+	require.NoError(t, WriteArg(arg3Writer, BytesOutput(inArg3)))
 }
 
 func TestRoundTrip(t *testing.T) {

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -22,6 +22,7 @@ package tchannel
 
 import (
 	"errors"
+	"io"
 
 	"golang.org/x/net/context"
 )
@@ -155,8 +156,13 @@ func (call *InboundCall) CallerName() string {
 
 // Reads the entire operation name (arg1) from the request stream.
 func (call *InboundCall) readOperation() error {
+	reader, err := call.arg1Reader()
+	if err != nil {
+		return call.failed(err)
+	}
+
 	var arg1 BytesInput
-	if err := call.readArg1(&arg1); err != nil {
+	if err := ReadArg(reader, &arg1); err != nil {
 		return call.failed(err)
 	}
 
@@ -164,16 +170,36 @@ func (call *InboundCall) readOperation() error {
 	return nil
 }
 
+// Arg2Reader returns an io.ReadCloser to read the second argument.
+// The ReadCloser must be closed once the argument has been read.
+func (call *InboundCall) Arg2Reader() (io.ReadCloser, error) {
+	return call.arg2Reader()
+}
+
+// Arg3Reader returns an io.ReadCloser to read the second argument.
+// The ReadCloser must be closed once the argument has been read.
+func (call *InboundCall) Arg3Reader() (io.ReadCloser, error) {
+	return call.arg3Reader()
+}
+
 // ReadArg2 reads the second argument from the request, blocking until the
 // argument is ready or an error/timeout has occurred
 func (call *InboundCall) ReadArg2(arg Input) error {
-	return call.readArg2(arg)
+	reader, err := call.Arg2Reader()
+	if err != nil {
+		return err
+	}
+	return ReadArg(reader, arg)
 }
 
 // ReadArg3 reads the third argument from the request, blocking until the
 // argument is ready or an error/timeout has occurred.
 func (call *InboundCall) ReadArg3(arg Input) error {
-	return call.readArg3(arg)
+	reader, err := call.Arg3Reader()
+	if err != nil {
+		return err
+	}
+	return ReadArg(reader, arg)
 }
 
 // Response provides access to the InboundCallResponse object which can be used
@@ -231,18 +257,42 @@ func (response *InboundCallResponse) SetApplicationError() error {
 	return nil
 }
 
+// Arg2Writer returns a WriteCloser that can be used to write the last argument.
+// The returned writer must be closed once the write is complete.
+func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
+	writer, err := response.arg1Writer()
+	if err != nil {
+		return nil, err
+	}
+	if err := WriteArg(writer, BytesOutput(nil)); err != nil {
+		return nil, err
+	}
+
+	return response.arg2Writer()
+}
+
+// Arg3Writer returns a WriteCloser that can be used to write the last argument.
+// The returned writer must be closed once the write is complete.
+func (response *InboundCallResponse) Arg3Writer() (io.WriteCloser, error) {
+	return response.arg3Writer()
+}
+
 // WriteArg2 writes the second argument in the response, blocking until the argument is
 // fully written or an error/timeout has occurred.
 func (response *InboundCallResponse) WriteArg2(arg Output) error {
-	if err := response.writeArg1(BytesOutput(nil)); err != nil {
+	writer, err := response.Arg2Writer()
+	if err != nil {
 		return err
 	}
-
-	return response.writeArg2(arg)
+	return WriteArg(writer, arg)
 }
 
 // WriteArg3 writes the third argument in the response, blocking until the argument is
 // fully written or an error/timeout has occurred
 func (response *InboundCallResponse) WriteArg3(arg Output) error {
-	return response.writeArg3(arg)
+	writer, err := response.Arg3Writer()
+	if err != nil {
+		return err
+	}
+	return WriteArg(writer, arg)
 }

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -176,7 +176,7 @@ func (call *InboundCall) Arg2Reader() (io.ReadCloser, error) {
 	return call.arg2Reader()
 }
 
-// Arg3Reader returns an io.ReadCloser to read the second argument.
+// Arg3Reader returns an io.ReadCloser to read the last argument.
 // The ReadCloser must be closed once the argument has been read.
 func (call *InboundCall) Arg3Reader() (io.ReadCloser, error) {
 	return call.arg3Reader()
@@ -257,7 +257,7 @@ func (response *InboundCallResponse) SetApplicationError() error {
 	return nil
 }
 
-// Arg2Writer returns a WriteCloser that can be used to write the last argument.
+// Arg2Writer returns a WriteCloser that can be used to write the second argument.
 // The returned writer must be closed once the write is complete.
 func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
 	writer, err := response.arg1Writer()

--- a/golang/mex.go
+++ b/golang/mex.go
@@ -128,7 +128,7 @@ type messageExchangeSet struct {
 // newExchange creates and adds a new message exchange to this set
 func (mexset *messageExchangeSet) newExchange(ctx context.Context,
 	msgType messageType, msgID uint32, bufferSize int) (*messageExchange, error) {
-	mexset.log.Debugf("Creating new %s message exchange for [%s:%d]", mexset.name, msgType, msgID)
+	mexset.log.Debugf("Creating new %s message exchange for [%v:%d]", mexset.name, msgType, msgID)
 
 	mex := &messageExchange{
 		msgType: msgType,

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -146,7 +146,7 @@ func (call *OutboundCall) writeOperation(operation []byte) error {
 	return WriteArg(writer, BytesOutput(operation))
 }
 
-// Arg2Writer returns a WriteCloser that can be used to write the last argument.
+// Arg2Writer returns a WriteCloser that can be used to write the second argument.
 // The returned writer must be closed once the write is complete.
 func (call *OutboundCall) Arg2Writer() (io.WriteCloser, error) {
 	return call.arg2Writer()
@@ -209,7 +209,7 @@ func (response *OutboundCallResponse) Arg2Reader() (io.ReadCloser, error) {
 	return response.arg2Reader()
 }
 
-// Arg3Reader returns an io.ReadCloser to read the second argument.
+// Arg3Reader returns an io.ReadCloser to read the last argument.
 // The ReadCloser must be closed once the argument has been read.
 func (response *OutboundCallResponse) Arg3Reader() (io.ReadCloser, error) {
 	return response.arg3Reader()

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -21,6 +21,7 @@ package tchannel
 // THE SOFTWARE.
 
 import (
+	"io"
 	"time"
 
 	"github.com/uber/tchannel/golang/typed"
@@ -138,20 +139,43 @@ func (call *OutboundCall) Response() *OutboundCallResponse {
 
 // writeOperation writes the operation (arg1) to the call
 func (call *OutboundCall) writeOperation(operation []byte) error {
-	operationOut := BytesOutput(operation)
-	return call.writeArg1(operationOut)
+	writer, err := call.arg1Writer()
+	if err != nil {
+		return err
+	}
+	return WriteArg(writer, BytesOutput(operation))
+}
+
+// Arg2Writer returns a WriteCloser that can be used to write the last argument.
+// The returned writer must be closed once the write is complete.
+func (call *OutboundCall) Arg2Writer() (io.WriteCloser, error) {
+	return call.arg2Writer()
+}
+
+// Arg3Writer returns a WriteCloser that can be used to write the last argument.
+// The returned writer must be closed once the write is complete.
+func (call *OutboundCall) Arg3Writer() (io.WriteCloser, error) {
+	return call.arg3Writer()
 }
 
 // WriteArg2 writes the second argument in the request, blocking until the argument is
 // fully written or an error/timeout has occurred.
 func (call *OutboundCall) WriteArg2(arg Output) error {
-	return call.writeArg2(arg)
+	writer, err := call.Arg2Writer()
+	if err != nil {
+		return err
+	}
+	return WriteArg(writer, arg)
 }
 
 // WriteArg3 writes the third argument in the request, blocking until the argument is
 // fully written or an error/timeout has occurred
 func (call *OutboundCall) WriteArg3(arg Output) error {
-	return call.writeArg3(arg)
+	writer, err := call.arg3Writer()
+	if err != nil {
+		return err
+	}
+	return WriteArg(writer, arg)
 }
 
 // An OutboundCallResponse is the response to an outbound call
@@ -170,21 +194,45 @@ func (response *OutboundCallResponse) ApplicationError() bool {
 	return response.callRes.ResponseCode == responseApplicationError
 }
 
+// Arg2Reader returns an io.ReadCloser to read the second argument.
+// The ReadCloser must be closed once the argument has been read.
+func (response *OutboundCallResponse) Arg2Reader() (io.ReadCloser, error) {
+	reader, err := response.arg1Reader()
+	if err != nil {
+		return nil, err
+	}
+	var operation BytesInput
+	if err := ReadArg(reader, &operation); err != nil {
+		return nil, err
+	}
+
+	return response.arg2Reader()
+}
+
+// Arg3Reader returns an io.ReadCloser to read the second argument.
+// The ReadCloser must be closed once the argument has been read.
+func (response *OutboundCallResponse) Arg3Reader() (io.ReadCloser, error) {
+	return response.arg3Reader()
+}
+
 // ReadArg2 reads the second argument from the response, blocking until the
 // argument is ready or an error/timeout has occurred
 func (response *OutboundCallResponse) ReadArg2(arg Input) error {
-	var operation BytesInput
-	if err := response.readArg1(&operation); err != nil {
+	reader, err := response.Arg2Reader()
+	if err != nil {
 		return err
 	}
-
-	return response.readArg2(arg)
+	return ReadArg(reader, arg)
 }
 
 // ReadArg3 reads the third argument from the response, blocking until the
 // argument is ready or an error/timeout has occurred.
 func (response *OutboundCallResponse) ReadArg3(arg Input) error {
-	return response.readArg3(arg)
+	reader, err := response.Arg3Reader()
+	if err != nil {
+		return err
+	}
+	return ReadArg(reader, arg)
 }
 
 // handleError andles an error coming back from the peer. If the error is a


### PR DESCRIPTION
This change makes implementing a thrift protocol that can be used with the thrift autogenerated client much easier, see:
https://github.com/uber/tchannel/commit/b816c279e823be83bed200b6eaf8a6d2689dc7c6

I'll remove ReadArg2, ReadArg3, WriteArg2, WriteArg3 separately, don't want to make this change any larger.

@mranney if you're interested in the go tchannel argument interface change.