### PR TITLE
Add error listeners to connection objects

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -248,6 +248,7 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
     conn.spanEvent.on(function handleSpanFromConn(span) {
         self.tracer.report(span);
     });
+    conn.errorEvent.on(onConnectionError);
 
     if (self.serverConnections[socketRemoteAddr]) {
         var oldConn = self.serverConnections[socketRemoteAddr];
@@ -263,6 +264,17 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
     self.connectionEvent.emit(self, conn);
 
     function onSocketClose() {
+        delete self.serverConnections[socketRemoteAddr];
+    }
+
+    function onConnectionError(err) {
+        self.logger.error('Got a connection error', {
+            err: err,
+            direction: conn.direction,
+            remoteName: conn.remoteName,
+            socketRemoteAddr: conn.socketRemoteAddr
+        });
+
         delete self.serverConnections[socketRemoteAddr];
     }
 };

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -152,7 +152,10 @@ TChannelConnectionBase.prototype.buildResponse = function buildResponse(req, opt
     var done = false;
     if (req.res && req.res.state !== States.Initial) {
         self.errorEvent.emit(self, errors.ResponseAlreadyStarted({
-            state: req.res.state
+            state: req.res.state,
+            reason: 'buildResponse called twice',
+            codeString: req.res.codeString,
+            responseMessage: req.res.message
         }));
     }
     options = extend({

--- a/node/peer.js
+++ b/node/peer.js
@@ -246,8 +246,14 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
     conn.closeEvent.on(onConnectionClose);
     return conn;
 
-    function onConnectionError(/* err */) {
-        // TODO: log?
+    function onConnectionError(err) {
+        self.logger.error('Got a connection error', {
+            err: err,
+            direction: conn.direction,
+            remoteName: conn.remoteName,
+            socketRemoteAddr: conn.socketRemoteAddr
+        });
+
         self.removeConnection(conn);
     }
 

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -94,6 +94,23 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
         });
         return;
     }
+
+    // It is possible that the inreq gets reaped with a timeout
+    // It is also possible that the out request gets repead with a timeout
+    // Both the in & out req try to create an outgoing response
+    if (self.inreq.res && self.inreq.res.codeString === 'Timeout') {
+        self.channel.logger.info('relay: in request already timed out', {
+            codeString: self.inreq.res.codeString,
+            responseMessage: self.inreq.res.message,
+            serviceName: self.outreq.serviceName,
+            arg1: String(self.outreq.arg1),
+            outRemoteAddr: self.outreq.remoteAddr,
+            inRemoteAddr: self.inreq.remoteAddr,
+            inSocketRemoteAddr: self.inreq.connection.socketRemoteAddr
+        });
+        return;
+    }
+
     self.outres = self.buildRes(options);
     self.outres.finishEvent.on(emitFinish);
     return self.outres;


### PR DESCRIPTION
I've added an error listener for incoming connections; it
previously went directly to uncaught

 - Add error listener for incoming
 - Add error log for outgoing connection errors
 - Fix relay_request timeout race condition.

r: @jcorbin @rf