### PR TITLE
bring back the examples

### DIFF
--- a/python/examples/options.py
+++ b/python/examples/options.py
@@ -21,7 +21,7 @@
 import argparse
 
 
-def get_args():
+def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--port",
@@ -31,9 +31,9 @@ def get_args():
         "--host",
         dest="host", default="localhost"
     )
-    parser.add_argument(
-        "--file",
-        dest="filename"
-    )
+    return parser
 
+
+def get_args():
+    parser = get_parser()
     return parser.parse_args()

--- a/python/examples/stream_client.py
+++ b/python/examples/stream_client.py
@@ -24,7 +24,7 @@ import sys
 import tornado
 import tornado.ioloop
 
-from options import get_args
+from options import get_parser
 from tchannel.tornado import TChannel
 from tchannel.tornado.stream import InMemStream
 from tchannel.tornado.stream import PipeStream
@@ -33,7 +33,10 @@ from tchannel.tornado.util import print_arg
 
 @tornado.gen.coroutine
 def send_stream(arg1, arg2, arg3, host):
-    tchannel = TChannel()
+    tchannel = TChannel(
+        name='stream-client',
+    )
+
     response = yield tchannel.request(host).send(
         arg1,
         arg2,
@@ -45,13 +48,19 @@ def send_stream(arg1, arg2, arg3, host):
 
 
 def main():
-    args = get_args()
+    parser = get_parser()
+    parser.add_argument(
+        "--file",
+        dest="filename"
+    )
+    args = parser.parse_args()
 
     arg1 = InMemStream("echo")
     arg2 = InMemStream()
     arg3 = InMemStream()
 
     ioloop = tornado.ioloop.IOLoop.current()
+
     if args.filename == "stdin":
         arg3 = PipeStream(sys.stdin.fileno())
         send_stream(arg1, arg2, arg3, args.host)
@@ -62,6 +71,7 @@ def main():
         ioloop.run_sync(lambda: send_stream(arg1, arg2, arg3, args.host))
     else:
         raise NotImplementedError()
+
 
 if __name__ == '__main__':  # pragma: no cover
     main()

--- a/python/examples/tchannel_server.py
+++ b/python/examples/tchannel_server.py
@@ -30,7 +30,11 @@ from tchannel.tornado import TChannel
 def main():  # pragma: no cover
     args = get_args()
 
-    client = TChannel('localhost:%d' % args.port)
+    client = TChannel(
+        name='tchannel_server',
+        hostport='%s:%d' % (args.host, args.port),
+    )
+
     register_example_endpoints(client)
     client.listen()
 

--- a/python/examples/thrift_examples/client.py
+++ b/python/examples/thrift_examples/client.py
@@ -28,7 +28,8 @@ from tchannel.tornado import TChannel
 
 @gen.coroutine
 def run():
-    client = client_for('hello', HelloService)(TChannel(), 'localhost:4040')
+    tchannel = TChannel(name='thrift-client')
+    client = client_for('hello', HelloService)(tchannel, 'localhost:4040')
     response = yield client.hello("world")
     print response
 

--- a/python/examples/thrift_examples/server.py
+++ b/python/examples/thrift_examples/server.py
@@ -23,7 +23,7 @@ from tornado import ioloop
 from hello import HelloService
 from tchannel.tornado import TChannel
 
-app = TChannel('localhost:4040')
+app = TChannel('thrift-server', 'localhost:4040')
 
 
 @app.register(HelloService)

--- a/python/examples/tornado_client.py
+++ b/python/examples/tornado_client.py
@@ -37,7 +37,7 @@ def main():
 
     args = get_args()
     conn = yield StreamConnection.outgoing('%s:%d' % (args.host, args.port))
-    conn.tchannel = TChannel()
+    conn.tchannel = TChannel(name='tornado-client')
     N = 10000
     before = time.time()
     batch_size = 100


### PR DESCRIPTION
These were broken when we made `name` a required argument.

@abhinav @junchaowu @breerly 