### PR TITLE
go: Fix for Closed channel still being reachable.

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -273,8 +273,8 @@ func (ch *Channel) Logger() Logger {
 
 // Closed returns whether this channel has been closed with .Close()
 func (ch *Channel) Closed() bool {
-	ch.mutable.mut.Lock()
-	defer ch.mutable.mut.Unlock()
+	ch.mutable.mut.RLock()
+	defer ch.mutable.mut.RUnlock()
 	return ch.mutable.closed
 }
 

--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -1,0 +1,123 @@
+package tchannel
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+type channelState struct {
+	ch      *Channel
+	closeCh chan struct{}
+	closed  bool
+}
+
+func makeCall(ch *Channel, hostPort, service string) error {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	_, _, _, err := sendRecv(ctx, ch, hostPort, service, "test", nil, nil)
+	return err
+}
+
+// TestClose ensures that once a Channel is closed, it cannot be reached.
+func TestClose(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	const numHandlers = 5
+	handler := &swapper{t}
+	var lock sync.RWMutex
+	var channels []*channelState
+
+	// Start numHandlers servers, and don't close the connections till they are signalled.
+	for i := 0; i < numHandlers; i++ {
+		go func() {
+			assert.NoError(t, withServerChannel(nil, func(ch *Channel, hostPort string) {
+				ch.Register(AsRaw(handler), "test")
+
+				chState := &channelState{
+					ch:      ch,
+					closeCh: make(chan struct{}),
+				}
+
+				lock.Lock()
+				channels = append(channels, chState)
+				lock.Unlock()
+
+				// Wait for a close signal.
+				<-chState.closeCh
+
+				// Lock until the connection is closed.
+				lock.Lock()
+				chState.closed = true
+			}))
+			lock.Unlock()
+		}()
+	}
+
+	time.Sleep(time.Millisecond * 100)
+
+	// Start goroutines to make calls until the test has ended.
+	testEnded := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func() {
+			for {
+				select {
+				case <-testEnded:
+					return
+				default:
+					// Keep making requests till the test ends.
+				}
+
+				// Get 2 random channels and make a call from one to the other.
+				chState1 := channels[rand.Intn(len(channels))]
+				chState2 := channels[rand.Intn(len(channels))]
+				if chState1 == chState2 {
+					continue
+				}
+
+				// Grab a read lock to make sure channels aren't closed while we call.
+				lock.RLock()
+				ch1Closed := chState1.closed
+				ch2Closed := chState2.closed
+				err := makeCall(chState1.ch, chState2.ch.PeerInfo().HostPort, chState2.ch.PeerInfo().ServiceName)
+				lock.RUnlock()
+				if ch1Closed || ch2Closed {
+					assert.Error(t, err, "Call from %v to %v should fail", chState1.ch.PeerInfo(), chState2.ch.PeerInfo())
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+		}()
+	}
+
+	// Kill connections till all of the connections are dead.
+	for i := 0; i < numHandlers; i++ {
+		time.Sleep(time.Duration(rand.Intn(50)) * time.Millisecond)
+		channels[i].closeCh <- struct{}{}
+	}
+}

--- a/golang/errors.go
+++ b/golang/errors.go
@@ -85,6 +85,9 @@ var (
 
 	// ErrTimeoutRequired is a SystemError indicating that timeouts must be specified.
 	ErrTimeoutRequired = NewSystemError(ErrCodeBadRequest, "timeout required")
+
+	// ErrChannelClosed is a SystemError indicating that the channel has been closed.
+	ErrChannelClosed = NewSystemError(ErrCodeDeclined, "closed channel cannot make calls")
 )
 
 // A SystemError is a system-level error, containing an error code and message

--- a/golang/frame_pool_test.go
+++ b/golang/frame_pool_test.go
@@ -145,7 +145,11 @@ func checkEmptyExchangesConns(connections []*Connection) string {
 }
 
 func TestFramesReleased(t *testing.T) {
-	testutils.SetTimeout(t, time.Second*100)
+	if testing.Short() {
+		return
+	}
+
+	testutils.SetTimeout(t, time.Second*10)
 	const (
 		requestsPerGoroutine = 10
 		numGoroutines        = 10

--- a/golang/peer.go
+++ b/golang/peer.go
@@ -111,6 +111,10 @@ func (p *Peer) getActive() []*Connection {
 // GetConnection returns an active connection to this peer. If no active connections
 // are found, it will create a new outbound connection and return it.
 func (p *Peer) GetConnection(ctx context.Context) (*Connection, error) {
+	if p.channel.Closed() {
+		return nil, ErrChannelClosed
+	}
+
 	// TODO(prashant): Should we clear inactive connections.
 	activeConns := p.getActive()
 
@@ -163,7 +167,6 @@ func (p *Peer) Connect(ctx context.Context) (*Connection, error) {
 // BeginCall starts a new call to this specific peer, returning an OutboundCall that can
 // be used to write the arguments of the call.
 func (p *Peer) BeginCall(ctx context.Context, serviceName string, operationName string, callOptions *CallOptions) (*OutboundCall, error) {
-
 	conn, err := p.GetConnection(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Even after a channel is closed, it was able to make outgoing requests, and those outgoing connections could be used by other servers to connect back to the closed channel. This ensures that once a channel is closed, it is really not reachable.

r: @mmihic 
cc: @slantin 