### PR TITLE
go: Remove ReadArgX/WriteArgX. Create ArgWriter/ArgReader.

### DIFF
--- a/golang/arguments.go
+++ b/golang/arguments.go
@@ -48,8 +48,8 @@ func (r *ArgReader) read(f func() error) error {
 	return r.reader.Close()
 }
 
-// ReadBytes reads from the reader into the byte slice.
-func (r *ArgReader) ReadBytes(bs *[]byte) error {
+// Read reads from the reader into the byte slice.
+func (r *ArgReader) Read(bs *[]byte) error {
 	return r.read(func() error {
 		var err error
 		*bs, err = ioutil.ReadAll(r.reader)

--- a/golang/arguments.go
+++ b/golang/arguments.go
@@ -26,111 +26,81 @@ import (
 	"io/ioutil"
 )
 
-// An Input is able to read an argument from a call body
-type Input interface {
-	// Reads the argument from the given io.Reader
-	ReadFrom(r io.Reader) error
+// ArgReader providers a simpler interface to reading arguments.
+type ArgReader struct {
+	reader io.ReadCloser
+	err    error
 }
 
-// An Output is able to write an argument to a call body
-type Output interface {
-	// Writes the argument to the given io.Writer
-	WriteTo(w io.Writer) error
+// NewArgReader wraps the result of calling ArgXReader to provide a simpler
+// interface for reading arguments.
+func NewArgReader(reader io.ReadCloser, err error) *ArgReader {
+	return &ArgReader{reader, err}
 }
 
-// A BytesOutput writes a byte slice as a call argument
-type BytesOutput []byte
+func (r *ArgReader) read(f func() error) error {
+	if r.err != nil {
+		return r.err
+	}
+	if err := f(); err != nil {
+		return err
+	}
+	return r.reader.Close()
+}
 
-// WriteTo writes out the byte stream
-func (out BytesOutput) WriteTo(w io.Writer) error {
-	if _, err := w.Write(out); err != nil {
+// ReadBytes reads from the reader into the byte slice.
+func (r *ArgReader) ReadBytes(bs *[]byte) error {
+	return r.read(func() error {
+		var err error
+		*bs, err = ioutil.ReadAll(r.reader)
+		return err
+	})
+}
+
+// ReadJSON deserializes JSON from the underlying reader into data.
+func (r *ArgReader) ReadJSON(data interface{}) error {
+	return r.read(func() error {
+		d := json.NewDecoder(r.reader)
+		return d.Decode(data)
+	})
+}
+
+// ArgWriter providers a simpler interface to writing arguments.
+type ArgWriter struct {
+	writer io.WriteCloser
+	err    error
+}
+
+// NewArgWriter wraps the result of calling ArgXWriter to provider a simpler
+// interface for writing arguments.
+func NewArgWriter(writer io.WriteCloser, err error) *ArgWriter {
+	return &ArgWriter{writer, err}
+}
+
+func (w *ArgWriter) write(f func() error) error {
+	if w.err != nil {
+		return w.err
+	}
+
+	if err := f(); err != nil {
 		return err
 	}
 
-	return nil
+	return w.writer.Close()
 }
 
-// A BytesInput reads an entire call argument into a byte slice
-type BytesInput []byte
-
-// ReadFrom fills in the byte slice from the input stream
-func (in *BytesInput) ReadFrom(r io.Reader) error {
-	var err error
-	*in, err = ioutil.ReadAll(r)
-	return err
-}
-
-// StreamingOutput streams the contents of the given io.Reader
-type StreamingOutput struct {
-	r io.Reader
-}
-
-// NewStreamingOutput creates a new StreamingOutput around an io.Reader
-func NewStreamingOutput(r io.Reader) Output { return StreamingOutput{r} }
-
-// WriteTo streams the contents of the io.Reader to the output
-func (out StreamingOutput) WriteTo(w io.Writer) error {
-	_, err := io.Copy(w, out.r)
-	return err
-}
-
-// StreamingInput streams the contents of the argument to the given io.Writer
-type StreamingInput struct {
-	w io.Writer
-}
-
-// NewStreamingInput creates a new StreamingInput around an io.Writer
-func NewStreamingInput(w io.Writer) Input { return StreamingInput{w} }
-
-// ReadFrom streams the contents of an argument to the output io.Writer
-func (in StreamingInput) ReadFrom(r io.Reader) error {
-	if _, err := io.Copy(in.w, r); err != nil && err != io.EOF {
+// Write writes the given bytes to the underlying writer.
+func (w *ArgWriter) Write(bs []byte) error {
+	return w.write(func() error {
+		_, err := w.writer.Write(bs)
 		return err
-	}
-	return nil
+	})
 }
 
-// JSONInput reads an interface encoded as a JSON object
-type JSONInput struct {
-	data interface{}
-}
-
-// NewJSONInput reates a new JSONInput around an arbitrary data interface
-func NewJSONInput(data interface{}) Input { return JSONInput{data} }
-
-// ReadFrom unmarshals the json data into the desired interface
-func (in JSONInput) ReadFrom(r io.Reader) error {
-	d := json.NewDecoder(r)
-	return d.Decode(in.data)
-}
-
-// JSONOutput writes an interface as an encoded JSON object
-type JSONOutput struct {
-	data interface{}
-}
-
-// NewJSONOutput creates a new JSONOutput around an arbitrary data interface
-func NewJSONOutput(data interface{}) Output { return JSONOutput{data} }
-
-// WriteTo marshals the data to the output stream in json format
-func (out JSONOutput) WriteTo(w io.Writer) error {
-	e := json.NewEncoder(w)
-	return e.Encode(out.data)
-}
-
-// WriteArg writes an argument to an io.WriteCloser.
-func WriteArg(argWriter io.WriteCloser, arg Output) error {
-	if err := arg.WriteTo(argWriter); err != nil {
-		return err
-	}
-	return argWriter.Close()
-}
-
-// ReadArg reads an argument from an io.ReadCloser.
-func ReadArg(argReader io.ReadCloser, arg Input) error {
-	if err := arg.ReadFrom(argReader); err != nil {
-		return err
-	}
-
-	return argReader.Close()
+// WriteJSON writes the given object as JSON.
+func (w *ArgWriter) WriteJSON(data interface{}) error {
+	return w.write(func() error {
+		e := json.NewEncoder(w.writer)
+		return e.Encode(data)
+	})
 }

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -60,19 +60,16 @@ type echoSaver struct {
 }
 
 func (e *echoSaver) echo(t *testing.T, ctx context.Context, call *InboundCall) {
-	var inArg2 BytesInput
-	var inArg3 BytesInput
+	var inArg2 []byte
+	var inArg3 []byte
 
 	e.format = call.Format()
 	e.caller = call.CallerName()
 
-	require.NoError(t, call.ReadArg2(&inArg2))
-	require.NoError(t, call.ReadArg3(&inArg3))
-	require.NoError(t, call.Response().WriteArg2(BytesOutput(inArg2)))
-
-	arg3Writer, err := call.Response().Arg3Writer()
-	require.NoError(t, err)
-	require.NoError(t, WriteArg(arg3Writer, BytesOutput(inArg3)))
+	require.NoError(t, NewArgReader(call.Arg2Reader()).ReadBytes(&inArg2))
+	require.NoError(t, NewArgReader(call.Arg3Reader()).ReadBytes(&inArg3))
+	require.NoError(t, NewArgWriter(call.Response().Arg2Writer()).Write(inArg2))
+	require.NoError(t, NewArgWriter(call.Response().Arg3Writer()).Write(inArg3))
 }
 
 func TestRoundTrip(t *testing.T) {
@@ -86,15 +83,15 @@ func TestRoundTrip(t *testing.T) {
 		call, err := ch.BeginCall(ctx, hostPort, "Capture", "ping", &CallOptions{Format: JSON})
 		require.NoError(t, err)
 
-		require.NoError(t, call.WriteArg2(BytesOutput(testArg2)))
-		require.NoError(t, call.WriteArg3(BytesOutput(testArg3)))
+		require.NoError(t, NewArgWriter(call.Arg2Writer()).Write(testArg2))
+		require.NoError(t, NewArgWriter(call.Arg3Writer()).Write(testArg3))
 
-		var respArg2 BytesInput
-		require.NoError(t, call.Response().ReadArg2(&respArg2))
+		var respArg2 []byte
+		require.NoError(t, NewArgReader(call.Response().Arg2Reader()).ReadBytes(&respArg2))
 		assert.Equal(t, testArg2, []byte(respArg2))
 
-		var respArg3 BytesInput
-		require.NoError(t, call.Response().ReadArg3(&respArg3))
+		var respArg3 []byte
+		require.NoError(t, NewArgReader(call.Response().Arg3Reader()).ReadBytes(&respArg3))
 		assert.Equal(t, testArg3, []byte(respArg3))
 
 		assert.Equal(t, JSON, echoSaver.format)
@@ -190,25 +187,25 @@ func sendRecv(ctx context.Context, ch *Channel, hostPort string, serviceName, op
 		return nil, nil, err
 	}
 
-	if err := call.WriteArg2(BytesOutput(arg2)); err != nil {
+	if err := NewArgWriter(call.Arg2Writer()).Write(arg2); err != nil {
 		return nil, nil, err
 	}
 
-	if err := call.WriteArg3(BytesOutput(arg3)); err != nil {
+	if err := NewArgWriter(call.Arg3Writer()).Write(arg3); err != nil {
 		return nil, nil, err
 	}
 
-	var respArg2 BytesInput
-	if err := call.Response().ReadArg2(&respArg2); err != nil {
+	var respArg2 []byte
+	if err := NewArgReader(call.Response().Arg2Reader()).ReadBytes(&respArg2); err != nil {
 		return nil, nil, err
 	}
 
-	var respArg3 BytesInput
-	if err := call.Response().ReadArg3(&respArg3); err != nil {
+	var respArg3 []byte
+	if err := NewArgReader(call.Response().Arg3Reader()).ReadBytes(&respArg3); err != nil {
 		return nil, nil, err
 	}
 
-	return []byte(respArg2), []byte(respArg3), nil
+	return respArg2, respArg3, nil
 }
 
 func withTestChannel(t *testing.T, f func(ch *Channel, hostPort string)) {

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -66,8 +66,8 @@ func (e *echoSaver) echo(t *testing.T, ctx context.Context, call *InboundCall) {
 	e.format = call.Format()
 	e.caller = call.CallerName()
 
-	require.NoError(t, NewArgReader(call.Arg2Reader()).ReadBytes(&inArg2))
-	require.NoError(t, NewArgReader(call.Arg3Reader()).ReadBytes(&inArg3))
+	require.NoError(t, NewArgReader(call.Arg2Reader()).Read(&inArg2))
+	require.NoError(t, NewArgReader(call.Arg3Reader()).Read(&inArg3))
 	require.NoError(t, NewArgWriter(call.Response().Arg2Writer()).Write(inArg2))
 	require.NoError(t, NewArgWriter(call.Response().Arg3Writer()).Write(inArg3))
 }
@@ -87,11 +87,11 @@ func TestRoundTrip(t *testing.T) {
 		require.NoError(t, NewArgWriter(call.Arg3Writer()).Write(testArg3))
 
 		var respArg2 []byte
-		require.NoError(t, NewArgReader(call.Response().Arg2Reader()).ReadBytes(&respArg2))
+		require.NoError(t, NewArgReader(call.Response().Arg2Reader()).Read(&respArg2))
 		assert.Equal(t, testArg2, []byte(respArg2))
 
 		var respArg3 []byte
-		require.NoError(t, NewArgReader(call.Response().Arg3Reader()).ReadBytes(&respArg3))
+		require.NoError(t, NewArgReader(call.Response().Arg3Reader()).Read(&respArg3))
 		assert.Equal(t, testArg3, []byte(respArg3))
 
 		assert.Equal(t, JSON, echoSaver.format)
@@ -196,12 +196,12 @@ func sendRecv(ctx context.Context, ch *Channel, hostPort string, serviceName, op
 	}
 
 	var respArg2 []byte
-	if err := NewArgReader(call.Response().Arg2Reader()).ReadBytes(&respArg2); err != nil {
+	if err := NewArgReader(call.Response().Arg2Reader()).Read(&respArg2); err != nil {
 		return nil, nil, err
 	}
 
 	var respArg3 []byte
-	if err := NewArgReader(call.Response().Arg3Reader()).ReadBytes(&respArg3); err != nil {
+	if err := NewArgReader(call.Response().Arg3Reader()).Read(&respArg3); err != nil {
 		return nil, nil, err
 	}
 

--- a/golang/examples/hello/client/main.go
+++ b/golang/examples/hello/client/main.go
@@ -98,7 +98,7 @@ func main() {
 	}
 
 	var respArg2 []byte
-	if err := tchannel.NewArgReader(call.Response().Arg2Reader()).ReadBytes(&respArg2); err != nil {
+	if err := tchannel.NewArgReader(call.Response().Arg2Reader()).Read(&respArg2); err != nil {
 		log.Fatalf("Could not read arg2: %v", err)
 	}
 
@@ -109,7 +109,7 @@ func main() {
 	log.Infof("resp-arg2: %s", respArg2)
 
 	var respArg3 []byte
-	if err := tchannel.NewArgReader(call.Response().Arg3Reader()).ReadBytes(&respArg3); err != nil {
+	if err := tchannel.NewArgReader(call.Response().Arg3Reader()).Read(&respArg3); err != nil {
 		log.Fatalf("Could not read arg3: %v", err)
 	}
 

--- a/golang/examples/hello/server/main.go
+++ b/golang/examples/hello/server/main.go
@@ -31,28 +31,28 @@ import (
 var log = tchannel.SimpleLogger
 
 func echo(ctx context.Context, call *tchannel.InboundCall) {
-	var inArg2 tchannel.BytesInput
-	if err := call.ReadArg2(&inArg2); err != nil {
+	var inArg2 []byte
+	if err := tchannel.NewArgReader(call.Arg2Reader()).ReadBytes(&inArg2); err != nil {
 		log.Errorf("could not start arg2: %v", err)
 		return
 	}
 
 	log.Infof("Arg2: %s", inArg2)
 
-	var inArg3 tchannel.BytesInput
-	if err := call.ReadArg3(&inArg3); err != nil {
+	var inArg3 []byte
+	if err := tchannel.NewArgReader(call.Arg3Reader()).ReadBytes(&inArg3); err != nil {
 		log.Errorf("could not start arg3: %v", err)
 		return
 	}
 
 	log.Infof("Arg3: %s", inArg3)
 
-	if err := call.Response().WriteArg2(tchannel.BytesOutput(inArg2)); err != nil {
+	if err := tchannel.NewArgWriter(call.Response().Arg2Writer()).Write(inArg2); err != nil {
 		log.Errorf("could not write arg2: %v", err)
 		return
 	}
 
-	if err := call.Response().WriteArg3(tchannel.BytesOutput(inArg3)); err != nil {
+	if err := tchannel.NewArgWriter(call.Response().Arg3Writer()).Write(inArg3); err != nil {
 		log.Errorf("could not write arg3: %v", err)
 		return
 	}

--- a/golang/examples/hello/server/main.go
+++ b/golang/examples/hello/server/main.go
@@ -32,7 +32,7 @@ var log = tchannel.SimpleLogger
 
 func echo(ctx context.Context, call *tchannel.InboundCall) {
 	var inArg2 []byte
-	if err := tchannel.NewArgReader(call.Arg2Reader()).ReadBytes(&inArg2); err != nil {
+	if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&inArg2); err != nil {
 		log.Errorf("could not start arg2: %v", err)
 		return
 	}
@@ -40,7 +40,7 @@ func echo(ctx context.Context, call *tchannel.InboundCall) {
 	log.Infof("Arg2: %s", inArg2)
 
 	var inArg3 []byte
-	if err := tchannel.NewArgReader(call.Arg3Reader()).ReadBytes(&inArg3); err != nil {
+	if err := tchannel.NewArgReader(call.Arg3Reader()).Read(&inArg3); err != nil {
 		log.Errorf("could not start arg3: %v", err)
 		return
 	}

--- a/golang/examples/ping/main.go
+++ b/golang/examples/ping/main.go
@@ -42,13 +42,13 @@ func pingHandler(ctx context.Context, call *tchannel.InboundCall) {
 	var headers Headers
 
 	var inArg2 []byte
-	if err := tchannel.NewArgReader(call.Arg2Reader()).ReadBytes(&inArg2); err != nil {
+	if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&inArg2); err != nil {
 		log.Errorf("Could not read headers from client: %v", err)
 		return
 	}
 
 	var inArg3 []byte
-	if err := tchannel.NewArgReader(call.Arg2Reader()).ReadBytes(&inArg3); err != nil {
+	if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&inArg3); err != nil {
 		log.Errorf("Could not read body from client: %v", err)
 		return
 	}

--- a/golang/fragmentation_test.go
+++ b/golang/fragmentation_test.go
@@ -192,7 +192,7 @@ func TestFragmentationReaderErrors(t *testing.T) {
 		assert.NoError(t, err)
 
 		var arg []byte
-		assert.NoError(t, NewArgReader(reader, nil).ReadBytes(&arg))
+		assert.NoError(t, NewArgReader(reader, nil).Read(&arg))
 		assert.Equal(t, "hello", string(arg))
 		assert.Error(t, r.BeginArgument(false /* last */))
 	})
@@ -207,7 +207,7 @@ func TestFragmentationReaderErrors(t *testing.T) {
 		assert.NoError(t, err)
 
 		var arg []byte
-		assert.Error(t, NewArgReader(reader, nil).ReadBytes(&arg))
+		assert.Error(t, NewArgReader(reader, nil).Read(&arg))
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
@@ -272,7 +272,7 @@ func TestFragmentationChecksumTypeErrors(t *testing.T) {
 	assert.NoError(t, err)
 
 	var arg []byte
-	assert.Error(t, NewArgReader(reader, nil).ReadBytes(&arg))
+	assert.Error(t, NewArgReader(reader, nil).Read(&arg))
 }
 
 func TestFragmentationChecksumMismatch(t *testing.T) {
@@ -299,7 +299,7 @@ func TestFragmentationChecksumMismatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	var arg []byte
-	assert.Error(t, NewArgReader(reader, nil).ReadBytes(&arg))
+	assert.Error(t, NewArgReader(reader, nil).Read(&arg))
 }
 
 func runFragmentationErrorTest(f func(w *fragmentingWriter, r *fragmentingReader)) {
@@ -337,7 +337,7 @@ func runFragmentationTest(t *testing.T, args []string, expectedFragments [][]byt
 			require.NoError(t, err)
 
 			var arg []byte
-			require.NoError(t, NewArgReader(reader, nil).ReadBytes(&arg))
+			require.NoError(t, NewArgReader(reader, nil).Read(&arg))
 			actualArgs = append(actualArgs, string(arg))
 		}
 
@@ -345,7 +345,7 @@ func runFragmentationTest(t *testing.T, args []string, expectedFragments [][]byt
 		require.NoError(t, err)
 
 		var arg []byte
-		require.NoError(t, NewArgReader(reader, nil).ReadBytes(&arg))
+		require.NoError(t, NewArgReader(reader, nil).Read(&arg))
 		actualArgs = append(actualArgs, string(arg))
 	}()
 

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -156,13 +156,8 @@ func (call *InboundCall) CallerName() string {
 
 // Reads the entire operation name (arg1) from the request stream.
 func (call *InboundCall) readOperation() error {
-	reader, err := call.arg1Reader()
-	if err != nil {
-		return call.failed(err)
-	}
-
-	var arg1 BytesInput
-	if err := ReadArg(reader, &arg1); err != nil {
+	var arg1 []byte
+	if err := NewArgReader(call.arg1Reader()).ReadBytes(&arg1); err != nil {
 		return call.failed(err)
 	}
 
@@ -180,26 +175,6 @@ func (call *InboundCall) Arg2Reader() (io.ReadCloser, error) {
 // The ReadCloser must be closed once the argument has been read.
 func (call *InboundCall) Arg3Reader() (io.ReadCloser, error) {
 	return call.arg3Reader()
-}
-
-// ReadArg2 reads the second argument from the request, blocking until the
-// argument is ready or an error/timeout has occurred
-func (call *InboundCall) ReadArg2(arg Input) error {
-	reader, err := call.Arg2Reader()
-	if err != nil {
-		return err
-	}
-	return ReadArg(reader, arg)
-}
-
-// ReadArg3 reads the third argument from the request, blocking until the
-// argument is ready or an error/timeout has occurred.
-func (call *InboundCall) ReadArg3(arg Input) error {
-	reader, err := call.Arg3Reader()
-	if err != nil {
-		return err
-	}
-	return ReadArg(reader, arg)
 }
 
 // Response provides access to the InboundCallResponse object which can be used
@@ -260,14 +235,9 @@ func (response *InboundCallResponse) SetApplicationError() error {
 // Arg2Writer returns a WriteCloser that can be used to write the second argument.
 // The returned writer must be closed once the write is complete.
 func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
-	writer, err := response.arg1Writer()
-	if err != nil {
+	if err := NewArgWriter(response.arg1Writer()).Write(nil); err != nil {
 		return nil, err
 	}
-	if err := WriteArg(writer, BytesOutput(nil)); err != nil {
-		return nil, err
-	}
-
 	return response.arg2Writer()
 }
 
@@ -275,24 +245,4 @@ func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
 // The returned writer must be closed once the write is complete.
 func (response *InboundCallResponse) Arg3Writer() (io.WriteCloser, error) {
 	return response.arg3Writer()
-}
-
-// WriteArg2 writes the second argument in the response, blocking until the argument is
-// fully written or an error/timeout has occurred.
-func (response *InboundCallResponse) WriteArg2(arg Output) error {
-	writer, err := response.Arg2Writer()
-	if err != nil {
-		return err
-	}
-	return WriteArg(writer, arg)
-}
-
-// WriteArg3 writes the third argument in the response, blocking until the argument is
-// fully written or an error/timeout has occurred
-func (response *InboundCallResponse) WriteArg3(arg Output) error {
-	writer, err := response.Arg3Writer()
-	if err != nil {
-		return err
-	}
-	return WriteArg(writer, arg)
 }

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -157,7 +157,7 @@ func (call *InboundCall) CallerName() string {
 // Reads the entire operation name (arg1) from the request stream.
 func (call *InboundCall) readOperation() error {
 	var arg1 []byte
-	if err := NewArgReader(call.arg1Reader()).ReadBytes(&arg1); err != nil {
+	if err := NewArgReader(call.arg1Reader()).Read(&arg1); err != nil {
 		return call.failed(err)
 	}
 

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -174,7 +174,7 @@ func (response *OutboundCallResponse) ApplicationError() bool {
 // The ReadCloser must be closed once the argument has been read.
 func (response *OutboundCallResponse) Arg2Reader() (io.ReadCloser, error) {
 	var operation []byte
-	if err := NewArgReader(response.arg1Reader()).ReadBytes(&operation); err != nil {
+	if err := NewArgReader(response.arg1Reader()).Read(&operation); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
ArgWriter and ArgReader give some of the convenience of ReadArgX/WriteArgX methods for clients.