### PR TITLE
go: Add header support to Thrift

### DIFF
--- a/golang/examples/keyvalue/client.go
+++ b/golang/examples/keyvalue/client.go
@@ -36,8 +36,11 @@ import (
 	"github.com/uber/tchannel/golang/thrift"
 )
 
+var curUser = "anonymous"
+
 func printHelp() {
-	fmt.Printf("Usage:\n get [key]\n set [key] [value]\n")
+	fmt.Println("Usage:\n get [key]\n set [key] [value]")
+	fmt.Println(" user [newUser]\n clearAll")
 }
 
 func main() {
@@ -82,6 +85,12 @@ func main() {
 				break
 			}
 			set(client, parts[1], parts[2])
+		case "user":
+			if len(parts) < 2 {
+				printHelp()
+				break
+			}
+			curUser = parts[1]
 		case "clearAll":
 			clear(adminClient)
 		default:
@@ -126,7 +135,7 @@ func set(client keyvalue.TChanKeyValue, key, value string) {
 		return
 	}
 
-	log.Printf("Set %v:%v succeeded", key, value)
+	log.Printf("Set %v:%v succeeded with headers: %v", key, value, ctx.ResponseHeaders())
 }
 
 func clear(adminClient keyvalue.TChanAdmin) {
@@ -148,6 +157,6 @@ func clear(adminClient keyvalue.TChanAdmin) {
 
 func createContext() (thrift.Context, func()) {
 	tctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	ctx := thrift.WrapContext(tchannel.NewRootContext(tctx))
+	ctx := thrift.WithHeaders(tchannel.NewRootContext(tctx), map[string]string{"user": curUser})
 	return ctx, cancel
 }

--- a/golang/examples/keyvalue/client.go
+++ b/golang/examples/keyvalue/client.go
@@ -93,8 +93,8 @@ func main() {
 }
 
 func get(client keyvalue.TChanKeyValue, key string) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	ctx = tchannel.NewRootContext(ctx)
+	ctx, cancel := createContext()
+	defer cancel()
 
 	val, err := client.Get(ctx, key)
 	if err != nil {
@@ -113,8 +113,8 @@ func get(client keyvalue.TChanKeyValue, key string) {
 }
 
 func set(client keyvalue.TChanKeyValue, key, value string) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	ctx = tchannel.NewRootContext(ctx)
+	ctx, cancel := createContext()
+	defer cancel()
 
 	if err := client.Set(ctx, key, value); err != nil {
 		switch err := err.(type) {
@@ -130,8 +130,8 @@ func set(client keyvalue.TChanKeyValue, key, value string) {
 }
 
 func clear(adminClient keyvalue.TChanAdmin) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	ctx = tchannel.NewRootContext(ctx)
+	ctx, cancel := createContext()
+	defer cancel()
 
 	if err := adminClient.ClearAll(ctx); err != nil {
 		switch err := err.(type) {
@@ -144,4 +144,10 @@ func clear(adminClient keyvalue.TChanAdmin) {
 	}
 
 	log.Printf("ClearAll completed, all keys cleared")
+}
+
+func createContext() (thrift.Context, func()) {
+	tctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx := thrift.WrapContext(tchannel.NewRootContext(tctx))
+	return ctx, cancel
 }

--- a/golang/examples/keyvalue/server.go
+++ b/golang/examples/keyvalue/server.go
@@ -21,8 +21,8 @@ package main
 // THE SOFTWARE.
 
 import (
+	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"sync"
 	"unicode"
@@ -102,6 +102,8 @@ func (h *kvHandler) Set(ctx thrift.Context, key, value string) error {
 	defer h.mut.Unlock()
 
 	h.vals[key] = value
+	// Example of how to use response headers. Normally, these values should be passed via result structs.
+	ctx.SetResponseHeaders(map[string]string{"count": fmt.Sprint(len(h.vals))})
 	return nil
 }
 
@@ -112,7 +114,7 @@ func (h *kvHandler) HealthCheck(ctx thrift.Context) (string, error) {
 
 // ClearAll clears all the keys.
 func (h *kvHandler) ClearAll(ctx thrift.Context) error {
-	if isAdmin(ctx) {
+	if !isAdmin(ctx) {
 		return &keyvalue.NotAuthorized{}
 	}
 
@@ -132,6 +134,5 @@ func isValidKey(key string) error {
 }
 
 func isAdmin(ctx thrift.Context) bool {
-	// TODO(prashant): Check if the user is allowed from headers in the context.
-	return rand.Intn(2) == 1
+	return ctx.Headers()["user"] == "admin"
 }

--- a/golang/examples/thrift/main.go
+++ b/golang/examples/thrift/main.go
@@ -92,10 +92,12 @@ func runClient1(hyperbahnService string, addr net.Addr) error {
 
 	go func() {
 		for {
-			ctx, _ := context.WithTimeout(context.Background(), time.Second)
+			tctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx := thrift.WrapContext(tctx)
 			res, err := client.Echo(ctx, "Hi")
 			log.Println("Echo(Hi) = ", res, ", err: ", err)
 			log.Println("AppError = ", client.AppError(ctx))
+			cancel()
 			time.Sleep(100 * time.Millisecond)
 		}
 	}()
@@ -113,9 +115,11 @@ func runClient2(hyperbahnService string, addr net.Addr) error {
 
 	go func() {
 		for {
-			ctx, _ := context.WithTimeout(context.Background(), time.Second)
+			tctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx := thrift.WrapContext(tctx)
 
 			client.Test(ctx)
+			cancel()
 			time.Sleep(100 * time.Millisecond)
 		}
 	}()

--- a/golang/thrift/context.go
+++ b/golang/thrift/context.go
@@ -22,8 +22,52 @@ package thrift
 
 import "golang.org/x/net/context"
 
-// Context represents the context for a single call.
-// TODO(prashant): Allow setting application headers on the context.
+// Context is a Thrift Context which contains request and response headers.
 type Context interface {
 	context.Context
+
+	// Headers returns the call request headers.
+	Headers() map[string]string
+
+	// ResponseHeaders returns the call response headers.
+	ResponseHeaders() map[string]string
+
+	// SetResponseHeaders sets the given response headers on the context.
+	SetResponseHeaders(map[string]string)
+}
+
+type thriftCtx struct {
+	context.Context
+	reqHeaders  map[string]string
+	respHeaders map[string]string
+}
+
+// Headers gets application headers out of the context.
+func (c *thriftCtx) Headers() map[string]string {
+	return c.reqHeaders
+}
+
+// ResponseHeaders returns the response headers.
+func (c *thriftCtx) ResponseHeaders() map[string]string {
+	return c.respHeaders
+}
+
+// SetResponseHeaders sets the response headers.
+func (c *thriftCtx) SetResponseHeaders(headers map[string]string) {
+	c.respHeaders = headers
+}
+
+// WrapContext returns a Context that can be used to make JSON calls.
+func WrapContext(ctx context.Context) Context {
+	return &thriftCtx{
+		Context: ctx,
+	}
+}
+
+// WithHeaders returns a Context that can be used to make a call with request headers.
+func WithHeaders(ctx context.Context, headers map[string]string) Context {
+	return &thriftCtx{
+		Context:    ctx,
+		reqHeaders: headers,
+	}
 }

--- a/golang/thrift/headers.go
+++ b/golang/thrift/headers.go
@@ -1,0 +1,64 @@
+package thrift
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// TODO(prashant): Refactor tchannel/typed so we can reuse it here.
+
+func writeHeaders(w io.Writer, headers map[string]string) error {
+	var err error
+	writeBinary := func(data interface{}) {
+		if err != nil {
+			return
+		}
+		err = binary.Write(w, binary.BigEndian, data)
+	}
+	writeBinary(uint16(len(headers)))
+	for k, v := range headers {
+		writeBinary(uint16(len(k)))
+		writeBinary([]byte(k))
+		writeBinary(uint16(len(v)))
+		writeBinary([]byte(v))
+	}
+	return err
+}
+
+func readHeaders(r io.Reader) (map[string]string, error) {
+	var err error
+
+	readUInt16 := func() uint16 {
+		if err != nil {
+			return 0
+		}
+		var data uint16
+		err = binary.Read(r, binary.BigEndian, &data)
+		return data
+	}
+
+	readString := func(length uint16) []byte {
+		if err != nil || length == 0 {
+			return nil
+		}
+		data := make([]byte, length)
+		_, err = io.ReadFull(r, data)
+		return data
+	}
+
+	headerLen := readUInt16()
+	if headerLen == 0 {
+		return nil, err
+	}
+
+	headers := make(map[string]string)
+	for i := uint16(0); i < headerLen; i++ {
+		klen := readUInt16()
+		k := readString(klen)
+		vlen := readUInt16()
+		v := readString(vlen)
+		headers[string(k)] = string(v)
+	}
+
+	return headers, err
+}

--- a/golang/thrift/headers_test.go
+++ b/golang/thrift/headers_test.go
@@ -1,0 +1,40 @@
+package thrift
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var headers = map[string]string{
+	"header1": "value1",
+	"header2": "value2",
+	"header3": "value1",
+	"header4": "value2",
+	"header5": "value1",
+	"header6": "value2",
+	"header7": "value1",
+	"header8": "value2",
+	"header9": "value1",
+	"header0": "value2",
+}
+
+func BenchmarkWriteHeaders(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		writeHeaders(ioutil.Discard, headers)
+	}
+}
+
+func BenchmarkReadHeaders(b *testing.B) {
+	buf := &bytes.Buffer{}
+	assert.NoError(b, writeHeaders(buf, headers))
+	bs := buf.Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader := bytes.NewReader(bs)
+		readHeaders(reader)
+	}
+}


### PR DESCRIPTION
Works and reuses the binary read/write logic, but at the cost of memory.

r @mmihic 