### PR TITLE
Go: Better support for frame pooling

### DIFF
--- a/golang/connection.go
+++ b/golang/connection.go
@@ -547,10 +547,11 @@ func (c *Connection) readFrames() {
 // writes them to the connection.
 func (c *Connection) writeFrames() {
 	for f := range c.sendCh {
-		defer c.framePool.Release(f)
-
 		c.log.Debugf("Writing frame %s", f.Header)
-		if err := f.WriteTo(c.conn); err != nil {
+
+		err := f.WriteTo(c.conn)
+		c.framePool.Release(f)
+		if err != nil {
 			c.connectionError(err)
 			return
 		}

--- a/golang/fragmentation_test.go
+++ b/golang/fragmentation_test.go
@@ -392,6 +392,7 @@ func (ch fragmentChannel) flushFragment(fragment *writableFragment) error {
 func (ch fragmentChannel) recvNextFragment(initial bool) (*readableFragment, error) {
 	rbuf := typed.NewReadBuffer(<-ch)
 	fragment := new(readableFragment)
+	fragment.done = func() {}
 	fragment.flags = rbuf.ReadByte()
 	fragment.checksumType = ChecksumType(rbuf.ReadByte())
 	fragment.checksum = rbuf.ReadBytes(fragment.checksumType.ChecksumSize())

--- a/golang/frame_pool.go
+++ b/golang/frame_pool.go
@@ -30,7 +30,7 @@ type FramePool interface {
 }
 
 // The DefaultFramePool uses the heap as the pool
-var DefaultFramePool = defaultFramePool{}
+var DefaultFramePool FramePool = defaultFramePool{}
 
 type defaultFramePool struct{}
 

--- a/golang/frame_pool_test.go
+++ b/golang/frame_pool_test.go
@@ -1,0 +1,186 @@
+package tchannel
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang/testutils"
+	"golang.org/x/net/context"
+)
+
+type swapper struct {
+	t *testing.T
+}
+
+func (s *swapper) OnError(ctx context.Context, err error) {
+	s.t.Errorf("OnError: %v", err)
+}
+
+func (*swapper) Handle(ctx context.Context, args *rawArgs) (*rawRes, error) {
+	return &rawRes{
+		Arg2: args.Arg3,
+		Arg3: args.Arg2,
+	}, nil
+}
+
+type recordingFramePool struct {
+	mut         sync.Mutex
+	allocations map[*Frame]string
+	badRelease  []string
+}
+
+func newRecordingFramePool() *recordingFramePool {
+	return &recordingFramePool{
+		allocations: make(map[*Frame]string),
+	}
+}
+
+func recordStack() string {
+	buf := make([]byte, 4096)
+	runtime.Stack(buf, false)
+	return string(buf)
+}
+
+func (p *recordingFramePool) Get() *Frame {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	frame := NewFrame(MaxFramePayloadSize)
+	p.allocations[frame] = recordStack()
+	return frame
+}
+
+func (p *recordingFramePool) Release(f *Frame) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	if _, ok := p.allocations[f]; !ok {
+		p.badRelease = append(p.badRelease, "bad Release at "+recordStack())
+		return
+	}
+
+	delete(p.allocations, f)
+}
+
+func (p *recordingFramePool) CheckEmpty() (int, string) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	var badCalls []string
+	badCalls = append(badCalls, p.badRelease...)
+	for f, s := range p.allocations {
+		badCalls = append(badCalls, fmt.Sprintf("frame %v not released, get from: %v", f.Header, s))
+	}
+	return len(p.allocations), strings.Join(badCalls, "\n")
+}
+
+func TestFramesReleased(t *testing.T) {
+	testutils.SetTimeout(t, time.Second*100)
+
+	pool := newRecordingFramePool()
+	origPool := DefaultFramePool
+	DefaultFramePool = pool
+	defer func() { DefaultFramePool = origPool }()
+
+	const (
+		// requestsPerGoroutine = 10
+		// numGoroutines        = 10
+		// maxRandArg           = 512 * 1024
+		requestsPerGoroutine = 1
+		numGoroutines        = 1
+		maxRandArg           = 500 * 1024
+	)
+
+	// Generate random bytes used to create arguments.
+	randBytes := make([]byte, maxRandArg)
+	for i := 0; i < len(randBytes); i += 8 {
+		n := rand.Int63()
+		for j := 0; j < 8; j++ {
+			randBytes[i+j] = byte(n & 0xff)
+			n = n << 1
+		}
+	}
+
+	require.NoError(t, withServerChannel(&testChannelOpts{
+		ServiceName: "swap-server",
+		DefaultConnectionOptions: ConnectionOptions{
+			FramePool: pool,
+		},
+	}, func(serverCh *Channel, hostPort string) {
+		serverCh.Register(AsRaw(&swapper{t}), "swap")
+
+		clientCh, err := NewChannel("swap-client", nil)
+		require.NoError(t, err)
+		defer clientCh.Close()
+
+		generateArg := func(n int) []byte {
+			from := rand.Intn(maxRandArg - n)
+			return randBytes[from : from+n]
+		}
+
+		var wg sync.WaitGroup
+		worker := func() {
+			for i := 0; i < requestsPerGoroutine; i++ {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+				defer cancel()
+
+				require.NoError(t, clientCh.Ping(ctx, hostPort))
+
+				argSize := rand.Intn(maxRandArg)
+				arg2 := generateArg(argSize)
+				arg3 := generateArg(argSize)
+				resArg2, resArg3, _, err := sendRecv(ctx, clientCh, hostPort, "swap-server", "swap", arg2, arg3)
+				if !assert.NoError(t, err, "error during sendRecv") {
+					continue
+				}
+
+				// We expect the arguments to be swapped.
+				if bytes.Compare(arg3, resArg2) != 0 {
+					t.Errorf("returned arg2 does not match expected:\n  got %v\n want %v", resArg2, arg3)
+				}
+				if bytes.Compare(arg2, resArg3) != 0 {
+					t.Errorf("returned arg2 does not match expected:\n  got %v\n want %v", resArg3, arg2)
+				}
+			}
+			wg.Done()
+		}
+
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go worker()
+		}
+
+		wg.Wait()
+	}))
+
+	if unreleasedCount, isEmpty := pool.CheckEmpty(); isEmpty != "" || unreleasedCount > 0 {
+		t.Errorf("Frame pool has %v unreleased frames, errors:\n%v", unreleasedCount, isEmpty)
+	}
+}

--- a/golang/mex.go
+++ b/golang/mex.go
@@ -44,11 +44,12 @@ const (
 // frames from the peer, and a Context that can controls when the exchange has
 // timed out or been cancelled.
 type messageExchange struct {
-	recvCh  chan *Frame
-	ctx     context.Context
-	msgID   uint32
-	msgType messageType
-	mexset  *messageExchangeSet
+	recvCh    chan *Frame
+	ctx       context.Context
+	msgID     uint32
+	msgType   messageType
+	mexset    *messageExchangeSet
+	framePool FramePool
 }
 
 // forwardPeerFrame forwards a frame from a peer to the message exchange, where
@@ -126,16 +127,17 @@ type messageExchangeSet struct {
 }
 
 // newExchange creates and adds a new message exchange to this set
-func (mexset *messageExchangeSet) newExchange(ctx context.Context,
+func (mexset *messageExchangeSet) newExchange(ctx context.Context, framePool FramePool,
 	msgType messageType, msgID uint32, bufferSize int) (*messageExchange, error) {
 	mexset.log.Debugf("Creating new %s message exchange for [%v:%d]", mexset.name, msgType, msgID)
 
 	mex := &messageExchange{
-		msgType: msgType,
-		msgID:   msgID,
-		ctx:     ctx,
-		recvCh:  make(chan *Frame, bufferSize),
-		mexset:  mexset,
+		msgType:   msgType,
+		msgID:     msgID,
+		ctx:       ctx,
+		recvCh:    make(chan *Frame, bufferSize),
+		mexset:    mexset,
+		framePool: framePool,
 	}
 
 	mexset.mut.Lock()

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -57,7 +57,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	}
 
 	requestID := c.NextMessageID()
-	mex, err := c.outbound.newExchange(ctx, messageTypeCallReq, requestID, 512)
+	mex, err := c.outbound.newExchange(ctx, c.framePool, messageTypeCallReq, requestID, 512)
 	if err != nil {
 		return nil, err
 	}
@@ -113,18 +113,22 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 
 // handleCallRes handles an incoming call req message, forwarding the
 // frame to the response channel waiting for it
-func (c *Connection) handleCallRes(frame *Frame) {
+func (c *Connection) handleCallRes(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
 		c.outbound.removeExchange(frame.Header.ID)
+		return true
 	}
+	return false
 }
 
 // handleCallResContinue handles an incoming call res continue message,
 // forwarding the frame to the response channel waiting for it
-func (c *Connection) handleCallResContinue(frame *Frame) {
+func (c *Connection) handleCallResContinue(frame *Frame) bool {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
 		c.outbound.removeExchange(frame.Header.ID)
+		return true
 	}
+	return false
 }
 
 // An OutboundCall is an active call to a remote peer.  A client makes a call


### PR DESCRIPTION
- Add a test to track frames and make sure none are leaked.
- Release frames in the successful case

Most of the change is for incoming call req fragments. We need to keep frames till the contents from that frame are read. We have to plumb framepool through mex so fragmenting reader / reqResReader can free frames once they complete parsing all contents in the frame.

Fixes #275 for the successful cases.