### PR TITLE
allow overriding 'not found' behavior

### DIFF
--- a/python/CHANGES.rst
+++ b/python/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog for tchannel.py
 0.8.6 (unreleased)
 ------------------
 
-- No changes yet.
+- Allow custom handlers for unrecognized endpoints.
 
 
 0.8.5 (2015-06-30)

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,7 +1,7 @@
 project := tchannel
 
 flake8 := flake8
-pytest := PYTHONDONTWRITEBYTECODE=1 py.test -s --tb short \
+pytest := PYTHONDONTWRITEBYTECODE=1 py.test --tb short \
 	--cov-config .coveragerc --cov $(project) \
 	--async-test-timeout=1 --timeout=30 tests
 

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -74,6 +74,7 @@ class RequestDispatcher(BaseRequestHandler):
 
         # event: receive_request
         request.tracing.name = request.endpoint
+
         connection.tchannel.event_emitter.fire(
             EventType.before_receive_request,
             request,
@@ -120,6 +121,8 @@ class RequestDispatcher(BaseRequestHandler):
                 response.id,
             )
 
+        raise gen.Return(response)
+
     def route(self, rule, helper=None):
         """See ``register`` for documentation."""
 
@@ -163,6 +166,10 @@ class RequestDispatcher(BaseRequestHandler):
         # Dispatcher but only handles serialization.
         if not broker:
             broker = self.default_broker
+
+        if rule is None:
+            self.endpoints.default_factory = lambda: handler
+            return
 
         broker.register(rule, handler)
 

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -52,6 +52,8 @@ class RequestDispatcher(BaseRequestHandler):
             response.write('hello world')
     """
 
+    FALLBACK = object()
+
     def __init__(self):
         super(RequestDispatcher, self).__init__()
         self.default_broker = ArgSchemeBroker()
@@ -145,9 +147,9 @@ class RequestDispatcher(BaseRequestHandler):
             Name of the endpoint. Incoming Call Requests must have this as
             ``arg1`` to dispatch to this handler.
 
-            If ``None`` is specified as a rule, the given handler will be used
-            as the 'fallback' handler when requests don't match any registered
-            rules.
+            If ``RequestHandler.FALLBACK`` is specified as a rule, the given
+            handler will be used as the 'fallback' handler when requests don't
+            match any registered rules.
 
         :param handler:
             A function that gets called with ``Request``, ``Response``, and
@@ -167,7 +169,7 @@ class RequestDispatcher(BaseRequestHandler):
         if not broker:
             broker = self.default_broker
 
-        if rule is None:
+        if rule is self.FALLBACK:
             self.endpoints.default_factory = lambda: handler
             return
 

--- a/python/tchannel/tornado/dispatch.py
+++ b/python/tchannel/tornado/dispatch.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 
+from collections import defaultdict
+
 import tornado
 import tornado.gen
 from tornado import gen
@@ -45,15 +47,15 @@ class RequestDispatcher(BaseRequestHandler):
 
         handler = # ...
 
-        @hanlder.route('myMethod')
-        def myMethod(request, response, opts):
+        @handler.route('my_method')
+        def my_method(request, response, proxy):
             response.write('hello world')
     """
 
     def __init__(self):
         super(RequestDispatcher, self).__init__()
         self.default_broker = ArgSchemeBroker()
-        self.endpoints = {}
+        self.endpoints = defaultdict(lambda: self.not_found)
 
     @tornado.gen.coroutine
     def handle_call(self, request, connection):
@@ -65,6 +67,7 @@ class RequestDispatcher(BaseRequestHandler):
         # request.endpoint. The original argstream[0] is no longer valid. If
         # user still tries read from it, it will return empty.
         chunk = yield request.argstreams[0].read()
+
         while chunk:
             request.endpoint += chunk
             chunk = yield request.argstreams[0].read()
@@ -76,52 +79,46 @@ class RequestDispatcher(BaseRequestHandler):
             request,
         )
 
-        endpoint = self.endpoints.get(request.endpoint, None)
-        if endpoint is None:
+        endpoint = self.endpoints[request.endpoint]
+
+        response = Response(
+            id=request.id,
+            checksum=request.checksum,
+            tracing=request.tracing,
+            connection=connection,
+            headers={'as': request.headers.get('as', 'raw')},
+        )
+
+        connection.post_response(response)
+
+        try:
+            yield gen.maybe_future(
+                endpoint(
+                    request,
+                    response,
+                    TChannelProxy(
+                        connection.tchannel,
+                        request.tracing,
+                    ),
+                )
+            )
+            response.flush()
+        except (InvalidMessageError, InvalidEndpointError) as e:
+            response.set_exception(e)
+            connection.request_message_factory.remove_buffer(response.id)
             connection.send_error(
                 ErrorCode.bad_request,
-                "Endpoint '%s' for service '%s' is not defined" % (
-                    request.endpoint, request.service),
-                request.id)
-        else:
-            response = Response(
-                id=request.id,
-                checksum=request.checksum,
-                tracing=request.tracing,
-                connection=connection,
-                headers={'as': request.headers.get('as', 'raw')},
+                e.message,
+                response.id,
             )
