### PR TITLE
go: Thrift + Hyperbahn compatibility fixes

### DIFF
--- a/golang/thrift/input_protocol.go
+++ b/golang/thrift/input_protocol.go
@@ -22,6 +22,7 @@ package thrift
 
 import (
 	"io"
+	"io/ioutil"
 	"strings"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -55,6 +56,8 @@ func (p *inProtocol) ReadMessageBegin() (string, thrift.TMessageType, int32, err
 	if err != nil {
 		return "", 0, 0, err
 	}
+	// TODO(prashant): Read application headers out of arg2.
+	io.Copy(ioutil.Discard, reader)
 	if err := reader.Close(); err != nil {
 		return "", 0, 0, err
 	}
@@ -85,6 +88,8 @@ func (p *inProtocol) WriteMessageBegin(name string, typeID thrift.TMessageType, 
 	if err != nil {
 		return err
 	}
+	// TODO(prashant): Support application headers.
+	writer.Write([]byte{0, 0})
 	if err := writer.Close(); err != nil {
 		return err
 	}

--- a/golang/thrift/output_protocol.go
+++ b/golang/thrift/output_protocol.go
@@ -22,6 +22,7 @@ package thrift
 import (
 	"errors"
 	"io"
+	"io/ioutil"
 
 	"golang.org/x/net/context"
 
@@ -29,6 +30,8 @@ import (
 	tchannel "github.com/uber/tchannel/golang"
 )
 
+// ErrApplication is returned on application errors.
+// TODO(prashant): Remove this and return the real error?
 var ErrApplication = errors.New("application error")
 
 // TChanOutboundOptions are parameters passed to the underlying tchannel when making requests.
@@ -97,6 +100,8 @@ func (p *outProtocol) WriteMessageBegin(name string, _ thrift.TMessageType, seqI
 	if err != nil {
 		return err
 	}
+	// TODO(prashant): Support application headers.
+	writer.Write([]byte{0, 0})
 	if err := writer.Close(); err != nil {
 		return err
 	}
@@ -125,6 +130,8 @@ func (p *outProtocol) ReadMessageBegin() (string, thrift.TMessageType, int32, er
 	if err != nil {
 		return "", 0, 0, err
 	}
+	// TODO(prashant): Read application headers out of arg2.
+	io.Copy(ioutil.Discard, reader)
 	if err := reader.Close(); err != nil {
 		return "", 0, 0, err
 	}

--- a/golang/thrift/server.go
+++ b/golang/thrift/server.go
@@ -58,5 +58,8 @@ type Handler struct {
 // a tchannel protocol.
 func (h *Handler) Handle(ctx context.Context, call *tchannel.InboundCall) {
 	protocol := NewTChannelInbound(call)
-	h.processor.Process(protocol, protocol)
+	_, err := h.processor.Process(protocol, protocol)
+	if err != nil {
+		// TODO(prashant): Separate application errors from tchannel errors and log tchannel errors.
+	}
 }


### PR DESCRIPTION
Add TODOs for Thrift handling:
 - application headers
 - inbound call handling errors
When making outbound calls, don't require Dst to be set.