### PR TITLE
Enforce that the ttl is non-zero

### DIFF
--- a/node/errors.js
+++ b/node/errors.js
@@ -172,6 +172,12 @@ module.exports.InvalidJSONBody = TypedError({
     body: null
 });
 
+module.exports.InvalidTTL = TypedError({
+    type: 'tchannel.protocol.invalid-ttl',
+    message: 'Got an invalid ttl. Expected positive ttl but got {ttl}',
+    ttl: null
+});
+
 module.exports.JSONBodyParserError = WrappedError({
     type: 'tchannel-json-handler.parse-error.body-failed',
     message: 'Could not parse body (arg3) argument.\n' +
@@ -530,6 +536,7 @@ module.exports.classify = function classify(err) {
         case 'tchannel.init.ephemeral-init-response':
         case 'tchannel.transport-header-too-long':
         case 'tchannel.protocol.too-many-headers':
+        case 'tchannel.protocol.invalid-ttl':
             return 'ProtocolError';
 
         case 'tchannel.connection.close':

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -148,6 +148,12 @@ function writeCallReqInto(body, buffer, offset) {
     // flags:1 -- filled in later after argsrw
     offset += bufrw.UInt8.width;
 
+    if (body.ttl === 0) {
+        return bufrw.WriteResult.error(errors.InvalidTTL({
+            ttl: body.ttl
+        }), offset);
+    }
+
     // ttl:4
     res = bufrw.UInt32BE.writeInto(body.ttl, buffer, offset);
     if (res.err) return res;

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -21,6 +21,8 @@
 'use strict';
 
 var bufrw = require('bufrw');
+
+var errors = require('../errors');
 var ArgsRW = require('./args');
 var Checksum = require('./checksum');
 var header = require('./header');
@@ -104,6 +106,13 @@ function readCallReqFrom(buffer, offset) {
     // ttl:4
     res = bufrw.UInt32BE.readFrom(buffer, offset);
     if (res.err) return res;
+
+    if (res.value === 0) {
+        return bufrw.ReadResult.error(errors.InvalidTTL({
+            ttl: res.value
+        }), offset, body);
+    }
+
     offset = res.offset;
     body.ttl = res.value;
 

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -107,7 +107,7 @@ function readCallReqFrom(buffer, offset) {
     res = bufrw.UInt32BE.readFrom(buffer, offset);
     if (res.err) return res;
 
-    if (res.value === 0) {
+    if (res.value <= 0) {
         return bufrw.ReadResult.error(errors.InvalidTTL({
             ttl: res.value
         }), offset, body);
@@ -148,7 +148,7 @@ function writeCallReqInto(body, buffer, offset) {
     // flags:1 -- filled in later after argsrw
     offset += bufrw.UInt8.width;
 
-    if (body.ttl === 0) {
+    if (body.ttl <= 0) {
         return bufrw.WriteResult.error(errors.InvalidTTL({
             ttl: body.ttl
         }), offset);


### PR DESCRIPTION
In the protocol doc the ttl must be non-zero.

cc @abhinav @prashant I hope your python/go implementation
also enforces this.

r: @jcorbin @rf @shannili