### PR TITLE
optimization suggestions

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -270,6 +270,7 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
         delete self.serverConnections[socketRemoteAddr];
     }
 
+    // TODO: move method
     function onConnectionError(err) {
         var codeName = errors.classify(err);
 

--- a/node/connection.js
+++ b/node/connection.js
@@ -85,10 +85,15 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
     var self = this;
 
     self.socket.setNoDelay(true);
+    // TODO: stream the data with backpressure
+    // when you add data event listener you go into
+    // a deoptimized mode and you have lost all
+    // backpressure on the stream
     self.socket.on('data', onSocketChunk);
     self.socket.on('close', onSocketClose);
     self.socket.on('error', onSocketError);
 
+    // TODO: move to method for function optimization
     function onSocketChunk(chunk) {
         var err = self.mach.handleChunk(chunk);
         if (err) {
@@ -96,6 +101,7 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
         }
     }
 
+    // TODO: move to method for function optimization
     function onSocketClose() {
         self.resetAll(errors.SocketClosedError({
             reason: 'remote closed',
@@ -260,6 +266,7 @@ TChannelConnection.prototype.handleReadFrame = function handleReadFrame(frame) {
     }
     self.handler.handleFrame(frame, handledFrame);
     function handledFrame(err) {
+        // TODO: move if check to onHandlerError
         if (err) self.onHandlerError(err);
     }
 };
@@ -290,6 +297,7 @@ TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {
 
     req.emitResponse(res);
 
+    // TODO: move to method
     function popOutReq() {
         if (called) {
             return;

--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -218,6 +218,7 @@ function sendRelayAdvertise(opts, callback) {
 
     tryRequest();
 
+    // TODO: move functions out to methods
     function tryRequest() {
         attempts++;
 


### PR DESCRIPTION
I'm using this PR as a way to make suggestions for optimizations. I will just point out things as I see them. My general observations are

- If you only optimize the "happy hot path" you will blow up in the "sad hot path", so don't be too quick to suggest that something is not in the hot path when a badly behaving client or network issue would exercise those paths frequently

- Get rid of every nested closure longer than 1 line. It's much easier to apply a blanket style for nested functions than to try to justify one way or the other on a case by case basis. This one line should simply be a function call. I prefer to do a direct lookup in closure scope rather than calling methods, but sometimes you do genuinely want the function to be a method.

- As a corollary that means killing all forEach statements regardless of how you try to justify them, It's probably always going to be faster to just use a for loop.

- Suspect object creation causes memory allocation which is distributed very evenly across your process lifecycle, making it very difficult to see how much CPU you're spending on it. Try recycling objects, particularly those created per request.

- Watch out for object hashes and Object.keys. It's very easy to get into the habit of thinking these things are free. You will hit a ceiling at some point and suffer heavy deoptimizations and memory allocations. I think in general we need a hash map that scales well without needing to use delete, or worrying about object key collisions etc.

- Don't be scared of optimizing the computation heavy parts. The node HTTP parser is a C library because binary operations are relatively slow in javascript. It's not a bad idea to write a C parser that operates over the raw inbound buffers (more productive than trying to rewrite in Go). Flamegraphs show we spend a non-trivial amount of time parsing.

- Worry about backpressure and worry a lot. You need to have some idea of how many concurrent requests you can handle in the worse case path. Relying on error signals is too late in my opinion.

- The node internals lower the performance ceiling, so if you have the bandwidth to avoid them (streams are really heavy for example) then do so. Remember that they are not making the best decisions in core because of the back-compat requirement. We have no such requirements.
