### PR TITLE
Limit max call frame overhead.

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -307,7 +307,7 @@ The meaning of the three args depends on the systems on each end. The format of
 arg1, arg2, and arg3 is unspecified at the transport level. These are opaque
 binary blobs as far as tchannel is concerned.
 
-The size of `arg1` is at most 16 kilobytes.
+The size of `arg1` is at most 16KiB.
 
 Future versions will likely allow callers to specify specific service instances
 on which to run this request, or a mechanism to route a certain percentage of
@@ -330,7 +330,7 @@ Very similar to call req (type 0x03), differing only in:
 
 All common fields have identical definition to call req, see its section above for detail.  It is not necessary for arg1 to have the same value between the call req and the call res; by convention, existing implementations leave arg1 at zero length for call res messages.
 
-The size of `arg1` is at most 16 kilobytes.
+The size of `arg1` is at most 16KiB.
 
 Headers described below in the "Transport Headers" section.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -307,6 +307,8 @@ The meaning of the three args depends on the systems on each end. The format of
 arg1, arg2, and arg3 is unspecified at the transport level. These are opaque
 binary blobs as far as tchannel is concerned.
 
+The size of `arg1` is at most 16 kilobytes.
+
 Future versions will likely allow callers to specify specific service instances
 on which to run this request, or a mechanism to route a certain percentage of
 all traffic to a subset of instances for canary analysis.
@@ -327,6 +329,8 @@ Very similar to call req (type 0x03), differing only in:
 - no `service` field
 
 All common fields have identical definition to call req, see its section above for detail.  It is not necessary for arg1 to have the same value between the call req and the call res; by convention, existing implementations leave arg1 at zero length for call res messages.
+
+The size of `arg1` is at most 16 kilobytes.
 
 Headers described below in the "Transport Headers" section.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -533,6 +533,7 @@ Header keys may not be 0 length (should result in a parse error), but header
 values may be 0 length.
 
 Header keys have a maximum length of 16 bytes;
+The total number of transport headers allowed is 128
 
 Schema:
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -528,6 +528,8 @@ Duplicate header keys are not allowed and should result in a parse error.
 Header keys may not be 0 length (should result in a parse error), but header
 values may be 0 length.
 
