### PR TITLE
Refactor hyperbahn test to use cluster.dummies

### DIFF
--- a/node/test/hyperbahn/hyperbahn-down.js
+++ b/node/test/hyperbahn/hyperbahn-down.js
@@ -34,14 +34,14 @@ function runTests(HyperbahnCluster) {
     HyperbahnCluster.test('register with hyperbahn down', {
         size: 2
     }, function t(cluster, assert) {
-        var bob = cluster.remotes.bob;
+        var bob = cluster.dummies[0];
 
         var client = HyperbahnClient({
             serviceName: 'A',
             callerName: 'A-client',
             // 5001 & 5002 should be DEAD ports
             hostPortList: ['127.0.0.1:5001', '127.0.0.1:5002'],
-            tchannel: bob.channel,
+            tchannel: bob,
             hardFail: true,
             registrationTimeout: 200,
             logger: DebugLogtron('hyperbahnClient')
@@ -81,14 +81,14 @@ function runTests(HyperbahnCluster) {
     HyperbahnCluster.test('register with hyperbahn down + no hardFail', {
         size: 5
     }, function t(cluster, assert) {
-        var bob = cluster.remotes.bob;
+        var bob = cluster.dummies[0];
 
         var client = HyperbahnClient({
             serviceName: 'A',
             callerName: 'A-client',
             // 5001 & 5002 should be DEAD ports
             hostPortList: ['127.0.0.1:5001', '127.0.0.1:5002'],
-            tchannel: bob.channel,
+            tchannel: bob,
             logger: DebugLogtron('hyperbahnClient')
         });
 

--- a/node/test/hyperbahn/hyperbahn-times-out.js
+++ b/node/test/hyperbahn/hyperbahn-times-out.js
@@ -34,16 +34,16 @@ function runTests(HyperbahnCluster) {
     HyperbahnCluster.test('register with timed out hyperbahn', {
         size: 2
     }, function t(cluster, assert) {
-        var bob = cluster.remotes.bob;
-        var steve = cluster.remotes.steve;
+        var bob = cluster.dummies[0];
+        var steve = cluster.dummies[1];
 
-        MockBahn(steve.channel);
+        MockBahn(steve);
 
         var client = HyperbahnClient({
             serviceName: 'A',
             callerName: 'A-client',
-            hostPortList: [steve.channel.hostPort],
-            tchannel: bob.channel,
+            hostPortList: [steve.hostPort],
+            tchannel: bob,
             hardFail: true,
             registrationTimeout: 100,
             logger: DebugLogtron('hyperbahnClient')
@@ -80,16 +80,16 @@ function runTests(HyperbahnCluster) {
     HyperbahnCluster.test('register with timed out hyperbahn + no hardFail', {
         size: 2
     }, function t(cluster, assert) {
-        var bob = cluster.remotes.bob;
-        var steve = cluster.remotes.steve;
+        var bob = cluster.dummies[0];
+        var steve = cluster.dummies[0];
 
-        MockBahn(steve.channel);
+        MockBahn(steve);
 
         var client = HyperbahnClient({
             serviceName: 'A',
             callerName: 'A-client',
-            hostPortList: [steve.channel.hostPort],
-            tchannel: bob.channel,
+            hostPortList: [steve.hostPort],
+            tchannel: bob,
             logger: DebugLogtron('hyperbahnClient')
         });
 

--- a/node/test/lib/hyperbahn-cluster.js
+++ b/node/test/lib/hyperbahn-cluster.js
@@ -23,6 +23,7 @@
 var tape = require('tape');
 var tapeCluster = require('tape-cluster');
 
+var allocCluster = require('./alloc-cluster.js');
 var RelayNetwork = require('./relay_network.js');
 
 HyperbahnCluster.test = tapeCluster(tape, HyperbahnCluster);
@@ -66,6 +67,8 @@ function HyperbahnCluster(options) {
     self.apps = null;
     self.logger = null;
     self.hostPortList = null;
+    self.dummyCluster = null;
+    self.dummies = null;
 }
 
 HyperbahnCluster.prototype.bootstrap = function bootstrap(cb) {
@@ -100,6 +103,15 @@ HyperbahnCluster.prototype.bootstrap = function bootstrap(cb) {
             hostPortList: self.hostPortList
         });
 
+        allocCluster({
+            numPeers: 2
+        }).ready(onDummyCluster);
+    }
+
+    function onDummyCluster(cluster) {
+        self.dummyCluster = cluster;
+        self.dummies = cluster.channels;
+
         cb();
     }
 };
@@ -112,6 +124,7 @@ function checkExitPeers(assert, options) {
 HyperbahnCluster.prototype.close = function close(cb) {
     var self = this;
 
+    self.dummyCluster.destroy();
     self.relayNetwork.close(cb);
 };
 


### PR DESCRIPTION
To get the tests to be correct they should use dummies instead of
remotes. Using remotes is incorrect because remotes come
pre-advertised with hyperbahn.

This fixes the tests upstream in autobahn.

cc: @shannili @rf