### PR TITLE
go: Use CRC32C by default as it's hardware accelerated

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -105,7 +105,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 	}
 	ch.mutable.subChannels = make(map[string]*SubChannel)
 	ch.peers = newPeerList(ch)
-	ch.connectionOptions.ChecksumType = ChecksumTypeCrc32
+	ch.connectionOptions.ChecksumType = ChecksumTypeCrc32C
 	return ch, nil
 }
 


### PR DESCRIPTION
Found stress tests were running slow, turns out CRC32C is hardware accelerated and way faster. This is the default in Node as well.