### PR TITLE
Most close ephemeral peers or leak peer objects

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -105,6 +105,10 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
         }));
 
         if (self.ephemeral) {
+            var peer = self.channel.peers.get(self.socketRemoteAddr);
+            if (peer) {
+                peer.close(noop);
+            }
             self.channel.peers.delete(self.socketRemoteAddr);
         }
     }
@@ -113,6 +117,8 @@ TChannelConnection.prototype.setupSocket = function setupSocket() {
         self.onSocketError(err);
     }
 };
+
+function noop() {}
 
 TChannelConnection.prototype.setupHandler = function setupHandler() {
     var self = this;

--- a/node/test/ephemeral-client.js
+++ b/node/test/ephemeral-client.js
@@ -1,0 +1,82 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var TChannel = require('../channel.js');
+
+module.exports = runTests;
+
+if (require.main === module) {
+    runTests(require('./lib/hyperbahn-cluster.js'));
+}
+
+function runTests(HyperbahnCluster) {
+    HyperbahnCluster.test('ephemeral client works', {
+        size: 5
+    }, function t(cluster, assert) {
+        var bob = cluster.remotes.bob;
+
+        for (var i = 0; i < cluster.apps.length; i++) {
+            var app = cluster.apps[i];
+            app.clients.serviceProxy.block('*', bob.serviceName);
+        }
+
+        var client = TChannel({
+            trace: false
+        });
+        var subClient = client.makeSubChannel({
+            serviceName: 'test',
+            requestDefaults: {
+                hasNoParent: true,
+                headers: {
+                    as: 'raw',
+                    cn: 'client'
+                }
+            },
+            peers: [cluster.hostPortList[0]]
+        });
+
+        subClient.waitForIdentified({
+            host: cluster.hostPortList[0]
+        }, onIdentified);
+
+        function onIdentified(err) {
+            assert.ifError(err);
+
+            subClient.request({
+                serviceName: bob.serviceName
+            }).send('echo', 'a', 'b', onResponse);
+        }
+
+        function onResponse(err, res, arg2, arg3) {
+            assert.ok(err);
+            assert.equal(err.type, 'tchannel.request.timeout');
+
+            assert.equal(res, null);
+
+            client.close();
+
+            setTimeout(function later() {
+                assert.end();
+            }, 10);
+        }
+    });
+}

--- a/node/test/hyperbahn/index.js
+++ b/node/test/hyperbahn/index.js
@@ -23,6 +23,7 @@
 require('./constructor.js');
 require('./todo.js');
 require('./sub-channel.js');
+require('./kill-switch.js');
 
 module.exports = runTests;
 
@@ -37,5 +38,4 @@ function runTests(HyperbahnCluster) {
 
     require('./hyperbahn-down.js')(HyperbahnCluster);
     require('./hyperbahn-times-out.js')(HyperbahnCluster);
-    require('./kill-switch.js');
 }

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -62,5 +62,6 @@ require('./max-call-overhead.js');
 require('./non-zero-ttl.js');
 require('./examples.js');
 require('./busy.js');
+require('./ephemeral-client.js');
 
 require('./hyperbahn/')(HyperbahnCluster);

--- a/node/test/lib/hyperbahn-cluster.js
+++ b/node/test/lib/hyperbahn-cluster.js
@@ -90,6 +90,7 @@ HyperbahnCluster.prototype.bootstrap = function bootstrap(cb) {
         self.apps = relayNetwork.relayChannels.map(function p(channel, index) {
             return HyperbahnApp({
                 relayChannel: channel,
+                serviceProxy: channel.handler,
                 egressNodes: relayNetwork.egressNodesForRelay[index]
             });
         });
@@ -135,21 +136,24 @@ function HyperbahnApp(opts) {
 
     var self = this;
 
-    self.relayChannel = opts.relayChannel;
-    self.egressNodes = opts.egressNodes;
-    self.hostPort = self.relayChannel.hostPort;
+    self.__relayChannel = opts.relayChannel;
+    self.__egressNodes = opts.egressNodes;
+    self.hostPort = opts.relayChannel.hostPort;
+    self.clients = {
+        serviceProxy: opts.serviceProxy
+    };
 }
 
 HyperbahnApp.prototype.exitsFor = function exitsFor(serviceName) {
     var self = this;
 
-    return self.egressNodes.exitsFor(serviceName);
+    return self.__egressNodes.exitsFor(serviceName);
 };
 
 HyperbahnApp.prototype.destroy = function destroy() {
     var self = this;
 
-    self.relayChannel.close();
+    self.__relayChannel.close();
 };
 
 function HyperbahnRemote(opts) {

--- a/node/test/lib/hyperbahn-cluster.js
+++ b/node/test/lib/hyperbahn-cluster.js
@@ -136,8 +136,8 @@ function HyperbahnApp(opts) {
 
     var self = this;
 
-    self.__relayChannel = opts.relayChannel;
-    self.__egressNodes = opts.egressNodes;
+    self._relayChannel = opts.relayChannel;
+    self._egressNodes = opts.egressNodes;
     self.hostPort = opts.relayChannel.hostPort;
     self.clients = {
         serviceProxy: opts.serviceProxy
@@ -147,13 +147,13 @@ function HyperbahnApp(opts) {
 HyperbahnApp.prototype.exitsFor = function exitsFor(serviceName) {
     var self = this;
 
-    return self.__egressNodes.exitsFor(serviceName);
+    return self._egressNodes.exitsFor(serviceName);
 };
 
 HyperbahnApp.prototype.destroy = function destroy() {
     var self = this;
 
-    self.__relayChannel.close();
+    self._relayChannel.close();
 };
 
 function HyperbahnRemote(opts) {


### PR DESCRIPTION
We were leaking peer objects in prod; peer objects will
report stats in a loop. Because we 10s of thousands of
these objects we were reporting the same stat 10s of
thousands of time and saw a huge spike in about 5k
UDP writes per second.

r: @rf @jcorbin @kriskowal