### PR TITLE
add stats for outbound.calls.retries, per-attempt.latency

### DIFF
--- a/python/tchannel/event.py
+++ b/python/tchannel/event.py
@@ -63,11 +63,11 @@ class EventHook(object):
 
     """
     def before_send_request(self, request):
-        """Called before any request initiated by the service."""
+        """Called before each request is sent."""
         pass
 
     def before_send_request_per_attempt(self, request, retry_count):
-        """Called before sending each request for each attempt."""
+        """Called before each attempt to send the request."""
         pass
 
     def after_send_request(self, request):

--- a/python/tchannel/event.py
+++ b/python/tchannel/event.py
@@ -33,6 +33,7 @@ log = logging.getLogger('tchannel')
 EventType = enum(
     'EventType',
     before_send_request=0x00,
+    before_send_request_per_attempt=0x02,
     after_send_request=0x01,
     before_send_response=0x10,
     after_send_response=0x11,
@@ -62,7 +63,11 @@ class EventHook(object):
 
     """
     def before_send_request(self, request):
-        """Called before any part of a ``CALL_REQ`` message is sent."""
+        """Called before any request initiated by the service."""
+        pass
+
+    def before_send_request_per_attempt(self, request, retry_count):
+        """Called before sending each request for each attempt."""
         pass
 
     def after_send_request(self, request):

