### PR TITLE
Add tchannel options and callback to forwardToTChannel

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -177,7 +177,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
     if (!peer) {
         hres.writeHead(503, 'Service Unavailable: no tchannel peer');
         hres.end(); // TODO: error content
-        callback(errors.NoPeerAvailable);
+        callback(errors.NoPeerAvailable());
         return null;
     } else {
         // TODO: observable

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -212,7 +212,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
             hres.writeHead(head.statusCode, head.message, headers);
             body.pipe(hres);
         }
-        callback(err)
+        callback(err);
     }
 };
 

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -26,7 +26,6 @@ var http = require('http');
 var PassThrough = require('readable-stream').PassThrough;
 var extend = require('xtend');
 var extendInto = require('xtend/mutable');
-var errors = require('../errors.js');
 
 var headerRW = bufrw.Repeat(bufrw.UInt16BE,
     bufrw.Series(bufrw.str2, bufrw.str2));

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -26,6 +26,7 @@ var http = require('http');
 var PassThrough = require('readable-stream').PassThrough;
 var extend = require('xtend');
 var extendInto = require('xtend/mutable');
+var errors = require('../errors.js');
 
 var headerRW = bufrw.Repeat(bufrw.UInt16BE,
     bufrw.Series(bufrw.str2, bufrw.str2));

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -25,6 +25,7 @@ var bufrw = require('bufrw');
 var http = require('http');
 var PassThrough = require('readable-stream').PassThrough;
 var extend = require('xtend');
+var extendInto = require('xtend/mutable');
 var errors = require('../errors.js');
 
 var headerRW = bufrw.Repeat(bufrw.UInt16BE,
@@ -159,8 +160,7 @@ TChannelHTTP.prototype.setHandler = function register(tchannel, handler) {
     return tchannel.handler;
 };
 
-TChannelHTTP.prototype.forwardToTChannel =
-    function forwardToTChannel(tchannel, hreq, hres, tchannelRequestOptions, callback) {
+TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, hreq, hres, tchannelRequestOptions, callback) {
     var self = this;
 
     // TODO: no retrying due to:
@@ -169,8 +169,7 @@ TChannelHTTP.prototype.forwardToTChannel =
     // TODO: more http state machine integration
 
     var treq;
-    if (!tchannelRequestOptions) tchannelRequestOptions = {};
-    var options = tchannel.requestOptions(extend({
+    var options = tchannel.requestOptions(extendInto({
         streamed: true,
         hasNoParent: true
     }, tchannelRequestOptions));
@@ -213,9 +212,7 @@ TChannelHTTP.prototype.forwardToTChannel =
             hres.writeHead(head.statusCode, head.message, headers);
             body.pipe(hres);
         }
-        if (typeof callback === 'function') {
-            callback(err)
-        }
+        callback(err)
     }
 };
 

--- a/node/examples/http_egress.js
+++ b/node/examples/http_egress.js
@@ -62,7 +62,10 @@ httpServer.listen(argv.httpPort, argv.bind, onHTTPListening);
 var svcChan = tchan.makeSubChannel({
     serviceName: serviceName,
     requestDefaults: {
-        serviceName: serviceName
+        serviceName: serviceName,
+        headers: {
+            cn: 'examples/http_ingress'
+        }
     }
 });
 
@@ -84,5 +87,5 @@ function onHTTPListening() {
 }
 
 function onHTTPRequest(hreq, hres) {
-    asHTTP.forwardToTChannel(svcChan, hreq, hres);
+    asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function() { return true; });
 }

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -192,7 +192,14 @@ function allocHTTPBridge(opts) {
     }
 
     function onEgressRequest(hreq, hres) {
-        cluster.asHTTP.forwardToTChannel(cluster.egressChan, hreq, hres, {}, function nocallback(err){});
+        cluster.asHTTP.forwardToTChannel(
+            cluster.egressChan,
+            hreq,
+            hres,
+            {},
+            function nocallback(err){
+                if (err) throw err;
+            });
     }
 
     function destroy(callback) {

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -192,7 +192,7 @@ function allocHTTPBridge(opts) {
     }
 
     function onEgressRequest(hreq, hres) {
-        cluster.asHTTP.forwardToTChannel(cluster.egressChan, hreq, hres);
+        cluster.asHTTP.forwardToTChannel(cluster.egressChan, hreq, hres, {}, function nocallback(err){});
     }
 
     function destroy(callback) {


### PR DESCRIPTION
forwardToTChannel options for setting target serviceName and cn (caller name)
callback for consumers to receive errors and completion status