### PR TITLE
go: Remove serviceName from Register call.

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -167,8 +167,8 @@ func (ch *Channel) listen(hostPort string) error {
 }
 
 // Register registers a handler for a service+operation pair
-func (ch *Channel) Register(h Handler, serviceName, operationName string) {
-	ch.handlers.register(h, serviceName, operationName)
+func (ch *Channel) Register(h Handler, operationName string) {
+	ch.handlers.register(h, ch.PeerInfo().ServiceName, operationName)
 }
 
 // PeerInfo returns the current peer info for the channel

--- a/golang/examples/hello/client/main.go
+++ b/golang/examples/hello/client/main.go
@@ -33,7 +33,7 @@ import (
 var log = tchannel.SimpleLogger
 
 var peerAddr = flag.String("peer", "localhost:10500", "Host and port of remote peer")
-var serviceName = flag.String("service", "TestService", "Name of service to invoke")
+var serviceName = flag.String("service", "HelloService", "Name of service to invoke")
 var operationName = flag.String("operation", "echo", "Name of operation to invoke")
 var arg2 = flag.String("arg2", "hello", "Input for arg2.  Curl-style, use @foo.txt to read from foo.txt")
 var arg3 = flag.String("arg3", "world", "Input for arg3.  Curl-style, use @foo.txt to read from foo.txt")
@@ -59,7 +59,7 @@ func writeArgument(writer io.WriteCloser, arg string) error {
 		writer.Write([]byte(arg))
 	}
 
-	return writer.Close()
+	return nil
 }
 
 func main() {

--- a/golang/examples/hello/server/main.go
+++ b/golang/examples/hello/server/main.go
@@ -85,18 +85,18 @@ var bindAddr = flag.String("bind", "127.0.0.1:10500", "host and port on which to
 func main() {
 	flag.Parse()
 
-	ch, err := tchannel.NewChannel("hello-server", &tchannel.ChannelOptions{
+	ch, err := tchannel.NewChannel("HelloService", &tchannel.ChannelOptions{
 		Logger: log,
 	})
 	if err != nil {
 		log.Fatalf("could not create channel %v", err)
 	}
 
-	ch.Register(tchannel.HandlerFunc(echo), "TestService", "echo")
-	ch.Register(tchannel.HandlerFunc(serverBusy), "TestService", "busy")
-	ch.Register(tchannel.HandlerFunc(badRequest), "TestService", "badRequest")
-	ch.Register(tchannel.HandlerFunc(appError), "TestService", "appError")
-	ch.Register(tchannel.HandlerFunc(timeout), "TestService", "timeout")
+	ch.Register(tchannel.HandlerFunc(echo), "echo")
+	ch.Register(tchannel.HandlerFunc(serverBusy), "busy")
+	ch.Register(tchannel.HandlerFunc(badRequest), "badRequest")
+	ch.Register(tchannel.HandlerFunc(appError), "appError")
+	ch.Register(tchannel.HandlerFunc(timeout), "timeout")
 
 	if err := ch.ListenAndServe(*bindAddr); err != nil {
 		log.Fatalf("Could not listen on %s: %v", *bindAddr, err)

--- a/golang/examples/ping/main.go
+++ b/golang/examples/ping/main.go
@@ -48,7 +48,7 @@ func pingHandler(ctx context.Context, call *tchannel.InboundCall) {
 	}
 
 	var inArg3 []byte
-	if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&inArg3); err != nil {
+	if err := tchannel.NewArgReader(call.Arg3Reader()).Read(&inArg3); err != nil {
 		log.Errorf("Could not read body from client: %v", err)
 		return
 	}
@@ -77,13 +77,13 @@ func listenAndHandle(s *tchannel.Channel, hostPort string) {
 
 func main() {
 	// Create a new TChannel for handling requests
-	ch, err := tchannel.NewChannel("ping-server", nil)
+	ch, err := tchannel.NewChannel("PingService", &tchannel.ChannelOptions{Logger: tchannel.SimpleLogger})
 	if err != nil {
 		log.Fatalf("Could not create new channel: %v", err)
 	}
 
 	// Register a handler for the ping message on the PingService
-	ch.Register(tchannel.HandlerFunc(pingHandler), "PingService", "ping")
+	ch.Register(tchannel.HandlerFunc(pingHandler), "ping")
 
 	// Listen for incoming requests
 	go listenAndHandle(ch, "127.0.0.1:10500")

--- a/golang/thrift/server.go
+++ b/golang/thrift/server.go
@@ -45,7 +45,7 @@ func (s *Server) Register(thriftName string, processorInterface reflect.Type, pr
 	handler := &Handler{processor}
 	for i := 0; i < processorInterface.NumMethod(); i++ {
 		methodName := processorInterface.Method(i).Name
-		s.Channel.Register(handler, s.Channel.PeerInfo().ServiceName, thriftName+"::"+methodName)
+		s.Channel.Register(handler, thriftName+"::"+methodName)
 	}
 }
 

--- a/golang/tracing_test.go
+++ b/golang/tracing_test.go
@@ -41,7 +41,7 @@ type TracingResponse struct {
 type Headers map[string]string
 
 func TestTracingPropagates(t *testing.T) {
-	withTestChannel(t, func(ch *Channel, hostPort string) {
+	withTestChannel(t, testServiceName, func(ch *Channel, hostPort string) {
 		srv1 := func(ctx context.Context, incall *InboundCall) {
 			headers := Headers{}
 
@@ -59,7 +59,7 @@ func TestTracingPropagates(t *testing.T) {
 			var childRequest TracingRequest
 			var childResponse TracingResponse
 
-			outcall, err := ch.BeginCall(ctx, hostPort, "TestService", "call2", nil)
+			outcall, err := ch.BeginCall(ctx, hostPort, testServiceName, "call2", nil)
 			if err != nil {
 				incall.Response().SendSystemError(err)
 				return
@@ -110,8 +110,8 @@ func TestTracingPropagates(t *testing.T) {
 			})
 		}
 
-		ch.Register(HandlerFunc(srv1), "TestService", "call1")
-		ch.Register(HandlerFunc(srv2), "TestService", "call2")
+		ch.Register(HandlerFunc(srv1), "call1")
+		ch.Register(HandlerFunc(srv2), "call2")
 
 		ctx, cancel := context.WithTimeout(NewRootContext(context.Background()), 5*time.Second)
 		defer cancel()
@@ -120,7 +120,7 @@ func TestTracingPropagates(t *testing.T) {
 		var request TracingRequest
 		var response TracingResponse
 
-		call, err := ch.BeginCall(ctx, hostPort, "TestService", "call1", nil)
+		call, err := ch.BeginCall(ctx, hostPort, testServiceName, "call1", nil)
 		require.NoError(t, err)
 		require.NoError(t, NewArgWriter(call.Arg2Writer()).WriteJSON(headers))
 		require.NoError(t, NewArgWriter(call.Arg3Writer()).WriteJSON(&request))


### PR DESCRIPTION
The serviceName is already passed in NewChannel, so use the service name
from there.