### PR TITLE
go: Change Serve to not block on processing sockets.

### DIFF
--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -275,9 +275,7 @@ func withTestChannel(t *testing.T, serviceName string, f func(ch *Channel, hostP
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.Nil(t, err)
 
-	go ch.Serve(l)
-
+	ch.Serve(l)
 	f(ch, l.Addr().String())
-
 	ch.Close()
 }

--- a/golang/examples/hello/server/main.go
+++ b/golang/examples/hello/server/main.go
@@ -101,4 +101,7 @@ func main() {
 	if err := ch.ListenAndServe(*bindAddr); err != nil {
 		log.Fatalf("Could not listen on %s: %v", *bindAddr, err)
 	}
+
+	// Serve accepts connections in the background, so block until ctrl-c.
+	select {}
 }

--- a/golang/examples/ping/main.go
+++ b/golang/examples/ping/main.go
@@ -68,8 +68,7 @@ func pingHandler(ctx context.Context, call *tchannel.InboundCall) {
 func listenAndHandle(s *tchannel.Channel, hostPort string) {
 	log.Infof("Service %s", hostPort)
 
-	// If no error is returned, this blocks forever
-
+	// If no error is returned, the listen was successful. Serving happens in the background.
 	if err := s.ListenAndServe(hostPort); err != nil {
 		log.Fatalf("Could not listen on %s: %v", hostPort, err)
 	}
@@ -86,7 +85,7 @@ func main() {
 	ch.Register(tchannel.HandlerFunc(pingHandler), "ping")
 
 	// Listen for incoming requests
-	go listenAndHandle(ch, "127.0.0.1:10500")
+	listenAndHandle(ch, "127.0.0.1:10500")
 
 	// Create a new TChannel for sending requests.
 	client, err := tchannel.NewChannel("ping-client", nil)
@@ -97,9 +96,6 @@ func main() {
 	// Make a call to ourselves, with a timeout of 10s
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-
-	// Wait for the server to start before connecting
-	time.Sleep(time.Millisecond * 100)
 
 	call, err := client.BeginCall(ctx, "127.0.0.1:10500", "PingService", "ping", nil)
 	if err != nil {

--- a/golang/examples/thrift/main.go
+++ b/golang/examples/thrift/main.go
@@ -91,7 +91,8 @@ func setupServer() (net.Listener, error) {
 	sh := &secondHandler{}
 	server.Register("Second", reflect.TypeOf(sh), gen.NewSecondProcessor(&secondHandler{}))
 
-	go tchan.Serve(listener)
+	// Serve will set the local peer info, and start accepting sockets in a separate goroutine.
+	tchan.Serve(listener)
 	return listener, nil
 }
 


### PR DESCRIPTION
Serve currently does 2 things:
- Set LocalPeerInfo
- Handle sockets.

Hyperbahn client creation needs the LocalPeerInfo set, but there's no nice way to detect when this step is done. To clean this up, Serve will now return after setting LocalPeerInfo. The actual handling of sockets happens in a goroutine. Tests+examples are updated to not call Serve using a goroutine as it's no longer required.