### PR TITLE
fix the double-success bug of outbound.calls.success

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -116,6 +116,7 @@ function TChannel(options) {
     self.statsd = self.options.statsd;
     if (self.statsd) {
         self.channelStatsd = new TChannelStatsd(self, self.statsd);
+        self.options.statsd = null;
     }
 
     self.requestDefaults = extend({


### PR DESCRIPTION
@Raynos 