### PR TITLE
HyperbahnClient apply backoff to advertise

### DIFF
--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -30,9 +30,9 @@ var Errors = require('../errors.js');
 var TChannelJSON = require('../as/json');
 var TChannelEndpointHandler = require('../endpoint-handler');
 
-var MAX_RELAY_AD_ATTEMPTS = 4;
+var MAX_RELAY_AD_ATTEMPTS = 2;
 var RELAY_AD_RETRY_TIME = 1 * 1000;
-var RELAY_AD_TIMEOUT = 500;
+var RELAY_AD_TIMEOUT = 50;
 
 module.exports = HyperbahnHandler;
 
@@ -238,6 +238,7 @@ function sendRelayAdvertise(opts, callback) {
                 headers: {
                     cn: self.callerName
                 },
+                retryLimit: 1,
                 parent: opts.inreq
             }), 'relay-ad', null, {
                 services: opts.services

--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -245,6 +245,7 @@ function sendAdvertiseRequest(opts, cb) {
         timeout: (opts && opts.timeout) || 50,
         hasNoParent: true,
         trace: false,
+        retryLimit: 1,
         headers: {
             cn: self.callerName
         }

--- a/node/test/hyperbahn/constructor.js
+++ b/node/test/hyperbahn/constructor.js
@@ -47,7 +47,7 @@ test('creating HyperbahnClient with new', function t(assert) {
 test('create HyperbahnClient without options', function t(assert) {
     assert.throws(function throwIt() {
         HyperbahnClient();
-    }, /invalid option tchannel/);
+    }, /Must pass in top level tchannel/);
 
     assert.end();
 });
@@ -55,7 +55,7 @@ test('create HyperbahnClient without options', function t(assert) {
 test('create HyperbahnClient without options.tchannel', function t(assert) {
     assert.throws(function throwIt() {
         HyperbahnClient({});
-    }, /invalid option tchannel/);
+    }, /Must pass in top level tchannel/);
 
     assert.end();
 });
@@ -69,7 +69,7 @@ test('create HyperbahnClient with a subchannel', function t(assert) {
                 serviceName: 'foo'
             })
         });
-    }, /invalid option tchannel/);
+    }, /Must pass in top level tchannel/);
 
     assert.end();
 });
@@ -81,7 +81,7 @@ test('create HyperbahnClient without serviceName', function t(assert) {
         HyperbahnClient({
             tchannel: tchannel
         });
-    }, /invalid option serviceName/);
+    }, /must pass in serviceName/);
 
     assert.end();
 });
@@ -94,7 +94,7 @@ test('create HyperbahnClient without hostPortList', function t(assert) {
             tchannel: tchannel,
             serviceName: 'foo'
         });
-    }, /invalid option hostPortList/);
+    }, /Must pass in hostPortList/);
 
     assert.end();
 });

--- a/node/test/hyperbahn/hyperbahn-down.js
+++ b/node/test/hyperbahn/hyperbahn-down.js
@@ -93,6 +93,13 @@ function runTests(HyperbahnCluster) {
         });
 
         var attempts = 0;
+        var start = Date.now();
+
+        var gap = {
+            0: [0, 10],
+            1: [200, 225],
+            2: [1200, 1250]
+        };
 
         client.on('error', onError);
         client.on('advertise-attempt', onAdvertisementAttempt);
@@ -103,6 +110,10 @@ function runTests(HyperbahnCluster) {
         }
 
         function onAdvertisementAttempt() {
+            var delta = Date.now() - start;
+            assert.ok(gap[attempts][0] < delta);
+            assert.ok(delta < gap[attempts][1]);
+
             if (++attempts < 3) {
                 return;
             }

--- a/node/test/hyperbahn/hyperbahn-down.js
+++ b/node/test/hyperbahn/hyperbahn-down.js
@@ -111,8 +111,8 @@ function runTests(HyperbahnCluster) {
 
         function onAdvertisementAttempt() {
             var delta = Date.now() - start;
-            assert.ok(gap[attempts][0] < delta);
-            assert.ok(delta < gap[attempts][1]);
+            assert.ok(gap[attempts][0] <= delta);
+            assert.ok(delta <= gap[attempts][1]);
 
             if (++attempts < 3) {
                 return;

--- a/node/test/hyperbahn/sub-channel.js
+++ b/node/test/hyperbahn/sub-channel.js
@@ -35,11 +35,11 @@ test('getting client subChannel without serviceName', function t(assert) {
 
     assert.throws(function throwIt() {
         client.getClientChannel();
-    }, /invalid option serviceName/);
+    }, /must pass serviceName/);
 
     assert.throws(function throwIt() {
         client.getClientChannel({});
-    }, /invalid option serviceName/);
+    }, /must pass serviceName/);
 
     assert.end();
 });


### PR DESCRIPTION
Under failure conditions the edge clients will advertise with
hyperbahn every 200ms instead of every 60 seconds. This
creates extra load on hyperbahn which causes a cascading
failure of the hyperbahn network not being able to recover
in a timely fashion.

To mitigate this the hyperbahn clients should backoff. I've
maxed the backoff to 10seconds.

Secondarily; this PR also fuzzes the 60s retry to be a retry
every (30-90s) to try and even out the load on the hyperbahn
router.

r: @rf @shannili

cc: @prashantv @junchaowu It would be good to get the go
and python hyperbahn clients to also backoff on advertise.