-
-            connection.post_response(response)
-
-            try:
-                yield gen.maybe_future(
-                    endpoint(
-                        request,
-                        response,
-                        TChannelProxy(
-                            connection.tchannel,
-                            request.tracing,
-                        ),
-                    )
-                )
-                response.flush()
-            except (InvalidMessageError, InvalidEndpointError) as e:
-                response.set_exception(e)
-                connection.request_message_factory.remove_buffer(response.id)
-                connection.send_error(
-                    ErrorCode.bad_request,
-                    e.message,
-                    response.id,
-                )
-            except Exception as e:
-                response.set_exception(TChannelError(e.message))
-                connection.request_message_factory.remove_buffer(response.id)
-                connection.send_error(
-                    ErrorCode.unexpected,
-                    "An unexpected error has occurred from the handler",
-                    response.id,
-                )
+        except Exception as e:
+            response.set_exception(TChannelError(e.message))
+            connection.request_message_factory.remove_buffer(response.id)
+            connection.send_error(
+                ErrorCode.unexpected,
+                "An unexpected error has occurred from the handler",
+                response.id,
+            )
 
     def route(self, rule, helper=None):
         """See ``register`` for documentation."""
@@ -137,18 +134,22 @@ class RequestDispatcher(BaseRequestHandler):
 
         .. code-block:: python
 
-            def handler(request, response, proxy):
-                proxy.request(serviceName).send(...) # send outgoing request
+            @dispatcher.register('is_healthy')
+            def check_health(request, response, proxy):
                 # ...
-
-            handler.register('is_healthy', handler, foo='bar')
 
         :param rule:
             Name of the endpoint. Incoming Call Requests must have this as
             ``arg1`` to dispatch to this handler.
+
+            If ``None`` is specified as a rule, the given handler will be used
+            as the 'fallback' handler when requests don't match any registered
+            rules.
+
         :param handler:
             A function that gets called with ``Request``, ``Response``, and
             the ``proxy``.
+
         :param broker:
             Broker injects customized serializer and deserializer into
             request/response object.
@@ -156,13 +157,26 @@ class RequestDispatcher(BaseRequestHandler):
             broker==None means it registers as raw handle. It deals with raw
             buffer in the request/response.
         """
-        assert rule, "rule must not be None"
         assert handler, "handler must not be None"
+
+        # TODO: Get rid of this Broker thing!! It has the same interface as the
+        # Dispatcher but only handles serialization.
         if not broker:
             broker = self.default_broker
 
         broker.register(rule, handler)
+
         self.endpoints[rule] = broker.handle_call
+
+    @staticmethod
+    def not_found(request, response, proxy):
+        """Default behavior for requests to unrecognized endpoints."""
+        raise InvalidEndpointError(
+            "Endpoint '%s' for service '%s' is not defined" % (
+                request.endpoint,
+                request.service,
+            ),
+        )
 
 
 class TChannelProxy(object):

--- a/python/tests/tornado/test_dispatch.py
+++ b/python/tests/tornado/test_dispatch.py
@@ -75,7 +75,7 @@ def test_custom_fallback_behavior(dispatcher, req, connection):
     def handler(req, response, proxy):
         response.write_body('bar')
 
-    dispatcher.register(None, handler)
+    dispatcher.register(dispatcher.FALLBACK, handler)
     response = yield dispatcher.handle_call(req, connection)
     body = yield response.get_body()
     assert body == 'bar'

--- a/python/tests/tornado/test_dispatch.py
+++ b/python/tests/tornado/test_dispatch.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import tornado.concurrent
+import mock
+import pytest
+
+from tchannel.messages.error import ErrorCode
+from tchannel.tornado.dispatch import RequestDispatcher
+
+
+@pytest.fixture
+def dispatcher():
+    return RequestDispatcher()
+
+
+@pytest.fixture
+def req():
+    # FIXME: This is crazy for a unit test!!
+    request = mock.MagicMock(
+        endpoint='foo',
+        headers={'as': 'raw'},
+    )
+    endpoint_future = tornado.concurrent.Future()
+    endpoint_future.set_result(None)
+    request.argstreams[0].read.return_value = endpoint_future
+    return request
+
+
+@pytest.fixture
+def connection():
+    return mock.MagicMock()
+
+
+@pytest.mark.gen_test
+def test_handle_call(dispatcher, req, connection):
+    def handler(req, response, proxy):
+        response.write_body('bar')
+
+    dispatcher.register('foo', handler)
+
+    response = yield dispatcher.handle_call(req, connection)
+    body = yield response.get_body()
+    assert body == 'bar'
+
+
+@pytest.mark.gen_test
+def test_default_fallback_behavior(dispatcher, req, connection):
+    """Undefined endpoints return 'Bad Request' errors."""
+    yield dispatcher.handle_call(req, connection)
+    assert connection.send_error.call_args[0][0] == ErrorCode.bad_request
+
+
+@pytest.mark.gen_test
+def test_custom_fallback_behavior(dispatcher, req, connection):
+    def handler(req, response, proxy):
+        response.write_body('bar')
+
+    dispatcher.register(None, handler)
+    response = yield dispatcher.handle_call(req, connection)
+    body = yield response.get_body()
+    assert body == 'bar'


### PR DESCRIPTION
This is analogous to a 404 handler. The use case here is a testing tool that would accept requests at any endpoint, replay a response if it's available, or, if not, forward the request to a real server.

@abhinav @breerly @junchaowu 