### PR TITLE
support TChannelThrift#request helper

### DIFF
--- a/node/as/README.md
+++ b/node/as/README.md
@@ -13,7 +13,9 @@ var server = TChannel({
     serviceName: 'server'
 });
 var client = TChannel();
-var tchannelJSON = TChannelJSON();
+var tchannelJSON = TChannelJSON({
+    channel: client
+});
 
 var context = {};
 
@@ -29,10 +31,10 @@ function echo(context, req, head, body, callback) {
 server.listen(4040, '127.0.0.1', onListening);
 
 function onListening() {
-    tchannelJSON.send(client.request({
+    tchannelJSON.request({
         serviceName: 'server',
         host: '127.0.0.1:4040'
-    }), 'echo', {
+    }).send('echo', {
         head: 'object'
     }, {
         body: 'object'
@@ -70,6 +72,14 @@ type TChannelJSONHandler<T> : (
 ) => void
 
 type TChannelJSON : {
+    request: (reqOptions: Object) => {
+        send: (
+            endpoint: String,
+            head: JSONSerializable,
+            body: JSONSerializable,
+            callback: Callback<Error, JSONResponse>
+        ) => void
+    },
     send: (
         req: TChannelRequest,
         endpoint: String,
@@ -88,15 +98,16 @@ type TChannelJSON : {
 tchannel/as/json : ({
     logger?: Object,
     strictMode?: Boolean,
-    logParseFailures?: Boolean
+    logParseFailures?: Boolean,
+    channel?: TChannel
 }) => TChannelJSON
 ```
 
 ### `var tchannelJSON = TChannelJSON(opts)`
 
 `TChannelJSON` returns a `tchannelJSON` interface with a 
-`.send()` and `.register()` method used to send call requests
-and register call request handlers
+`.request()`, `.send()` and `.register()` method used to 
+send call requests and register call request handlers
 
 It can be passed options.
 
@@ -111,6 +122,20 @@ It can be passed options.
     it is set to true we will log parse failures to the logger using
     `logger.warn()`. If you do not want these log statements you
     can set the option to `false`
+ - `opts.channel` The channel used to make requests on. This
+    option is required if you want to use the `.request()` method
+
+### `tchannelJSON.request(reqOpts).send(endpoint, head, body, cb)`
+
+You **MUST** pass in a `channel` option to `TChannelJSON()`
+to use this method
+
+The `.request()` method can be used to make an outgoing JSON
+request.
+
+It returns an object with a `.send()` method used to send requests
+
+This is just sugar for `tchannelJSON.send(...)`
 
 ### `tchannelJSON.send(req, endpoint, head, body, callback)`
 

--- a/node/as/json.js
+++ b/node/as/json.js
@@ -47,7 +47,40 @@ function TChannelJSON(options) {
     var logParseFailures = options && options.logParseFailures;
     self.logParseFailures = typeof logParseFailures === 'boolean' ?
         logParseFailures : true;
+
+    // only used in request()
+    self.channel = options.channel;
 }
+
+function TChannelJSONRequest(options) {
+    var self = this;
+
+    self.channel = options.channel;
+    self.reqOptions = options.reqOptions;
+    self.tchannelJSON = options.tchannelJSON;
+}
+
+TChannelJSONRequest.prototype.send =
+function send(endpoint, head, body, callback) {
+    var self = this;
+
+    var outreq = self.channel.request(self.reqOptions);
+    self.tchannelJSON.send(outreq, endpoint, head, body, callback);
+};
+
+TChannelJSON.prototype.request = function request(reqOptions) {
+    var self = this;
+
+    assert(self.channel, 'channel is required for json.request()');
+
+    var req = new TChannelJSONRequest({
+        channel: self.channel,
+        reqOptions: reqOptions,
+        tchannelJSON: self
+    });
+
+    return req;
+};
 
 /*eslint max-params: [2, 5]*/
 TChannelJSON.prototype.send = function send(

--- a/node/as/thrift.js
+++ b/node/as/thrift.js
@@ -52,7 +52,40 @@ function TChannelAsThrift(opts) {
     var logParseFailures = opts && opts.logParseFailures;
     self.logParseFailures = typeof logParseFailures === 'boolean' ?
         logParseFailures : true;
+
+    // only used in request()
+    self.channel = opts.channel;
 }
+
+function TChannelThriftRequest(options) {
+    var self = this;
+
+    self.channel = options.channel;
+    self.reqOptions = options.reqOptions;
+    self.tchannelThrift = options.tchannelThrift;
+}
+
+TChannelThriftRequest.prototype.send =
+function send(endpoint, head, body, callback) {
+    var self = this;
+
+    var outreq = self.channel.request(self.reqOptions);
+    self.tchannelThrift.send(outreq, endpoint, head, body, callback);
+};
+
+TChannelAsThrift.prototype.request = function request(reqOptions) {
+    var self = this;
+
+    assert(self.channel, 'channel is required for thrift.request()');
+
+    var req = new TChannelThriftRequest({
+        channel: self.channel,
+        reqOptions: reqOptions,
+        tchannelThrift: self
+    });
+
+    return req;
+};
 
 TChannelAsThrift.prototype.register =
 function register(channel, name, opts, handle) {

--- a/node/test/as-json.js
+++ b/node/test/as-json.js
@@ -69,6 +69,27 @@ allocCluster.test('getting an ok response', {
     });
 });
 
+allocCluster.test('sending using request()', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var tchannelJSON = makeTChannelJSONServer(cluster, {
+        okResponse: true
+    });
+
+    tchannelJSON.request({
+        serviceName: 'server',
+        hasNoParent: true,
+        timeout: 1500
+    }).send('echo', null, 'body', function onResponse(err, resp) {
+        assert.ifError(err);
+
+        assert.ok(resp.ok);
+        assert.equal(resp.body.body, 'body');
+
+        assert.end();
+    });
+});
+
 allocCluster.test('getting a not ok response', {
     numPeers: 2
 }, function t(cluster, assert) {
@@ -236,7 +257,8 @@ function makeTChannelJSONServer(cluster, opts) {
             networkFailureHandler;
 
     var tchannelJSON = cluster.channels[0].TChannelAsJSON({
-        logParseFailures: false
+        logParseFailures: false,
+        channel: cluster.channels[1].subChannels.server
     });
     tchannelJSON.register(server, 'echo', options, fn);
 


### PR DESCRIPTION
This makes it easier to making outgoing requests as you only
need the TChannelAsX instance to making outgoing reqs.

See #656

r: @jcorbin @Willyham @rf