### PR TITLE
go: add a simple Hyperbahn client to register services.

### DIFF
--- a/golang/.gitignore
+++ b/golang/.gitignore
@@ -3,6 +3,4 @@
 .DS_Store
 build
 Godeps/_workspace
-messagetype_string.go
-reqresreaderstate_string.go
-reqreswriterstate_string.go
+*_string.go

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -1,7 +1,7 @@
 GODEPS := $(shell pwd)/Godeps/_workspace
 OLDGOPATH := $(GOPATH)
 PATH := $(GODEPS)/bin:$(PATH)
-PKGS := . ./thrift ./typed ./examples/hello/server ./examples/hello/client ./examples/ping ./examples/thrift
+PKGS := . ./hyperbahn ./thrift ./typed ./examples/hello/server ./examples/hello/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
 BUILD := ./build
 SRCS := $(foreach pkg,$(PKGS),$(wildcard $(pkg)/*.go))
 export GOPATH = $(GODEPS):$(OLDGOPATH)
@@ -65,6 +65,7 @@ examples: clean setup thrift_example
 	go build -o $(BUILD)/examples/hello/server ./examples/hello/server
 	go build -o $(BUILD)/examples/hello/client ./examples/hello/client
 	go build -o $(BUILD)/examples/ping/pong    ./examples/ping/main.go
+	go build -o $(BUILD)/examples/hyperbahn/echo-server    ./examples/hyperbahn/echo-server/main.go
 
 thrift_gen:
 	cd examples/thrift && thrift -r --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift test.thrift

--- a/golang/channel.go
+++ b/golang/channel.go
@@ -195,6 +195,14 @@ func (ch *Channel) GetSubChannel(serviceName string) *SubChannel {
 	return ch.registerNewSubChannel(serviceName)
 }
 
+// Peers returns the PeerList for the channel.
+func (ch *Channel) Peers() *PeerList {
+	ch.mutable.mut.RLock()
+	defer ch.mutable.mut.RUnlock()
+
+	return ch.peers
+}
+
 // BeginCall starts a new call to a remote peer, returning an OutboundCall that can
 // be used to write the arguments of the call.
 func (ch *Channel) BeginCall(ctx context.Context, hostPort, serviceName, operationName string, callOptions *CallOptions) (*OutboundCall, error) {

--- a/golang/channel.go
+++ b/golang/channel.go
@@ -259,6 +259,11 @@ func (ch *Channel) serve() {
 	}
 }
 
+// Logger returns the logger for this channel.
+func (ch *Channel) Logger() Logger {
+	return ch.log
+}
+
 // Closed returns whether this channel has been closed with .Close()
 func (ch *Channel) Closed() bool {
 	ch.mutable.mut.Lock()

--- a/golang/channel.go
+++ b/golang/channel.go
@@ -197,9 +197,6 @@ func (ch *Channel) GetSubChannel(serviceName string) *SubChannel {
 
 // Peers returns the PeerList for the channel.
 func (ch *Channel) Peers() *PeerList {
-	ch.mutable.mut.RLock()
-	defer ch.mutable.mut.RUnlock()
-
 	return ch.peers
 }
 

--- a/golang/examples/hyperbahn/echo-server/main.go
+++ b/golang/examples/hyperbahn/echo-server/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"time"
+
+	"github.com/uber/tchannel/golang"
+	"github.com/uber/tchannel/golang/hyperbahn"
+	"golang.org/x/net/context"
+)
+
+func main() {
+	tchan, err := tchannel.NewChannel("go-echo-server", nil)
+	if err != nil {
+		log.Fatalf("Failed to create channel: %v", err)
+	}
+
+	l, err := net.Listen("tcp", ":61543")
+	if err != nil {
+		log.Fatalf("Could not listen: %v", err)
+	}
+	log.Printf("Listening on %v", l.Addr())
+
+	tchan.Register(handler{}, "echo")
+	tchan.Serve(l)
+
+	// register service with Hyperbahn.
+	client := hyperbahn.NewClient(tchan, os.Args[1:], &hyperbahn.ClientOptions{
+		Handler: eventHandler{},
+		Timeout: time.Second,
+	})
+	if err := client.Register(); err != nil {
+		fmt.Println("Register threw error:", err)
+	}
+
+	// Server will keep running till Ctrl-C.
+	select {}
+}
+
+type eventHandler struct{}
+
+func (eventHandler) On(event hyperbahn.Event) {
+	fmt.Printf("On(%v)\n", event)
+}
+
+func (eventHandler) OnError(err error) {
+	fmt.Printf("OnError(%v)\n", err)
+}
+
+type handler struct{}
+
+func (handler) Handle(ctx context.Context, call *tchannel.InboundCall) {
+	var arg2 []byte
+	if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&arg2); err != nil {
+		log.Printf("Read arg2 failed: %v\n", err)
+	}
+
+	var arg3 []byte
+	if err := tchannel.NewArgReader(call.Arg3Reader()).Read(&arg3); err != nil {
+		log.Printf("Read arg2 failed: %v\n", err)
+	}
+
+	resp := call.Response()
+	if err := tchannel.NewArgWriter(resp.Arg2Writer()).Write(arg2); err != nil {
+		log.Printf("Write arg2 failed: %v", arg2)
+	}
+
+	if err := tchannel.NewArgWriter(resp.Arg3Writer()).Write(arg3); err != nil {
+		log.Printf("Write arg3 failed: %v", arg3)
+	}
+
+}

--- a/golang/examples/hyperbahn/echo-server/main.go
+++ b/golang/examples/hyperbahn/echo-server/main.go
@@ -18,14 +18,20 @@ func main() {
 		log.Fatalf("Failed to create channel: %v", err)
 	}
 
-	l, err := net.Listen("tcp", ":61543")
+	l, err := net.Listen("tcp", "127.0.0.1:61543")
 	if err != nil {
 		log.Fatalf("Could not listen: %v", err)
 	}
 	log.Printf("Listening on %v", l.Addr())
 
 	tchan.Register(handler{}, "echo")
-	tchan.Serve(l)
+	go tchan.Serve(l)
+
+	time.Sleep(100 * time.Millisecond)
+
+	if len(os.Args[1:]) == 0 {
+		log.Fatalf("You must provide Hyperbahn nodes as arguments")
+	}
 
 	// register service with Hyperbahn.
 	client := hyperbahn.NewClient(tchan, os.Args[1:], &hyperbahn.ClientOptions{
@@ -33,7 +39,7 @@ func main() {
 		Timeout: time.Second,
 	})
 	if err := client.Register(); err != nil {
-		fmt.Println("Register threw error:", err)
+		log.Fatalf("Register threw error: %v", err)
 	}
 
 	// Server will keep running till Ctrl-C.

--- a/golang/examples/hyperbahn/echo-server/main.go
+++ b/golang/examples/hyperbahn/echo-server/main.go
@@ -25,7 +25,7 @@ func main() {
 	log.Printf("Listening on %v", l.Addr())
 
 	tchan.Register(handler{}, "echo")
-	go tchan.Serve(l)
+	tchan.Serve(l)
 
 	time.Sleep(100 * time.Millisecond)
 

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -30,6 +30,7 @@ const hyperbahnServiceName = "hyperbahn"
 
 // ClientOptions are used to configure this Hyperbahn client.
 type ClientOptions struct {
+	// Timeout defaults to 1 second if it is not set.
 	Timeout      time.Duration
 	Handler      Handler
 	FailStrategy FailStrategy
@@ -46,6 +47,9 @@ func NewClient(ch *tchannel.Channel, initialNodes []string, opts *ClientOptions)
 	client := &Client{tchan: ch}
 	if opts != nil {
 		client.opts = *opts
+	}
+	if client.opts.Timeout == 0 {
+		client.opts.Timeout = time.Second
 	}
 	if client.opts.Handler == nil {
 		client.opts.Handler = nullHandler{}

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -19,7 +19,7 @@ type Client struct {
 type FailStrategy int
 
 const (
-	// FailStrategyFatal will call Fatalf on the channel's logger after triggerring handler.OnError.
+	// FailStrategyFatal will call Fatalf on the channel's logger after triggering handler.OnError.
 	// This is the default strategy.
 	FailStrategyFatal FailStrategy = iota
 	// FailStrategyIgnore will only call handler.OnError, even on fatal errors.

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -1,0 +1,96 @@
+package hyperbahn
+
+import (
+	"errors"
+	"time"
+
+	"github.com/uber/tchannel/golang"
+	"golang.org/x/net/context"
+)
+
+// Client manages Hyperbahn connections and registrations.
+type Client struct {
+	tchan *tchannel.Channel
+	opts  ClientOptions
+}
+
+const hyperbahnServiceName = "hyperbahn"
+
+// ClientOptions are used to configure this Hyperbahn client.
+type ClientOptions struct {
+	Timeout time.Duration
+	Handler Handler
+}
+
+// ErrAppError is returned if there was an application error during registration.
+// TODO(prashant): Check if there is more information returned that we can use.
+var ErrAppError = errors.New("app error")
+
+// NewClient creates a new Hyperbahn client using the given channel.
+// initialNodes is a list of hostPort strings identifying the initial Hyperbahn nodes to connect to.
+// opts are optional, and are used to customize the client.
+func NewClient(ch *tchannel.Channel, initialNodes []string, opts *ClientOptions) *Client {
+	client := &Client{tchan: ch}
+	if opts != nil {
+		client.opts = *opts
+	}
+	if client.opts.Handler == nil {
+		client.opts.Handler = nullHandler{}
+	}
+
+	// Add the given initial nodes as peers.
+	for _, node := range initialNodes {
+		addPeer(ch, node)
+	}
+
+	return client
+}
+
+// addPeer registers a peer in the Hyperbahn subchannel.
+// TODO(prashant): Start connections to the peers in the background.
+func addPeer(ch *tchannel.Channel, hostPort string) {
+	peers := ch.GetSubChannel(hyperbahnServiceName).Peers()
+	peers.Add(hostPort)
+}
+
+// Register registers the service to Hyperbahn, and returns any errors on initial registration.
+// If the registration succeeds, a goroutine is started to refresh the registration periodically.
+func (c *Client) Register() error {
+	if err := c.sendRegistration(); err != nil {
+		return err
+	}
+	c.opts.Handler.On(Registered)
+	go c.registrationLoop()
+	return nil
+}
+
+// TODO(prashant): Move the JSON call logic to a common tchannel location.
+func makeJSONCall(ctx context.Context, sc *tchannel.SubChannel, operation string, arg interface{}, resp interface{}) error {
+	call, err := sc.BeginCall(ctx, operation, &tchannel.CallOptions{
+		Format: tchannel.JSON,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := tchannel.NewArgWriter(call.Arg2Writer()).Write(nil); err != nil {
+		return err
+	}
+	if err := tchannel.NewArgWriter(call.Arg3Writer()).WriteJSON(arg); err != nil {
+		return err
+	}
+
+	// Call Arg2Reader before application error.
+	var arg2 []byte
+	if err := tchannel.NewArgReader(call.Response().Arg2Reader()).Read(&arg2); err != nil {
+		return err
+	}
+	if call.Response().ApplicationError() {
+		return ErrAppError
+	}
+	if err := tchannel.NewArgReader(call.Response().Arg3Reader()).ReadJSON(resp); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -14,12 +14,25 @@ type Client struct {
 	opts  ClientOptions
 }
 
+// FailStrategy is the strategy to use when registration fails maxRegistrationFailures
+// times consecutively in the background. This is not used if the initial registration fails.
+type FailStrategy int
+
+const (
+	// FailStrategyFatal will call Fatalf on the channel's logger after triggerring handler.OnError.
+	// This is the default strategy.
+	FailStrategyFatal FailStrategy = iota
+	// FailStrategyIgnore will only call handler.OnError, even on fatal errors.
+	FailStrategyIgnore
+)
+
 const hyperbahnServiceName = "hyperbahn"
 
 // ClientOptions are used to configure this Hyperbahn client.
 type ClientOptions struct {
-	Timeout time.Duration
-	Handler Handler
+	Timeout      time.Duration
+	Handler      Handler
+	FailStrategy FailStrategy
 }
 
 // ErrAppError is returned if there was an application error during registration.

--- a/golang/hyperbahn/events.go
+++ b/golang/hyperbahn/events.go
@@ -1,0 +1,31 @@
+package hyperbahn
+
+// Event describes different events that Client can trigger.
+type Event int
+
+const (
+	// UnknownEvent should never be used.
+	UnknownEvent Event = iota
+	// RegistrationAttempt is triggerred when the client tries to register.
+	RegistrationAttempt
+	// Registered is triggerred when the initial registration for a service is successful.
+	Registered
+	// RegistrationRefreshed is triggerred on periodic registrations.
+	RegistrationRefreshed
+)
+
+//go:generate stringer -type=Event
+
+// Handler
+type Handler interface {
+	// On is called when events are triggered.
+	On(event Event)
+	// OnError is called when an error is detected.
+	OnError(err error)
+}
+
+// nullHandler is the default Handler if nil is passed, so handlers can always be called.
+type nullHandler struct{}
+
+func (nullHandler) On(event Event)    {}
+func (nullHandler) OnError(err error) {}

--- a/golang/hyperbahn/events.go
+++ b/golang/hyperbahn/events.go
@@ -6,11 +6,11 @@ type Event int
 const (
 	// UnknownEvent should never be used.
 	UnknownEvent Event = iota
-	// RegistrationAttempt is triggerred when the client tries to register.
+	// RegistrationAttempt is triggered when the client tries to register.
 	RegistrationAttempt
-	// Registered is triggerred when the initial registration for a service is successful.
+	// Registered is triggered when the initial registration for a service is successful.
 	Registered
-	// RegistrationRefreshed is triggerred on periodic registrations.
+	// RegistrationRefreshed is triggered on periodic registrations.
 	RegistrationRefreshed
 )
 

--- a/golang/hyperbahn/registration.go
+++ b/golang/hyperbahn/registration.go
@@ -51,7 +51,7 @@ type adResponse struct {
 }
 
 func (c *Client) sendRegistration() error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), c.opts.Timeout)
 	defer cancel()
 
 	sc := c.tchan.GetSubChannel(hyperbahnServiceName)

--- a/golang/hyperbahn/registration.go
+++ b/golang/hyperbahn/registration.go
@@ -1,0 +1,101 @@
+package hyperbahn
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	// maxRegistrationFailures is the number of consecutive registration failures after
+	// which we give up and trigger an OnError event.
+	maxRegistrationFailures = 5
+	// registrationInterval is the (approximate) time interval between re-registrations.
+	// The interval is fuzzed to fuzzAmount.
+	registrationInterval = 60 * time.Second
+	// registrationRetryInterval is the duration to wait on failed registrations before retrying.
+	registrationRetryInterval = 5 * time.Second
+	// fuzzInterval is used to fuzz the registration interval.
+	fuzzInterval = 10 * time.Second
+)
+
+// timeSleep is a variable for stubbing in unit tests.
+var timeSleep = time.Sleep
+
+// ErrRegistrationFailed is triggerred when registration is failed.
+type ErrRegistrationFailed struct {
+	// WillRetry is set to true if registration will be retried.
+	WillRetry bool
+	// Cause is the underlying error returned from the register call.
+	Cause error
+}
+
+func (e ErrRegistrationFailed) Error() string {
+	return fmt.Sprintf("registration failed, retry: %v, cause: %v", e.WillRetry, e.Cause)
+}
+
+// The following parameters define the request/response for the Hyperbahn 'ad' call.
+type service struct {
+	Name string `json:"serviceName"`
+	Cost int    `json:"cost"`
+}
+
+type adRequest struct {
+	Services []service `json:"services"`
+}
+
+type adResponse struct {
+	ConnectionCount int `json:"connectionCount"`
+}
+
+func (c *Client) sendRegistration() error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	sc := c.tchan.GetSubChannel(hyperbahnServiceName)
+	arg := &adRequest{
+		Services: []service{{
+			Name: c.tchan.PeerInfo().ServiceName,
+			Cost: 0,
+		}},
+	}
+	var resp adResponse
+	c.opts.Handler.On(RegistrationAttempt)
+	if err := makeJSONCall(ctx, sc, "ad", arg, &resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) fuzzedRegistrationInterval() time.Duration {
+	// fuzz is a random value between -fuzzInterval and fuzzInterval
+	fuzz := time.Duration(rand.Intn(int(fuzzInterval)*2)) - fuzzInterval
+	return registrationInterval + fuzz
+}
+
+// registrationLoops re-registers the service approximately every minute (with some fuzzing).
+func (c *Client) registrationLoop() {
+	sleepFor := c.fuzzedRegistrationInterval()
+	consecutiveFailures := 0
+
+	for {
+		timeSleep(sleepFor)
+
+		if err := c.sendRegistration(); err != nil {
+			consecutiveFailures++
+			if consecutiveFailures >= maxRegistrationFailures {
+				c.opts.Handler.OnError(ErrRegistrationFailed{Cause: err, WillRetry: false})
+				return
+			}
+			c.opts.Handler.OnError(ErrRegistrationFailed{Cause: err, WillRetry: true})
+			sleepFor = registrationRetryInterval
+		} else {
+			c.opts.Handler.On(RegistrationRefreshed)
+			sleepFor = c.fuzzedRegistrationInterval()
+			consecutiveFailures = 0
+		}
+	}
+}

--- a/golang/hyperbahn/registration.go
+++ b/golang/hyperbahn/registration.go
@@ -14,9 +14,9 @@ const (
 	maxRegistrationFailures = 5
 	// registrationInterval is the (approximate) time interval between re-registrations.
 	// The interval is fuzzed to fuzzAmount.
-	registrationInterval = 60 * time.Second
+	registrationInterval = 10 * time.Second
 	// registrationRetryInterval is the duration to wait on failed registrations before retrying.
-	registrationRetryInterval = 5 * time.Second
+	registrationRetryInterval = 1 * time.Second
 	// fuzzInterval is used to fuzz the registration interval.
 	fuzzInterval = 10 * time.Second
 )
@@ -88,6 +88,9 @@ func (c *Client) registrationLoop() {
 			consecutiveFailures++
 			if consecutiveFailures >= maxRegistrationFailures {
 				c.opts.Handler.OnError(ErrRegistrationFailed{Cause: err, WillRetry: false})
+				if c.opts.FailStrategy == FailStrategyFatal {
+					c.tchan.Logger().Fatalf("Hyperbahn client registration failed: %v", err)
+				}
 				return
 			}
 			c.opts.Handler.OnError(ErrRegistrationFailed{Cause: err, WillRetry: true})

--- a/golang/hyperbahn/registration.go
+++ b/golang/hyperbahn/registration.go
@@ -24,7 +24,7 @@ const (
 // timeSleep is a variable for stubbing in unit tests.
 var timeSleep = time.Sleep
 
-// ErrRegistrationFailed is triggerred when registration is failed.
+// ErrRegistrationFailed is triggered when registration is failed.
 type ErrRegistrationFailed struct {
 	// WillRetry is set to true if registration will be retried.
 	WillRetry bool

--- a/golang/hyperbahn/registration_test.go
+++ b/golang/hyperbahn/registration_test.go
@@ -1,0 +1,220 @@
+package hyperbahn
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang"
+	"github.com/uber/tchannel/golang/testutils"
+	"golang.org/x/net/context"
+)
+
+func registrationHandler(t *testing.T, f func(req adRequest) (adResponse, error)) tchannel.Handler {
+	return tchannel.HandlerFunc(func(ctx context.Context, call *tchannel.InboundCall) {
+		var arg2 []byte
+		var req adRequest
+		require.NoError(t, tchannel.NewArgReader(call.Arg2Reader()).Read(&arg2))
+		require.NoError(t, tchannel.NewArgReader(call.Arg3Reader()).ReadJSON(&req))
+
+		resp := call.Response()
+		response, err := f(req)
+		if err != nil {
+			resp.SetApplicationError()
+			require.NoError(t, tchannel.NewArgWriter(resp.Arg2Writer()).Write([]byte("")))
+			require.NoError(t, tchannel.NewArgWriter(resp.Arg3Writer()).Write([]byte("false")))
+			return
+		}
+		require.NoError(t, tchannel.NewArgWriter(resp.Arg2Writer()).Write(nil))
+		require.NoError(t, tchannel.NewArgWriter(resp.Arg3Writer()).WriteJSON(response))
+	})
+}
+
+func TestRegistrationFailed(t *testing.T) {
+	withSetup(t, func(serverCh *tchannel.Channel, hostPort string) {
+		clientCh, err := tchannel.NewChannel("my-client", nil)
+		require.NoError(t, err)
+		defer clientCh.Close()
+
+		client := NewClient(clientCh, []string{hostPort}, nil)
+		require.Error(t, client.Register())
+	})
+}
+
+type retryTest struct {
+	// channel used to control the response to an 'ad' call.
+	respCh chan int
+	// req is the adRequest sent to the adHandler.
+	req adRequest
+
+	// sleep stub channels.
+	sleepArgs  <-chan time.Duration
+	sleepBlock chan<- struct{}
+
+	client *Client
+	mock   mock.Mock
+}
+
+func (r *retryTest) On(event Event) {
+	r.mock.Called(event)
+}
+func (r *retryTest) OnError(err error) {
+	r.mock.Called(err)
+}
+
+func (r *retryTest) adHandler(req adRequest) (adResponse, error) {
+	r.req = req
+	v := <-r.respCh
+	if v == 0 {
+		return adResponse{}, errors.New("failed")
+	}
+	return adResponse{v}, nil
+}
+
+func (r *retryTest) setup() {
+	r.respCh = make(chan int, 1)
+	r.sleepArgs, r.sleepBlock = testutils.SleepStub(&timeSleep)
+}
+
+func (r *retryTest) setRegistrationSuccess() {
+	r.respCh <- 1
+}
+
+func (r *retryTest) setRegistrationFailure() {
+	r.respCh <- 0
+}
+
+func runRetryTest(t *testing.T, f func(r *retryTest)) {
+	r := &retryTest{}
+	testutils.SetTimeout(t, time.Second)
+	r.setup()
+	defer testutils.ResetSleepStub(&timeSleep)
+
+	withSetup(t, func(serverCh *tchannel.Channel, hostPort string) {
+		serverCh.Register(registrationHandler(t, r.adHandler), "ad")
+
+		clientCh, err := tchannel.NewChannel("my-client", nil)
+		require.NoError(t, err)
+		defer clientCh.Close()
+
+		r.client = NewClient(clientCh, []string{hostPort}, &ClientOptions{Handler: r})
+		f(r)
+		r.mock.AssertExpectations(t)
+	})
+}
+
+func TestRegistrationSuccess(t *testing.T) {
+	runRetryTest(t, func(r *retryTest) {
+		r.mock.On("On", RegistrationAttempt).Return().
+			Times(1 /* initial */ + 10 /* successful retries */)
+		r.mock.On("On", Registered).Return().Once()
+		r.setRegistrationSuccess()
+		require.NoError(t, r.client.Register())
+
+		// Verify that the arguments passed to 'ad' are correct.
+		expectedRequest := adRequest{[]service{{Name: "my-client", Cost: 0}}}
+		require.Equal(t, expectedRequest, r.req)
+
+		// Verify re-registrations happen after sleeping for ~registrationInterval.
+		r.mock.On("On", RegistrationRefreshed).Return().Times(10)
+		for i := 0; i < 10; i++ {
+			s1 := <-r.sleepArgs
+			require.True(t, s1 >= registrationInterval-fuzzInterval)
+			require.True(t, s1 <= registrationInterval+fuzzInterval)
+			r.sleepBlock <- struct{}{}
+
+			r.setRegistrationSuccess()
+			require.Equal(t, expectedRequest, r.req)
+		}
+
+		// Block till the last registration completes.
+		<-r.sleepArgs
+	})
+}
+
+func TestRetryTemporaryFailure(t *testing.T) {
+	runRetryTest(t, func(r *retryTest) {
+		r.mock.On("On", RegistrationAttempt).Return().
+			Times(1 /* initial */ + 3 /* fail */ + 10 /* successful */)
+		r.mock.On("On", Registered).Return().Once()
+		r.setRegistrationSuccess()
+		require.NoError(t, r.client.Register())
+
+		s1 := <-r.sleepArgs
+		require.True(t, s1 >= registrationInterval-fuzzInterval)
+		require.True(t, s1 <= registrationInterval+fuzzInterval)
+
+		// When registrations fail, it retries after a short connection and triggers OnError.
+		r.mock.On("OnError", ErrRegistrationFailed{true, ErrAppError}).Return(nil).Times(3)
+		for i := 0; i < 3; i++ {
+			r.sleepBlock <- struct{}{}
+			r.setRegistrationFailure()
+
+			s1 := <-r.sleepArgs
+			require.True(t, s1 == registrationRetryInterval)
+		}
+
+		// If the retry suceeds, then it goes back to normal.
+		r.mock.On("On", RegistrationRefreshed).Return().Times(10)
+		// Verify re-registrations continue as usual when it succeeds.
+		for i := 0; i < 10; i++ {
+			r.sleepBlock <- struct{}{}
+			r.setRegistrationSuccess()
+
+			s1 := <-r.sleepArgs
+			require.True(t, s1 >= registrationInterval-fuzzInterval)
+			require.True(t, s1 <= registrationInterval+fuzzInterval)
+		}
+	})
+}
+
+func TestRetryFailure(t *testing.T) {
+	runRetryTest(t, func(r *retryTest) {
+		r.mock.On("On", RegistrationAttempt).Return().
+			Times(1 /* initial */ + maxRegistrationFailures /* fail */)
+		r.mock.On("On", Registered).Return().Once()
+
+		r.setRegistrationSuccess()
+		require.NoError(t, r.client.Register())
+
+		s1 := <-r.sleepArgs
+		require.True(t, s1 >= registrationInterval-fuzzInterval)
+		require.True(t, s1 <= registrationInterval+fuzzInterval)
+
+		// When retries fail maxRegistrationFailures times, we receive:
+		// maxRegistrationFailures - 1 OnError WithRetry=True
+		// 1 OnError WithRetry=False
+		noRetryFail := make(chan struct{})
+		r.mock.On("OnError", ErrRegistrationFailed{true, ErrAppError}).Return(nil).Times(maxRegistrationFailures - 1)
+		r.mock.On("OnError", ErrRegistrationFailed{false, ErrAppError}).Return(nil).Run(func(_ mock.Arguments) {
+			noRetryFail <- struct{}{}
+		}).Once()
+		for i := 0; i < maxRegistrationFailures-1; i++ {
+			r.sleepBlock <- struct{}{}
+			r.setRegistrationFailure()
+
+			s1 := <-r.sleepArgs
+			require.True(t, s1 == registrationRetryInterval)
+		}
+
+		r.sleepBlock <- struct{}{}
+		r.respCh <- 0
+
+		// Wait for the handler to be called and the mock expectation to be recorded.
+		<-noRetryFail
+	})
+}
+
+func withSetup(t *testing.T, f func(ch *tchannel.Channel, hostPort string)) {
+	serverCh, err := tchannel.NewChannel(hyperbahnServiceName, nil)
+	require.NoError(t, err)
+	defer serverCh.Close()
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	go serverCh.Serve(listener)
+
+	f(serverCh, listener.Addr().String())
+}

