### PR TITLE
do not trace hyperbahn advertise

### DIFF
--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -157,6 +157,7 @@ function sendAdvertise(services, options, callback) {
     }
 
     options.serviceName = 'hyperbahn';
+    options.trace = false;
     options.hasNoParent = true;
     options.headers = options.headers || {};
     options.headers.cn = self.callerName;
@@ -232,6 +233,7 @@ function sendRelayAdvertise(opts, callback) {
             self.tchannelJSON.send(self.channel.request({
                 host: opts.hostPort,
                 serviceName: 'hyperbahn',
+                trace: false,
                 timeout: self.relayAdTimeout,
                 headers: {
                     cn: self.callerName

--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -306,6 +306,7 @@ function advertise(opts) {
         serviceName: 'hyperbahn',
         timeout: (opts && opts.timeout) || 50,
         hasNoParent: true,
+        trace: false,
         headers: {
             cn: self.callerName
         }


### PR DESCRIPTION
Tracing the hyperbahn advertise can cause cascading failures
if there is something wrong with tcollector.

We need hyperbahn advertise to always work no matter what so
it is simply less risky to turn tracing off

r: @rf @shannili

cc: @junchaowu @prashantv We should turn tracing off for hyperbahn
advertise in python & go as well.