### PR TITLE
Do not confuse socket remoteAddr with init remoteName

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -188,7 +188,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
             self.sendRequest(treq, hreq, forwarded);
         }
 
-        return treq;
+        return null;
     }
 
     function forwarded(err, head, body) {

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -166,6 +166,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
     // - driving peer selection manually therefore
     // TODO: more http state machine integration
 
+    var treq;
     var options = tchannel.requestOptions({
         streamed: true,
         hasNoParent: true
@@ -177,12 +178,13 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
         return null;
     } else {
         // TODO: observable
-        var treq = peer.request(options);
         if (!peer.isConnected()) {
             peer.connect().on('identified', function onIdentified() {
+                treq = peer.request(options);
                 self.sendRequest(treq, hreq, forwarded);
             });
         } else {
+            treq = peer.request(options);
             self.sendRequest(treq, hreq, forwarded);
         }
 

--- a/node/channel.js
+++ b/node/channel.js
@@ -241,28 +241,28 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
         return;
     }
 
-    var remoteAddr = sock.remoteAddress + ':' + sock.remotePort;
-    var conn = new TChannelConnection(self, sock, 'in', remoteAddr);
+    var socketRemoteAddr = sock.remoteAddress + ':' + sock.remotePort;
+    var conn = new TChannelConnection(self, sock, 'in', socketRemoteAddr);
 
     conn.spanEvent.on(function handleSpanFromConn(span) {
         self.tracer.report(span);
     });
 
-    if (self.serverConnections[remoteAddr]) {
-        var oldConn = self.serverConnections[remoteAddr];
+    if (self.serverConnections[socketRemoteAddr]) {
+        var oldConn = self.serverConnections[socketRemoteAddr];
         oldConn.resetAll(errors.SocketClosedError({
-            reason: 'duplicate remoteAddr incoming conn'
+            reason: 'duplicate socketRemoteAddr incoming conn'
         }));
-        delete self.serverConnections[remoteAddr];
+        delete self.serverConnections[socketRemoteAddr];
     }
 
     sock.on('close', onSocketClose);
 
-    self.serverConnections[remoteAddr] = conn;
+    self.serverConnections[socketRemoteAddr] = conn;
     self.connectionEvent.emit(self, conn);
 
     function onSocketClose() {
-        delete self.serverConnections[remoteAddr];
+        delete self.serverConnections[socketRemoteAddr];
     }
 };
 

--- a/node/channel.js
+++ b/node/channel.js
@@ -234,7 +234,7 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
 
     if (self.destroyed) {
         self.logger.error('got incoming socket whilst destroyed', {
-            remoteAddr: sock.remoteAddr,
+            remoteAddress: sock.remoteAddress,
             remotePort: sock.remotePort,
             hostPort: self.hostPort
         });

--- a/node/connection.js
+++ b/node/connection.js
@@ -54,6 +54,7 @@ function TChannelConnection(channel, socket, direction, socketRemoteAddr) {
     }
 
     self.socket = socket;
+    self.ephemeral = false;
 
     var opts = {
         logger: self.channel.logger,
@@ -109,8 +110,9 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
             direction: self.direction,
             remoteName: self.remoteName
         }));
-        if (self.remoteName === '0.0.0.0:0') {
-            self.channel.peers.delete(self.remoteAddr);
+
+        if (self.ephemeral) {
+            self.channel.peers.delete(self.socketRemoteAddr);
         }
     }
 
@@ -341,6 +343,7 @@ TChannelConnection.prototype.onOutIdentified = function onOutIdentified(init) {
 TChannelConnection.prototype.onInIdentified = function onInIdentified(init) {
     var self = this;
     if (init.hostPort === '0.0.0.0:0') {
+        self.ephemeral = true;
         self.remoteName = '' + self.socket.remoteAddress + ':' + self.socket.remotePort;
         assert(self.remoteName !== self.channel.hostPort,
               'should not be able to receive ephemeral connection from self');

--- a/node/connection.js
+++ b/node/connection.js
@@ -320,6 +320,15 @@ TChannelConnection.prototype.start = function start() {
 
 TChannelConnection.prototype.onOutIdentified = function onOutIdentified(init) {
     var self = this;
+
+    if (init.hostPort === '0.0.0.0:0') {
+        return self.emit('error', errors.EphemeralInitResponse({
+            hostPort: init.hostPort,
+            socketRemoteAddr: self.socketRemoteAddr,
+            processName: init.processName
+        }));
+    }
+
     self.remoteName = init.hostPort;
     self.identifiedEvent.emit(self, {
         hostPort: init.hostPort,

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -78,7 +78,9 @@ inherits(TChannelConnectionBase, EventEmitter);
 TChannelConnectionBase.prototype.request = function connBaseRequest(options) {
     var self = this;
     if (!options) options = {};
-    options.remoteAddr = self.remoteAddr;
+
+    assert(self.remoteName, 'cannot make request unless identified');
+    options.remoteAddr = self.remoteName;
 
     options.channel = self.channel;
 

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -32,7 +32,7 @@ var Operations = require('./operations');
 var DEFAULT_OUTGOING_REQ_TIMEOUT = 2000;
 var CONNECTION_BASE_IDENTIFIER = 0;
 
-function TChannelConnectionBase(channel, direction, remoteAddr) {
+function TChannelConnectionBase(channel, direction, socketRemoteAddr) {
     assert(!channel.destroyed, 'refuse to create connection for destroyed channel');
 
     var self = this;
@@ -52,7 +52,7 @@ function TChannelConnectionBase(channel, direction, remoteAddr) {
     self.random = channel.random;
     self.timers = channel.timers;
     self.direction = direction;
-    self.remoteAddr = remoteAddr;
+    self.socketRemoteAddr = socketRemoteAddr;
     self.timer = null;
     self.remoteName = null; // filled in by identify message
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -122,6 +122,14 @@ module.exports.DuplicateInitResponseError = TypedError({
     message: 'tchannel: duplicate init response'
 });
 
+module.exports.EphemeralInitResponse = TypedError({
+    type: 'tchannel.init.ephemeral-init-response',
+    message: 'tchannel: got 0.0.0.0:0 as hostPort in Init Response',
+    hostPort: null,
+    socketRemoteAddr: null,
+    processName: null
+});
+
 module.exports.InvalidArgumentError = TypedError({
     type: 'tchannel.invalid-argument',
     message: 'invalid argument, expected array or null',
@@ -505,6 +513,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.unhandled-frame-type':
         case 'tchannel.handler.incoming-req-as-header-required':
         case 'tchannel.handler.incoming-req-cn-header-required':
+        case 'tchannel.init.ephemeral-init-response':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/errors.js
+++ b/node/errors.js
@@ -124,7 +124,7 @@ module.exports.DuplicateInitResponseError = TypedError({
 
 module.exports.EphemeralInitResponse = TypedError({
     type: 'tchannel.init.ephemeral-init-response',
-    message: 'tchannel: got 0.0.0.0:0 as hostPort in Init Response',
+    message: 'tchannel: got invalid 0.0.0.0:0 as hostPort in Init Response',
     hostPort: null,
     socketRemoteAddr: null,
     processName: null

--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -90,7 +90,7 @@ function handleAdvertise(self, req, arg2, arg3, cb) {
 
     for (var i = 0; i < services.length; i++) {
         var service = services[i];
-        service.hostPort = req.remoteAddr;
+        service.hostPort = req.connection.remoteName;
 
         var serviceName = service.serviceName;
         if (serviceName === '') {

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -59,7 +59,7 @@ function TChannelInRequest(id, options) {
             traceid: self.tracing.traceid,
             parentid: self.tracing.parentid,
             flags: self.tracing.flags,
-            hostPort: options.hostPort,
+            remoteName: options.hostPort,
             serviceName: self.serviceName,
             name: '' // fill this in later
         });

--- a/node/operations.js
+++ b/node/operations.js
@@ -135,7 +135,7 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
         // This could be because of a confused / corrupted server.
         self.logger.info('popOutReq received for unknown or lost id', {
             context: context,
-            remoteAddr: self.connection.remoteAddr,
+            socketRemoteAddr: self.connection.socketRemoteAddr,
             direction: self.connection.direction
         });
         return null;

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -74,7 +74,7 @@ function TChannelOutRequest(id, options) {
             traceid: null,
             parentid: null,
             flags: options.trace? 1 : 0,
-            hostPort: self.remoteAddr,
+            remoteName: self.remoteAddr,
             serviceName: self.serviceName,
             name: '' // fill this in later
         });

--- a/node/peer.js
+++ b/node/peer.js
@@ -42,11 +42,12 @@ function TChannelPeer(channel, hostPort, options) {
     self.stateChangedEvent = self.defineEvent('stateChanged');
     self.allocConnectionEvent = self.defineEvent('allocConnection');
 
+    assert(hostPort !== '0.0.0.0:0', 'Cannot create ephemeral peer');
+
     self.channel = channel;
     self.logger = self.channel.logger;
     self.options = options || {};
     self.hostPort = hostPort;
-    self.isEphemeral = self.hostPort === '0.0.0.0:0';
     self.connections = [];
     self.random = self.channel.random;
 

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -45,7 +45,7 @@ RelayRequest.prototype.createOutRequest = function createOutRequest() {
     if (self.outreq) {
         self.channel.logger.warn('relay request already started', {
             // TODO: better context
-            remoteAddr: self.inreq.remoteAddr,
+            inRemoteName: self.inreq.remoteAddr,
             id: self.inreq.id
         });
         return;
@@ -88,7 +88,7 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     if (self.outres) {
         self.channel.logger.warn('relay request already responded', {
             // TODO: better context
-            remoteAddr: self.inreq.remoteAddr,
+            inRemoteName: self.inreq.remoteAddr,
             id: self.inreq.id
         });
         return;
@@ -108,7 +108,7 @@ RelayRequest.prototype.onResponse = function onResponse(res) {
     if (self.inres) {
         self.channel.logger.warn('relay request got more than one response callback', {
             // TODO: better context
-            remoteAddr: res.remoteAddr,
+            inRemoteName: res.remoteAddr,
             id: res.id
         });
         return;
@@ -172,8 +172,8 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
     var logOptions = {
         error: err,
         isErrorFrame: err.isErrorFrame,
-        outRemoteAddr: self.outreq.remoteAddr,
-        inRemoteAddr: self.inreq.remoteAddr,
+        outRemoteName: self.outreq.remoteAddr,
+        inRemoteName: self.inreq.remoteAddr,
         serviceName: self.outreq.serviceName,
         callerName: self.inreq.headers.cn,
         outArg1: String(self.outreq.arg1)

--- a/node/request.js
+++ b/node/request.js
@@ -215,7 +215,8 @@ TChannelRequest.prototype.onIdentified = function onIdentified(peer) {
         });
     }
 
-    self.triedRemoteAddrs[outReq.remoteAddr] = (self.triedRemoteAddrs[outReq.remoteAddr] || 0) + 1;
+    self.triedRemoteAddrs[outReq.remoteAddr] =
+        (self.triedRemoteAddrs[outReq.remoteAddr] || 0) + 1;
     outReq.responseEvent.on(onResponse);
     outReq.errorEvent.on(onError);
     outReq.send(self.arg1, self.arg2, self.arg3);

--- a/node/self_connection.js
+++ b/node/self_connection.js
@@ -36,6 +36,9 @@ function TChannelSelfConnection(channel) {
     var self = this;
     TChannelConnectionBase.call(self, channel, 'in', channel.hostPort);
     self.idCount = 0;
+
+    // populate the remoteName as self
+    self.remoteName = channel.hostPort;
 }
 inherits(TChannelSelfConnection, TChannelConnectionBase);
 

--- a/node/self_connection.js
+++ b/node/self_connection.js
@@ -88,6 +88,10 @@ TChannelSelfConnection.prototype.ping = function ping() {
 };
 
 TChannelSelfConnection.prototype.close = function close(callback) {
+    var self = this;
+
+    self.ops.destroy();
+
     callback();
 };
 

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -33,7 +33,7 @@ allocCluster.test('emits response stats with ok', {
     var clientHost;
     var stats = [];
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr;
+        clientHost = conn.socketRemoteAddr;
     });
 
     server.makeSubChannel({
@@ -133,7 +133,7 @@ allocCluster.test('emits response stats with not ok', {
     var clientHost;
     var stats = [];
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr;
+        clientHost = conn.socketRemoteAddr;
     });
 
     server.makeSubChannel({
@@ -234,7 +234,7 @@ allocCluster.test('emits response stats with error', {
     var clientHost;
     var stats = [];
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr;
+        clientHost = conn.socketRemoteAddr;
     });
 
     server.makeSubChannel({

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -38,7 +38,7 @@ allocCluster.test('emits stats on response ok', {
     var client = cluster.channels[1];
     var clientHost;
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr
+        clientHost = conn.socketRemoteAddr
             .replace(/:/g, '-')
             .replace(/\./g, '-');
     });
@@ -125,7 +125,7 @@ allocCluster.test('emits stats on response not ok', {
     var client = cluster.channels[1];
     var clientHost;
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr
+        clientHost = conn.socketRemoteAddr
             .replace(/:/g, '-')
             .replace(/\./g, '-');
     });
@@ -212,7 +212,7 @@ allocCluster.test('emits stats on response error', {
     var client = cluster.channels[1];
     var clientHost;
     server.on('connection', function onConnection(conn) {
-        clientHost = conn.remoteAddr
+        clientHost = conn.socketRemoteAddr
             .replace(/:/g, '-')
             .replace(/\./g, '-');
     });

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -37,17 +37,9 @@ allocCluster.test('end response with error frame', {
         streamed: true
     }, streamHandler);
 
-    var req = client.makeSubChannel({
-        serviceName: 'stream'
-    }).request({
+    var subChan = client.makeSubChannel({
         serviceName: 'stream',
-        hasNoParent: true,
-        headers: {
-            as: 'raw',
-            cn: 'wat'
-        },
-        host: server.hostPort,
-        streamed: true
+        peers: [server.hostPort]
     });
 
     var peers = client.peers.values();
@@ -56,6 +48,16 @@ allocCluster.test('end response with error frame', {
         peer.connect().on('identified', ready.signal);
     });
     ready(function send() {
+        var req = subChan.request({
+            serviceName: 'stream',
+            hasNoParent: true,
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            },
+            streamed: true
+        });
+
         req.arg1.end('stream');
         req.arg2.end();
         req.arg3.end();

--- a/node/test/streaming.js
+++ b/node/test/streaming.js
@@ -105,8 +105,8 @@ function partsTest(testCase, assert) {
         options.headers = options.headers || {};
         options.headers.as = 'raw';
         options.headers.cn = 'wat';
-        var req = conn.request(options);
         conn.on('identified', function onId() {
+            var req = conn.request(options);
             var resultReady = Ready();
             req.hookupCallback(resultReady.signal);
             req.arg1.end(testCase.op);

--- a/node/test/tchannel.js
+++ b/node/test/tchannel.js
@@ -47,7 +47,7 @@ test('add peer: get connection', function t(assert) {
     var connection = server.peers.add(clientName).connect();
 
     assert.ok(connection, 'A connection object should be returned');
-    assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    assert.equals(connection.socketRemoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
     server.quit(assert.end);
   });
 });
@@ -58,7 +58,7 @@ test('peer add, connect', function t(assert) {
   server.listen(serverOptions.port, serverOptions.host, function listening() {
     var connection = server.peers.add(clientName).connect();
     assert.ok(connection, 'A connection object should be returned');
-    assert.equals(connection.remoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    assert.equals(connection.socketRemoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
     server.quit(assert.end);
   });
 });
@@ -80,7 +80,7 @@ test('get peer: should return requested peer', function t(assert) {
   server.listen(serverOptions.port, serverOptions.host, function listening() {
     server.peers.add(clientName).connect();
     assert.equals(clientName,
-      server.peers.get(clientName).connections[0].remoteAddr,
+      server.peers.get(clientName).connections[0].socketRemoteAddr,
       'added peer connection');
     server.quit(assert.end);
   });
@@ -94,8 +94,8 @@ test('get peers: should get all peers', function t(assert) {
     server.peers.add(client1Name).connect();
     var peers = server.peers.values();
     assert.equals(peers.length, 2);
-    assert.equals(clientName, peers[0].connections[0].remoteAddr, 'first peer connection');
-    assert.equals(client1Name, peers[1].connections[0].remoteAddr, 'first peer connection');
+    assert.equals(clientName, peers[0].connections[0].socketRemoteAddr, 'first peer connection');
+    assert.equals(client1Name, peers[1].connections[0].socketRemoteAddr, 'first peer connection');
     server.quit(assert.end);
   });
 });
@@ -119,7 +119,7 @@ test('getOut connection: add and get for provided peer', function t(assert) {
     assert.ok(peer, 'added peer should be returned');
     var conn = peer.connect();
     assert.ok(conn, 'added connections should be returned');
-    assert.equals(conn.remoteAddr, clientName, 'Remote address should match the client');
+    assert.equals(conn.socketRemoteAddr, clientName, 'Remote address should match the client');
     server.quit(assert.end);
   });
 });

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -60,7 +60,7 @@ function compareBufs(buf1, buf2) {
 Agent.prototype.setupNewSpan = function setupNewSpan(options) {
     var self = this;
 
-    var hostPortParts = options.hostPort.split(":");
+    var hostPortParts = options.remoteName.split(":");
     var host = hostPortParts[0], port = parseInt(hostPortParts[1], 10);
 
     var empty = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);


### PR DESCRIPTION
This PR fixes a bunch of confusion around remoteAddr
and remoteName.

In this PR we have

 - `conn.socketRemoteAddr`; the remote address of the socket
 - `conn.remoteName`; the remoteName as per init handshake
 - `req/res.remoteAddr`; the remoteName of the connection

We had a bug where we previously non-determinsically set
`req.remoteAddr` to remoteName or socketRemoteAddr

We also fix miscellanious things in this PR; mostly 
to do with not allowing out requests until initialized
and handling ephemeral remote names better.

r: @jcorbin @kriskowal @rf