--- a/golang/hyperbahn/registration_test.go
+++ b/golang/hyperbahn/registration_test.go
@@ -217,7 +217,8 @@ func withSetup(t *testing.T, f func(ch *tchannel.Channel, hostPort string)) {
 	defer serverCh.Close()
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
-	go serverCh.Serve(listener)
+	serverCh.Serve(listener)
 
 	f(serverCh, listener.Addr().String())
+	serverCh.Close()
 }

--- a/golang/hyperbahn/registration_test.go
+++ b/golang/hyperbahn/registration_test.go
@@ -100,7 +100,10 @@ func runRetryTest(t *testing.T, f func(r *retryTest)) {
 		require.NoError(t, err)
 		defer clientCh.Close()
 
-		r.client = NewClient(clientCh, []string{hostPort}, &ClientOptions{Handler: r})
+		r.client = NewClient(clientCh, []string{hostPort}, &ClientOptions{
+			Handler:      r,
+			FailStrategy: FailStrategyIgnore,
+		})
 		f(r)
 		r.mock.AssertExpectations(t)
 	})

--- a/golang/subchannel.go
+++ b/golang/subchannel.go
@@ -29,6 +29,10 @@ func (c *SubChannel) BeginCall(ctx context.Context, operationName string, callOp
 	if callOptions == nil {
 		callOptions = defaultCallOptions
 	}
-
 	return c.peers.Get().BeginCall(ctx, c.serviceName, operationName, callOptions)
+}
+
+// Peers returns the PeerList for this subchannel.
+func (c *SubChannel) Peers() *PeerList {
+	return c.peers
 }