--- a/python/tchannel/statsd.py
+++ b/python/tchannel/statsd.py
@@ -39,7 +39,7 @@ class StatsdHook(EventHook):
         :param statsd: instance of `StatsD <https://github.com/etsy/statsd>`
         """
         self._statsd = statsd
-        self.outbound_attempt = {}
+        self.outbound_attempt = {}  # {span_id: start_time}
 
     def before_send_request(self, request):
         statsd_name = "tchannel.outbound.calls.sent"
@@ -47,16 +47,9 @@ class StatsdHook(EventHook):
 
         self._statsd.count(key, 1)
 
-    def before_send_request_per_attempt(self, request, retry_count):
-        statsd_name = "tchannel.outbound.calls.retries"
-        retry_count += 1
-        key = common_prefix(statsd_name, request) + '.' + str(retry_count)
-
-        self._statsd.count(key, 1)
-
-        # record outbound call start time and retry_count
-        self.outbound_attempt[request.tracing.span_id] = (time.time(),
-                                                          retry_count)
+    def before_send_request_per_attempt(self, request):
+        # record outbound call start time
+        self.outbound_attempt[request.tracing.span_id] = time.time()
 
     def after_receive_response(self, request, response):
         if response.code == StatusCode.ok:
@@ -110,12 +103,10 @@ class StatsdHook(EventHook):
     def outbound_latency_per_attempt(self, request):
         if request.tracing.span_id not in self.outbound_attempt:
             return
-        (start_time, retry_count) = self.outbound_attempt.pop(
-            request.tracing.span_id)
+        start_time = self.outbound_attempt.pop(request.tracing.span_id)
 
         latency_statsd_name = "tchannel.outbound.calls.per-attempt.latency"
-        key = common_prefix(latency_statsd_name, request) + '.' + str(
-            retry_count)
+        key = common_prefix(latency_statsd_name, request)
         elapsed = (time.time() - start_time) * 1000.0
 
         self._statsd.timing(key, elapsed)

--- a/python/tchannel/tornado/connection.py
+++ b/python/tchannel/tornado/connection.py
@@ -618,7 +618,6 @@ class StreamConnection(TornadoConnection):
             protocol_exception = f.exception()
             protocol_exception.tracing = request.tracing
             response_future.set_exception(protocol_exception)
-
         else:
             response = f.result()
             response.tracing = request.tracing

--- a/python/tchannel/tornado/peer.py
+++ b/python/tchannel/tornado/peer.py
@@ -581,12 +581,6 @@ class PeerClientOperation(object):
             raise
 
         log.debug("Got response %s", response)
-        # event: after_receive_response
-        self.peer.tchannel.event_emitter.fire(
-            EventType.after_receive_response,
-            request,
-            response,
-        )
 
         raise gen.Return(response)
 
@@ -607,7 +601,19 @@ class PeerClientOperation(object):
         # mac number of times to retry 3.
         for num_of_attempt in range(attempt_times):
             try:
+                # event: before_send_request_per_attempt
+                self.peer.tchannel.event_emitter.fire(
+                    EventType.before_send_request_per_attempt,
+                    request,
+                    num_of_attempt,
+                )
                 response = yield self._send(connection, request)
+                # event: after_receive_response
+                self.peer.tchannel.event_emitter.fire(
+                    EventType.after_receive_response,
+                    request,
+                    response,
+                )
                 break
             except ProtocolError as protocol_error:
                 # event: after_receive_protocol_error_per_attempt

--- a/python/tchannel/tornado/peer.py
+++ b/python/tchannel/tornado/peer.py
@@ -605,7 +605,6 @@ class PeerClientOperation(object):
                 self.peer.tchannel.event_emitter.fire(
                     EventType.before_send_request_per_attempt,
                     request,
-                    num_of_attempt,
                 )
                 response = yield self._send(connection, request)
                 # event: after_receive_response

--- a/python/tchannel/zipkin/zipkin_trace.py
+++ b/python/tchannel/zipkin/zipkin_trace.py
@@ -47,7 +47,7 @@ class ZipkinTraceHook(EventHook):
             # to dst. By default it writes to stdout
             self.tracer = DebugTracer(dst)
 
-    def before_send_request(self, request):
+    def before_send_request_per_attempt(self, request, retry_count):
         if not request.tracing.traceflags:
             return
 
@@ -79,7 +79,7 @@ class ZipkinTraceHook(EventHook):
         response.tracing.annotations.append(ann)
         self.tracer.record([(response.tracing, response.tracing.annotations)])
 
-    def after_receive_system_error(self, request, error):
+    def after_receive_system_error_per_attempt(self, request, error):
         if not error.tracing.traceflags:
             return
 

--- a/python/tests/integration/test_retry.py
+++ b/python/tests/integration/test_retry.py
@@ -115,7 +115,7 @@ def test_retry_on_error_fail():
                 headers={
                     're': RetryType.CONNECTION_ERROR_AND_TIMEOUT
                 },
-                ttl=1,
+                ttl=0,
                 attempt_times=3,
                 retry_delay=0.01,
             )

--- a/python/tests/integration/test_retry.py
+++ b/python/tests/integration/test_retry.py
@@ -115,7 +115,7 @@ def test_retry_on_error_fail():
                 headers={
                     're': RetryType.CONNECTION_ERROR_AND_TIMEOUT
                 },
-                ttl=0.02,
+                ttl=1,
                 attempt_times=3,
                 retry_delay=0.01,
             )

--- a/python/tests/test_statsd.py
+++ b/python/tests/test_statsd.py
@@ -63,12 +63,12 @@ def before_send_request_per_attempt(statsd_hook, request):
 
 
 def test_outbound_latency(statsd_hook, request):
-    statsd_hook.before_send_request_per_attempt(request, 0)
+    statsd_hook.before_send_request_per_attempt(request)
     response = Response(code=StatusCode.error)
     statsd_hook.after_receive_response(request, response)
     kargs = statsd_hook._statsd.timing.call_args
     assert kargs[0][0] == "tchannel.outbound.calls.per-attempt.latency." + (
-        "no-service.test.endpoint1.1"
+        "no-service.test.endpoint1"
     )
 
 

--- a/python/tests/test_statsd.py
+++ b/python/tests/test_statsd.py
@@ -55,6 +55,23 @@ def test_before_send_request(statsd_hook, request):
     )
 
 
+def before_send_request_per_attempt(statsd_hook, request):
+    statsd_hook.before_send_request_per_attempt(request, 0)
+    statsd_hook._statsd.count.assert_called_with(
+        "tchannel.outbound.calls.retries.no-service.test.endpoint1", 1
+    )
+
+
+def test_outbound_latency(statsd_hook, request):
+    statsd_hook.before_send_request_per_attempt(request, 0)
+    response = Response(code=StatusCode.error)
+    statsd_hook.after_receive_response(request, response)
+    kargs = statsd_hook._statsd.timing.call_args
+    assert kargs[0][0] == "tchannel.outbound.calls.per-attempt.latency." + (
+        "no-service.test.endpoint1.1"
+    )
+
+
 def test_after_receive_response(statsd_hook, request):
     response = Response(code=StatusCode.ok)
     statsd_hook.after_receive_response(request, response)


### PR DESCRIPTION
@blampe @breerly @abhinav 

Doesn't support fragments or streaming case for latency calculation. 
