### PR TITLE
hyperbahn: rename register() to advertise()

### DIFF
--- a/node/bin/adhoc.js
+++ b/node/bin/adhoc.js
@@ -30,7 +30,7 @@ var os = require('os');
 var console = require('console');
 
 var TChannel = require('../');
-var AutobahnClient = require('../hyperbahn/');
+var HyperbahnClient = require('../hyperbahn/');
 
 if (require.main === module) {
     main();
@@ -61,7 +61,7 @@ function main() {
         res.sendOk(arg2, arg3);
     });
 
-    var autobahnClient = new AutobahnClient({
+    var hyperbahnClient = new HyperbahnClient({
         tchannel: tchannel,
         serviceName: serviceName,
         hostPortList: [
@@ -69,7 +69,7 @@ function main() {
         ],
         forwardRetries: 5,
         checkForwardListInterval: 60000,
-        registrationTimeout: 5000,
+        advertisementTimeout: 5000,
         logger: logtron
     });
 
@@ -81,16 +81,16 @@ function main() {
         }
 
         console.log('listening', tchannel.address());
-        console.log('registering', autobahnHost, autobahnPort);
+        console.log('advertising', autobahnHost, autobahnPort);
 
-        autobahnClient.on('registered', function onRegister(err2) {
+        hyperbahnClient.on('advertised', function onAdvertised(err2) {
             if (err2) {
                 throw err2;
             }
 
-            console.log('registered');
+            console.log('advertised');
         });
-        autobahnClient.register();
+        hyperbahnClient.advertise();
     });
 }
 

--- a/node/docs/hyperbahn.md
+++ b/node/docs/hyperbahn.md
@@ -4,12 +4,12 @@ To be able to make requests to a hyperbahn router it's recommended
 that you use the hyperbahn client.
 
 The hyperbahn client makes it easy to make requests to any service
-that hyperbahn knows about and makes it easy to register your
+that hyperbahn knows about and makes it easy to advertise your
 service with hyperbahn.
 
 The hyperbahn client has a few important methods
 
- - `hyperbahnClient.register();`
+ - `hyperbahnClient.advertise();`
  - `hyperbahnClient.getClientChannel({ serviceName: '...' });`
 
 ## Stability: stable
@@ -31,15 +31,15 @@ var hyperbahnClient = HyperbahnClient({
     hardFail: true
 });
 
-hyperbahnClient.register();
-hyperbahnClient.once('registered', onRegistered);
+hyperbahnClient.advertise();
+hyperbahnClient.once('advertised', onAdvertised);
 
-function onRegistered() {
+function onAdvertised() {
     /* hooray! */
 }
 ```
 
-The hyperbahnClient is used to `register()` with the hyperbahn
+The hyperbahnClient is used to `advertise()` with the hyperbahn
 router which will advertise your serviceName.
 
 It's also used to get a subchannel when making out going requests
@@ -70,21 +70,21 @@ router.
 ### `options.logger`
 
 A logger that hyperbahn client uses to log information about
-registrations
+advertisements
 
 ### `options.statsd`
 
 A statsd client hyperbahn client uses to count information about
-registration.
+advertisement.
 
 Counters:
 
- - `hyperbahn-client.{serviceName}.registration.success`
- - `hyperbahn-client.{serviceName}.registration.failure`
+ - `hyperbahn-client.{serviceName}.advertisement.success`
+ - `hyperbahn-client.{serviceName}.advertisement.failure`
 
-### `options.registrationTimeout`
+### `options.advertisementTimeout`
 
-If set; hyperbahn client registration will timeout.
+If set; hyperbahn client advertisemnt will timeout.
 
 This defaults to 5000 if `hardFail` is `true` and defaults to
 `Infinity` (no timeout) if `hardFail` is `false`.
@@ -92,21 +92,21 @@ This defaults to 5000 if `hardFail` is `true` and defaults to
 ### `options.hardFail`
 
 The hyperbahnClient by default runs in a hybrid mode. This means
-that `hardFail` is set to false and it will register() forever.
+that `hardFail` is set to false and it will advertise() forever.
 
 This is recommended for services that are both a HTTP server and
 a tchannel server.
 
 Any services that a pure tchannel server should set `hardFail`
-to true. This means that if hyperbahnClient cannot register
-after the `registrationTimeout` (default 5 seconds) it will
+to true. This means that if hyperbahnClient cannot advertise
+after the `advertisementTimeout` (default 5 seconds) it will
 emit an error event.
 
-Not being able to register with hyperbahn is a fatal exception.
+Not being able to advertise with hyperbahn is a fatal exception.
 
-### `hyperbahnClient.register()`
+### `hyperbahnClient.advertise()`
 
-You must call `register()` to start the registration loop with
+You must call `advertise()` to start the advertisement loop with
 the hyperbahn router. 
 
 ### `hyperbahnClient.getClientChannel(opts)`
@@ -120,16 +120,16 @@ This sub channel is pre-configured with the correct peers list
 and callerName so you can make requests to it without configuring
 it.
 
-### `hyperbahnClient.once('registered', listener)`
+### `hyperbahnClient.once('advertised', listener)`
 
 This event gets emitted every time hyperbahn router confirms your
-registration. This means the hyperbahn router will start routing
+advertisement. This means the hyperbahn router will start routing
 requests to you.
 
-Hyperbahn client will register every minute with the hyperbahn
+Hyperbahn client will advertise every minute with the hyperbahn
 routers. This event should get emitted every minute.
 
 ### `hyperbahnClient.once('error', listener)`
 
 This event gets emitted if there's a failure with hyperbahn
-registration. This only gets emitted if `hardFail` is `true`.
+advertisement. This only gets emitted if `hardFail` is `true`.

--- a/node/test/hyperbahn/advertise.js
+++ b/node/test/hyperbahn/advertise.js
@@ -31,7 +31,7 @@ if (require.main === module) {
 }
 
 function runTests(HyperbahnCluster) {
-    HyperbahnCluster.test('can register', {
+    HyperbahnCluster.test('can advertise', {
         size: 5
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
@@ -44,11 +44,11 @@ function runTests(HyperbahnCluster) {
             logger: DebugLogtron('hyperbahnClient')
         });
 
-        client.once('registered', onResponse);
-        client.register();
+        client.once('advertised', onResponse);
+        client.advertise();
 
         function onResponse() {
-            var result = client.latestRegistrationResult;
+            var result = client.latestAdvertisementResult;
 
             cluster.checkExitPeers(assert, {
                 serviceName: 'hello-bob',
@@ -60,7 +60,7 @@ function runTests(HyperbahnCluster) {
             // Because of duplicates in a size 5 cluster we know
             // that we have at most 5 kValues
             assert.ok(result.body.connectionCount <= 5,
-                'expect to have at most 5 register results');
+                'expect to have at most 5 advertise results');
 
             client.destroy();
             assert.end();

--- a/node/test/hyperbahn/forward-retry.js
+++ b/node/test/hyperbahn/forward-retry.js
@@ -32,7 +32,7 @@ if (require.main === module) {
 }
 
 function runTests(HyperbahnCluster) {
-    HyperbahnCluster.test('register and forward', {
+    HyperbahnCluster.test('advertise and forward', {
         size: 10
     }, function t(cluster, assert) {
         var steve = cluster.remotes.steve;
@@ -50,13 +50,13 @@ function runTests(HyperbahnCluster) {
             logger: steve.logger
         });
 
-        steveHyperbahnClient.once('registered', onSteveRegistered);
-        steveHyperbahnClient.register(onSteveRegistered);
+        steveHyperbahnClient.once('advertised', onSteveAdvertised);
+        steveHyperbahnClient.advertise(onSteveAdvertised);
 
         // TODO: intermittent flap about can't request on destroyed channel
         // TODO: flappy leaked handle hang
 
-        function onSteveRegistered() {
+        function onSteveAdvertised() {
             var egressNodes = cluster.apps[0].exitsFor(steve.serviceName);
 
             cluster.apps.forEach(function destroyBobEgressNodes(node) {

--- a/node/test/hyperbahn/forward.js
+++ b/node/test/hyperbahn/forward.js
@@ -32,7 +32,7 @@ if (require.main === module) {
 }
 
 function runTests(HyperbahnCluster) {
-    HyperbahnCluster.test('register and forward', {
+    HyperbahnCluster.test('advertise and forward', {
         size: 5
     }, function t(cluster, assert) {
         var steve = cluster.remotes.steve;
@@ -49,11 +49,11 @@ function runTests(HyperbahnCluster) {
             tchannel: steve.channel,
             logger: DebugLogtron('hyperbahnClient')
         });
-        steveHyperbahnClient.once('registered', onRegistered);
-        steveHyperbahnClient.register();
+        steveHyperbahnClient.once('advertised', onAdvertised);
+        steveHyperbahnClient.advertise();
 
-        function onRegistered() {
-            var result = steveHyperbahnClient.latestRegistrationResult;
+        function onAdvertised() {
+            var result = steveHyperbahnClient.latestAdvertisementResult;
 
             assert.equal(result.head, null, 'header is null');
             assert.ok(result.body, 'got a body');

--- a/node/test/hyperbahn/index.js
+++ b/node/test/hyperbahn/index.js
@@ -32,9 +32,9 @@ if (require.main === module) {
 
 function runTests(HyperbahnCluster) {
     require('./forward.js')(HyperbahnCluster);
-    require('./register.js')(HyperbahnCluster);
+    require('./advertise.js')(HyperbahnCluster);
     require('./forward-retry.js')(HyperbahnCluster);
-    
+
     require('./hyperbahn-down.js')(HyperbahnCluster);
     require('./hyperbahn-times-out.js')(HyperbahnCluster);
 }

--- a/node/test/hyperbahn/todo.js
+++ b/node/test/hyperbahn/todo.js
@@ -22,18 +22,18 @@
 
 var test = require('tape');
 
-test('register with hyperbahn + error frame');
-test('register with hyperbahn + error frame + no hardFail');
+test('advertise with hyperbahn + error frame');
+test('advertise with hyperbahn + error frame + no hardFail');
 
-// TODO test registationTimeout semantics
-test('register with invalid serviceName');
-test('register with invalid host port');
-test('register with unexpected hyperbahn failure');
-test('register with invalid serviceName + no hardFail');
-test('register with invalid host port + no hardFail');
-test('register with unexpected hyperbahn failure + no hardFail');
+// TODO test advertisementTimeout semantics
+test('advertise with invalid serviceName');
+test('advertise with invalid host port');
+test('advertise with unexpected hyperbahn failure');
+test('advertise with invalid serviceName + no hardFail');
+test('advertise with invalid host port + no hardFail');
+test('advertise with unexpected hyperbahn failure + no hardFail');
 
-test('register in a loop');
+test('advertise in a loop');
 
-test('calling register() after destroy');
+test('calling advertise() after destroy');
 test('calling getClientSubChannel() after destroy');


### PR DESCRIPTION
Whilst writing the tchannel guide I realized we used the word
`register()` twice. Once to mean registrying an endpoint with
a tchannel server and once to mean registrying a server with
hyperbahn.

Internally hyperbahn calls the "ad" method short for advertise.
We've already renamed hyperbahns advertisement protocol to be
around the word "advertise".

This PR changes the hyperbahnClient interface to have an
`advertise()` method. This means that when we document `register()`
it is no longer ambigious.

I've left the old `register()` method in place for 100% back-compat.

r: @shannili @rf @jcorbin

cc: @prashant @abhinav It would be good to rename python and go. It
looks like python already calls this advertise() but it looks like
go uses the word register() twice.