--- a/golang/testutils/sleep.go
+++ b/golang/testutils/sleep.go
@@ -1,0 +1,22 @@
+package testutils
+
+import "time"
+
+// SleepStub returns a function that can be used to stub time.Sleep, as well
+// as two channels to control the sleep stub:
+// .<-chan time.Duration which will contain arguments that the stub was called with.
+// chan<- struct{} that should be written to when you want the Sleep to return.
+func SleepStub(funcVar *func(time.Duration)) (<-chan time.Duration, chan<- struct{}) {
+	args := make(chan time.Duration)
+	block := make(chan struct{})
+	*funcVar = func(t time.Duration) {
+		args <- t
+		<-block
+	}
+	return args, block
+}
+
+// ResetSleepStub resets a Sleep stub.
+func ResetSleepStub(funcVar *func(time.Duration)) {
+	*funcVar = time.Sleep
+}

--- a/golang/testutils/timeout.go
+++ b/golang/testutils/timeout.go
@@ -1,0 +1,17 @@
+package testutils
+
+import (
+	"testing"
+	"time"
+)
+
+// SetTimeout is used to fail tests after a timeout.
+// This should be used in tests which may block forever (e.g. due to channels).
+func SetTimeout(t *testing.T, timeout time.Duration) {
+	go func() {
+		time.Sleep(timeout)
+		t.Logf("Test timed out after " + timeout.String())
+		// Unfortunately, tests cannot be failed from new goroutines, so use a panic.
+		panic("Test timed out after " + timeout.String())
+	}()
+}


### PR DESCRIPTION
This works with a local Hyperbahn server + tcurl. It re-registers periodically in the background.

The tests are a little complicated because the logic happens in the background periodically.