### PR TITLE
Add more context to out request errors

### DIFF
--- a/node/errors.js
+++ b/node/errors.js
@@ -259,9 +259,11 @@ module.exports.NullKeyError = TypedError({
 module.exports.ParentRequired = TypedError({
     type: 'tchannel.tracer.parent-required',
     message: 'parent not specified for outgoing call req.\n' +
-        'Expected either a parent or hasNoParent.\n',
+        'Expected either a parent or hasNoParent.\n' +
+        'For the call to {serviceName}.\n',
     parentSpan: null,
-    hasNoParent: null
+    hasNoParent: null,
+    serviceName: null
 });
 
 module.exports.ReconstructedError = TypedError({

--- a/node/package.json
+++ b/node/package.json
@@ -42,7 +42,7 @@
     "debug-logtron": "4.2.0",
     "duplexer": "^0.1.1",
     "faucet": "0.0.1",
-    "format-stack": "4.0.0",
+    "format-stack": "4.1.1",
     "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
     "ldjson-stream": "^1.2.1",

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -54,3 +54,4 @@ require('./ping.js');
 require('./permissions_cache.js');
 require('./connection-stats.js');
 require('./connection-with-statsd.js');
+require('./request-error-context.js');

--- a/node/test/request-error-context.js
+++ b/node/test/request-error-context.js
@@ -1,0 +1,138 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var allocCluster = require('./lib/alloc-cluster.js');
+
+allocCluster.test('request() without hasNoParent', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var one = remoteService(cluster.channels[0]);
+    var two = cluster.channels[1];
+
+    var subTwo = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+
+    subTwo.waitForIdentified({
+        host: one.hostPort
+    }, function onIdentified(err) {
+        assert.ifError(err);
+
+        var error = getError(function throwIt() {
+            subTwo.request({
+                serviceName: 'server'
+            }).send('echo', 'a', 'b');
+        });
+        assert.ok(error.message.indexOf('For the call to server') >= 0);
+
+        assert.end();
+    });
+});
+
+allocCluster.test('request() without as header', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var one = remoteService(cluster.channels[0]);
+    var two = cluster.channels[1];
+
+    var subTwo = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+
+    subTwo.waitForIdentified({
+        host: one.hostPort
+    }, function onIdentified(err) {
+        assert.ifError(err);
+
+        var error = getError(function throwIt() {
+            subTwo.request({
+                serviceName: 'server',
+                hasNoParent: true
+            }).send('echo', 'a', 'b', noop);
+        });
+        assert.ok(error.message.indexOf(
+            'Got request for server echo without as header'
+        ) >= 0);
+
+        assert.end();
+    });
+});
+
+allocCluster.test('request() without cn header', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    var one = remoteService(cluster.channels[0]);
+    var two = cluster.channels[1];
+
+    var subTwo = two.makeSubChannel({
+        serviceName: 'server',
+        peers: [one.hostPort]
+    });
+
+    subTwo.waitForIdentified({
+        host: one.hostPort
+    }, function onIdentified(err) {
+        assert.ifError(err);
+
+        var error = getError(function throwIt() {
+            subTwo.request({
+                serviceName: 'server',
+                hasNoParent: true,
+                headers: {
+                    as: 'raw'
+                }
+            }).send('echo', 'a', 'b', noop);
+        });
+        assert.ok(error.message.indexOf(
+            'Got request for server echo without cn header'
+        ) >= 0);
+
+        assert.end();
+    });
+});
+
+function noop() {}
+
+function getError(fn) {
+    var error = null;
+
+    try {
+        fn();
+    } catch (err) {
+        error = err;
+    }
+
+    return error;
+}
+
+function remoteService(chan) {
+    chan.makeSubChannel({
+        serviceName: 'server'
+    }).register('echo', function echo(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
+    });
+
+    return chan;
+}

--- a/node/trace/agent.js
+++ b/node/trace/agent.js
@@ -97,7 +97,8 @@ Agent.prototype.setupNewSpan = function setupNewSpan(options) {
     if (options.outgoing && !parentSpan && !options.hasNoParent) {
         throw errors.ParentRequired({
             parentSpan: parentSpan,
-            hasNoParent: options.hasNoParent
+            hasNoParent: options.hasNoParent,
+            serviceName: options.serviceName
         });
     }
 

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -475,10 +475,13 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
     var reqBody = new v2.CallRequest(
         flags, req.ttl, req.tracing, req.serviceName, req.headers,
         req.checksum.type, args);
+    var message;
 
     if (self.requireAs) {
-        assert(req.headers && req.headers.as,
-            'Expected the "as" transport header to be set for request');
+        message = 'Expected the "as" transport header to be set for request\n' +
+            'Got request for ' + req.serviceName + ' ' + String(args[0]) + ' without as header';
+
+        assert(req.headers && req.headers.as, message);
     } else if (!req.headers || !req.headers.as) {
         self.logger.error('Expected "as" header to be set for request', {
             arg1: String(args[0]),
@@ -490,8 +493,10 @@ TChannelV2Handler.prototype.sendCallRequestFrame = function sendCallRequestFrame
     }
 
     if (self.requireCn) {
-        assert(req.headers && req.headers.cn,
-            'Expected the "cn" transport header to be set for request');
+        message = 'Expected the "cn" transport header to be set for request\n' +
+            'Got request for ' + req.serviceName + ' ' + String(args[0]) + ' without cn header';
+
+        assert(req.headers && req.headers.cn, message);
     } else if (!req.headers || !req.headers.cn) {
         self.logger.error('Expected "cn" header to be set for request', {
             arg1: String(args[0]),


### PR DESCRIPTION
This adds more context to the following errors

 - Not setting `parent` or `hasNoParent`
 - Not setting "as" header
 - Not setting "cn" header

These are currently difficult to debug because we have the
init blocking logic and the actual callsite to `request()`
will not be in the error stack.

By adding the serviceName / arg1 it will be easier to upgrade
older services to newer versions of tchannel

r: @jcorbin @shannili