### PR TITLE
go: Free memory exchange + add test for happy case

### DIFF
--- a/golang/fragmentation_test.go
+++ b/golang/fragmentation_test.go
@@ -400,6 +400,9 @@ func (ch fragmentChannel) recvNextFragment(initial bool) (*readableFragment, err
 	return fragment, rbuf.Err()
 }
 
+func (ch fragmentChannel) doneReading() {}
+func (ch fragmentChannel) doneSending() {}
+
 func buffers(elements ...[][]byte) [][]byte {
 	var buffers [][]byte
 	for i := range elements {

--- a/golang/fragmenting_reader.go
+++ b/golang/fragmenting_reader.go
@@ -51,6 +51,9 @@ type fragmentReceiver interface {
 	// recvNextFragment returns the next received fragment, blocking until
 	// it's available or a deadline/cancel occurs
 	recvNextFragment(intial bool) (*readableFragment, error)
+
+	// doneReading is called when the fragment receiver is finished reading all fragments.
+	doneReading()
 }
 
 type fragmentingReadState int
@@ -212,6 +215,7 @@ func (r *fragmentingReader) EndArgument() error {
 			return r.err
 		}
 
+		r.receiver.doneReading()
 		r.curFragment.done()
 		r.curChunk = nil
 		r.state = fragmentingReadComplete

--- a/golang/fragmenting_writer.go
+++ b/golang/fragmenting_writer.go
@@ -103,6 +103,9 @@ type fragmentSender interface {
 
 	// flushFragment flushes the given fragment
 	flushFragment(f *writableFragment) error
+
+	// doneSending is called when the fragment receiver is finished sending all fragments.
+	doneSending()
 }
 
 type fragmentingWriterState int
@@ -258,6 +261,7 @@ func (w *fragmentingWriter) EndArgument() error {
 		w.state = fragmentingWriteComplete
 		w.curFragment.finish(false)
 		w.err = w.sender.flushFragment(w.curFragment)
+		w.sender.doneSending()
 		return w.err
 	}
 

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -191,6 +191,8 @@ func (call *InboundCall) Response() *InboundCallResponse {
 	return call.response
 }
 
+func (call *InboundCall) doneReading() {}
+
 // An InboundCallResponse is used to send the response back to the calling peer
 type InboundCallResponse struct {
 	reqResWriter
@@ -257,4 +259,10 @@ func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
 // The returned writer must be closed once the write is complete.
 func (response *InboundCallResponse) Arg3Writer() (io.WriteCloser, error) {
 	return response.arg3Writer()
+}
+
+// doneSending shuts down the message exchange for this call.
+// For incoming calls, the last message is sending the call response.
+func (response *InboundCallResponse) doneSending() {
+	response.mex.shutdown()
 }

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -165,6 +165,8 @@ func (call *OutboundCall) Arg3Writer() (io.WriteCloser, error) {
 	return call.arg3Writer()
 }
 
+func (call *OutboundCall) doneSending() {}
+
 // An OutboundCallResponse is the response to an outbound call
 type OutboundCallResponse struct {
 	reqResReader
@@ -226,4 +228,10 @@ func (c *Connection) handleError(frame *Frame) {
 	if err := c.outbound.forwardPeerFrame(frame); err != nil {
 		c.outbound.removeExchange(frame.Header.ID)
 	}
+}
+
+// doneReading shuts down the message exchange for this call.
+// For outgoing calls, the last message is reading the call response.
+func (response *OutboundCallResponse) doneReading() {
+	response.mex.shutdown()
 }


### PR DESCRIPTION
This avoids leaking memory on successful calls.