### PR TITLE
switching from int to int64

### DIFF
--- a/golang/hyperbahn/registration.go
+++ b/golang/hyperbahn/registration.go
@@ -72,7 +72,7 @@ func (c *Client) sendRegistration() error {
 
 func (c *Client) fuzzedRegistrationInterval() time.Duration {
 	// fuzz is a random value between -fuzzInterval and fuzzInterval
-	fuzz := time.Duration(rand.Intn(int(fuzzInterval)*2)) - fuzzInterval
+	fuzz := time.Duration(rand.Int63n(int64(fuzzInterval)*2)) - fuzzInterval
 	return registrationInterval + fuzz
 }
 


### PR DESCRIPTION
This should fix this error I was getting:

src/github.com/uber/tchannel/golang/hyperbahn/registration.go:75: constant 10000000000 overflows int
src/github.com/uber/tchannel/golang/hyperbahn/registration.go:75: constant 20000000000 overflows int