### PR TITLE
go: Fix for partial reads causing connection corruption

### DIFF
--- a/golang/frame.go
+++ b/golang/frame.go
@@ -125,9 +125,8 @@ func (f *Frame) ReadFrom(r io.Reader) error {
 	if err := f.Header.read(&rbuf); err != nil {
 		return err
 	}
-
 	if f.Header.PayloadSize() > 0 {
-		if _, err := r.Read(f.SizedPayload()); err != nil {
+		if _, err := io.ReadFull(r, f.SizedPayload()); err != nil {
 			return err
 		}
 	}

--- a/golang/typed/buffer.go
+++ b/golang/typed/buffer.go
@@ -148,7 +148,7 @@ func (r *ReadBuffer) FillFrom(ior io.Reader, n int) (int, error) {
 
 	r.err = nil
 	r.remaining = r.buffer[:n]
-	return ior.Read(r.remaining)
+	return io.ReadFull(ior, r.remaining)
 }
 
 // Wrap initializes the buffer to read from the given byte slice


### PR DESCRIPTION
When stress testing, I noticed some data corruption. After some
debugging, I found out that we weren't reading some packets
completely and the remaining part of the packet was being read
as the frame header.

Read may not fill the whole buffer, and so we were only partially
reading buffers and then the rest of the buffer was read as a separate
packet.