### PR TITLE
statsd: do not add peer for per-attempt latency

### DIFF
--- a/node/lib/statsd.js
+++ b/node/lib/statsd.js
@@ -96,7 +96,6 @@ function getKey(common, stat) {
                 clean(stat.tags.service, 'service') + '.' +
                 clean(stat.tags['target-service'], 'target-service') + '.' +
                 clean(stat.tags['target-endpoint'], 'endpoint') + '.' +
-                clean(stat.tags.peer) + '.' +
                 stat.tags['retry-count'];
 
         // inbound

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -96,7 +96,7 @@ allocCluster.test('emits stats on call success', {
             time: null
         }, {
             type: 'ms',
-            name: 'tchannel.outbound.calls.per-attempt-latency.inPipe.reservoir.Reservoir--get.' + server.hostPort.replace(':', '-') + '.0',
+            name: 'tchannel.outbound.calls.per-attempt-latency.inPipe.reservoir.Reservoir--get.0',
             value: null,
             delta: null,
             time: 500
@@ -186,7 +186,7 @@ allocCluster.test('emits stats on call failure', {
             time: null
         }, {
             type: 'ms',
-            name: 'tchannel.outbound.calls.per-attempt-latency.inPipe.reservoir.Reservoir--get.' + server.hostPort.replace(':', '-') + '.0',
+            name: 'tchannel.outbound.calls.per-attempt-latency.inPipe.reservoir.Reservoir--get.0',
             value: null,
             delta: null,
             time: 500


### PR DESCRIPTION
We currently send the peer to statsd. This has a huge
cardinality of O(n^2) because ringpop is fully connected.

This makes graphite painfully slow.

r: @shannili @jcorbin