+Header keys have a maximum length of 16 bytes;
+
 Schema:
 ```
 nh:1 (hk~1 hv~1){nh}

--- a/node/connection.js
+++ b/node/connection.js
@@ -90,10 +90,7 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
     self.socket.on('error', onSocketError);
 
     function onSocketChunk(chunk) {
-        self.mach.handleChunk(chunk, chunkHandled);
-    }
-
-    function chunkHandled(err) {
+        var err = self.mach.handleChunk(chunk);
         if (err) {
             self.resetAll(errors.TChannelReadProtocolError(err, {
                 remoteName: self.remoteName,

--- a/node/errors.js
+++ b/node/errors.js
@@ -461,7 +461,7 @@ module.exports.TopLevelRequestError = TypedError({
 });
 
 module.exports.TransportHeaderTooLong = TypedError({
-    type: 'tchannel.tranport-header-too-long',
+    type: 'tchannel.transport-header-too-long',
     message: 'The header: {headerName} exceeds 16 bytes',
     headerName: null,
     offset: null,
@@ -528,7 +528,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.handler.incoming-req-as-header-required':
         case 'tchannel.handler.incoming-req-cn-header-required':
         case 'tchannel.init.ephemeral-init-response':
-        case 'tchannel.tranport-header-too-long':
+        case 'tchannel.transport-header-too-long':
         case 'tchannel.protocol.too-many-headers':
             return 'ProtocolError';
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -459,6 +459,14 @@ module.exports.TopLevelRequestError = TypedError({
         'Must use a sub channel directly.'
 });
 
+module.exports.TransportHeaderTooLong = TypedError({
+    type: 'tchannel.tranport-header-too-long',
+    message: 'The header: {headerName} exceeds 16 bytes',
+    headerName: null,
+    offset: null,
+    endOffset: null
+});
+
 module.exports.UnimplementedMethod = TypedError({
     message: 'Unimplemented {className}#{methodName}',
     type: 'tchannel.unimplemented-method',
@@ -519,6 +527,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.handler.incoming-req-as-header-required':
         case 'tchannel.handler.incoming-req-cn-header-required':
         case 'tchannel.init.ephemeral-init-response':
+        case 'tchannel.tranport-header-too-long':
         case 'tchannel.protocol.failed':
             return 'ProtocolError';
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -447,6 +447,14 @@ module.exports.ThriftHeadStringifyError = WrappedError({
     direction: null
 });
 
+module.exports.TooManyHeaders = TypedError({
+    type: 'tchannel.protocol.too-many-headers',
+    message: 'Got too many headers. Expected at most 128 but got: {count}',
+    count: null,
+    offset: null,
+    endOffset: null
+});
+
 module.exports.TopLevelRegisterError = TypedError({
     type: 'tchannel.top-level-register',
     message: 'Cannot register endpoints points on top-level channel.\n' +
@@ -529,6 +537,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.init.ephemeral-init-response':
         case 'tchannel.tranport-header-too-long':
         case 'tchannel.protocol.failed':
+        case 'tchannel.protocol.too-many-headers':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/errors.js
+++ b/node/errors.js
@@ -372,6 +372,13 @@ module.exports.TChannelLocalResetError = WrappedError({
     message: 'tchannel: {causeMessage}'
 });
 
+module.exports.TChannelProtocolError = WrappedError({
+    type: 'tchannel.protocol.failed',
+    message: 'tchannel failure: {origMessage}',
+    remoteName: null,
+    localName: null
+});
+
 module.exports.TChannelReadProtocolError = WrappedError({
     type: 'tchannel.protocol.read-failed',
     message: 'tchannel read failure: {origMessage}',
@@ -512,6 +519,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.handler.incoming-req-as-header-required':
         case 'tchannel.handler.incoming-req-cn-header-required':
         case 'tchannel.init.ephemeral-init-response':
+        case 'tchannel.protocol.failed':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/errors.js
+++ b/node/errors.js
@@ -372,13 +372,6 @@ module.exports.TChannelLocalResetError = WrappedError({
     message: 'tchannel: {causeMessage}'
 });
 
-module.exports.TChannelProtocolError = WrappedError({
-    type: 'tchannel.protocol.failed',
-    message: 'tchannel failure: {origMessage}',
-    remoteName: null,
-    localName: null
-});
-
 module.exports.TChannelReadProtocolError = WrappedError({
     type: 'tchannel.protocol.read-failed',
     message: 'tchannel read failure: {origMessage}',
@@ -536,7 +529,6 @@ module.exports.classify = function classify(err) {
         case 'tchannel.handler.incoming-req-cn-header-required':
         case 'tchannel.init.ephemeral-init-response':
         case 'tchannel.tranport-header-too-long':
-        case 'tchannel.protocol.failed':
         case 'tchannel.protocol.too-many-headers':
             return 'ProtocolError';
 

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -55,3 +55,5 @@ require('./permissions_cache.js');
 require('./connection-stats.js');
 require('./connection-with-statsd.js');
 require('./request-error-context.js');
+require('./max-call-overhead.js');
+

--- a/node/test/max-call-overhead.js
+++ b/node/test/max-call-overhead.js
@@ -148,10 +148,11 @@ allocCluster.test('request() with too many headers', {
 
     function onResponse(err, resp, arg2, arg3) {
         assert.ok(err);
-        assert.ok(err.isErrorFrame);
-        assert.equal(err.codeName, 'ProtocolError');
+        assert.equal(err.fullType, 
+            'tchannel.connection.reset~!~tchannel.protocol.write-failed~!~tchannel.protocol.too-many-headers'
+        );
         assert.equal(err.message,
-            'tchannel read failure: Got too many headers. Expected at most 128 but got: 130'
+            'tchannel: tchannel write failure: Got too many headers. Expected at most 128 but got: 130'
         );
 
         assert.equal(null, resp);
@@ -159,7 +160,7 @@ allocCluster.test('request() with too many headers', {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
         assert.equal(logLine.levelName, 'info');
-        assert.equal(logLine.meta.error.type, 'tchannel.protocol.read-failed');
+        assert.equal(logLine.meta.error.type, 'tchannel.protocol.write-failed');
 
         assert.end();
     }

--- a/node/test/max-call-overhead.js
+++ b/node/test/max-call-overhead.js
@@ -53,7 +53,7 @@ allocCluster.test('request() with large header key', {
     function onResponse(err, resp, arg2, arg3) {
         assert.ok(err);
         assert.equal(err.fullType,
-            'tchannel.connection.reset~!~tchannel.protocol.write-failed~!~tchannel.tranport-header-too-long'
+            'tchannel.connection.reset~!~tchannel.protocol.write-failed~!~tchannel.transport-header-too-long'
         );
         assert.equal(err.message,
             'tchannel: tchannel write failure: The header: someReallyLargeHeaderKey exceeds 16 bytes'

--- a/node/test/max-call-overhead.js
+++ b/node/test/max-call-overhead.js
@@ -52,10 +52,11 @@ allocCluster.test('request() with large header key', {
 
     function onResponse(err, resp, arg2, arg3) {
         assert.ok(err);
-        assert.ok(err.isErrorFrame);
-        assert.equal(err.codeName, 'ProtocolError');
+        assert.equal(err.fullType,
+            'tchannel.connection.reset~!~tchannel.protocol.write-failed~!~tchannel.tranport-header-too-long'
+        );
         assert.equal(err.message,
-            'tchannel read failure: The header: someReallyLargeHeaderKey exceeds 16 bytes'
+            'tchannel: tchannel write failure: The header: someReallyLargeHeaderKey exceeds 16 bytes'
         );
 
         assert.equal(null, resp);
@@ -63,7 +64,8 @@ allocCluster.test('request() with large header key', {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
         assert.equal(logLine.levelName, 'info');
-        assert.equal(logLine.meta.error.type, 'tchannel.protocol.read-failed');
+        assert.equal(logLine.meta.error.type, 'tchannel.protocol.write-failed');
+
 
         assert.end();
     }

--- a/node/test/max-call-overhead.js
+++ b/node/test/max-call-overhead.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var allocCluster = require('./lib/alloc-cluster.js');
+
+allocCluster.test('request() with large header key', {
+    numPeers: 2
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('info', 'resetting connection');
+
+    var one = remoteService(cluster.channels[0]);
+    var two = cluster.channels[1];
+
+    var subTwo = two.makeSubChannel({
+        serviceName: 'server'
+    });
+
+    subTwo.waitForIdentified({
+        host: one.hostPort
+    }, function onIdentified(err) {
+        assert.ifError(err);
+
+        subTwo.request({
+            serviceName: 'server',
+            hasNoParent: true,
+            headers: {
+                'as': 'raw',
+                'cn': 'wat',
+                'someReallyLargeHeaderKey': 'a'
+            }
+        }).send('echo', 'a', 'b', onResponse);
+    });
+
+    function onResponse(err, resp, arg2, arg3) {
+        assert.ok(err);
+        assert.ok(err.isErrorFrame);
+        assert.equal(err.codeName, 'ProtocolError');
+        assert.equal(err.message,
+            'tchannel read failure: The header: someReallyLargeHeaderKey exceeds 16 bytes'
+        );
+
+        assert.equal(null, resp);
+
+        assert.equal(cluster.logger.items().length, 1);
+        var logLine = cluster.logger.items()[0];
+        assert.equal(logLine.levelName, 'info');
+        assert.equal(logLine.meta.error.type, 'tchannel.protocol.read-failed');
+
+        assert.end();
+    }
+});
+
+function remoteService(chan) {
+    chan.makeSubChannel({
+        serviceName: 'server'
+    }).register('echo', function echo(req, res, arg2, arg3) {
+        res.headers.as = 'raw';
+        res.sendOk(arg2, arg3);
+    });
+
+    return chan;
+}

--- a/node/v2/frame.js
+++ b/node/v2/frame.js
@@ -98,7 +98,11 @@ function readFrameFrom(buffer, offset) {
     offset += 8;
 
     res = BodyType.RW.readFrom(buffer, offset);
-    if (res.err) return res;
+    if (res.err) {
+        // TODO: wrapped?
+        res.err.frameId = frame.id;
+        return res;
+    }
     offset = res.offset;
     frame.body = res.value;
 

--- a/node/v2/frame.js
+++ b/node/v2/frame.js
@@ -23,6 +23,8 @@
 var bufrw = require('bufrw');
 var errors = require('../errors');
 
+var Types = require('./index.js').Types;
+
 /* jshint maxparams:5 */
 
 module.exports = Frame;
@@ -99,8 +101,12 @@ function readFrameFrom(buffer, offset) {
 
     res = BodyType.RW.readFrom(buffer, offset);
     if (res.err) {
-        // TODO: wrapped?
-        res.err.frameId = frame.id;
+        if (frame.type === Types.CallRequest ||
+            frame.type === Types.CallRequestCont
+        ) {
+            // TODO: wrapped?
+            res.err.frameId = frame.id;
+        }
         return res;
     }
     offset = res.offset;

--- a/node/v2/header.js
+++ b/node/v2/header.js
@@ -76,6 +76,15 @@ HeaderRW.prototype.writeInto = function writeInto(headers, buffer, offset) {
         offset = res.offset;
 
         var key = keys[i];
+        // TODO: Check that its' 16 bytes
+        if (self.enforceKeyLength && key.length > 16) {
+            return bufrw.WriteResult.error(errors.TransportHeaderTooLong({
+                offset: offset,
+                endOffset: res.offset,
+                headerName: key
+            }), offset);
+        }
+
         res = self.keyrw.writeInto(key, buffer, offset);
         if (res.err) return res;
         offset = res.offset;

--- a/node/v2/header.js
+++ b/node/v2/header.js
@@ -110,6 +110,13 @@ HeaderRW.prototype.readFrom = function readFrom(buffer, offset) {
                 offset: offset,
                 endOffset: res.offset
             }), offset, headers);
+        // TODO: check key is 16 bytes; not 16 characters
+        } else if (key.length > 16) {
+            return bufrw.ReadResult.error(errors.TransportHeaderTooLong({
+                offset: offset,
+                endOffset: res.offset,
+                headerName: key
+            }), offset, headers);
         }
         offset = res.offset;
 

--- a/node/v2/header.js
+++ b/node/v2/header.js
@@ -71,6 +71,14 @@ HeaderRW.prototype.writeInto = function writeInto(headers, buffer, offset) {
 
     res = self.countrw.writeInto(keys.length, buffer, offset);
 
+    if (self.enforceHeaderCount && keys.length > 128) {
+        return bufrw.WriteResult.error(errors.TooManyHeaders({
+            offset: offset,
+            endOffset: res.offset,
+            count: keys.length
+        }), offset);
+    }
+
     for (var i = 0; i < keys.length; i++) {
         if (res.err) return res;
         offset = res.offset;

--- a/node/v2/header.js
+++ b/node/v2/header.js
@@ -98,6 +98,14 @@ HeaderRW.prototype.readFrom = function readFrom(buffer, offset) {
     offset = res.offset;
     n = res.value;
 
+    if (n > 128) {
+        return bufrw.ReadResult.error(errors.TooManyHeaders({
+            offset: offset,
+            endOffset: res.offset,
+            count: n
+        }), offset, headers);
+    }
+
     for (var i = 0; i < n; i++) {
         start = offset;
 


### PR DESCRIPTION
This PR implements #486

 - Max arg1 is 16kb (already in master)
 - Max transport header count is 128 (this PR)
 - Max transport header key length is 16 (this PR)

In this PR we also improve how we handle protocol read and write
failures as seen in the new `sendProtocolError()` method in
connection.js

r: @jcorbin @rf