### PR TITLE
Fix typo in typeName description for as-thrift documentation

### DIFF
--- a/node/docs/as-thrift.md
+++ b/node/docs/as-thrift.md
@@ -155,7 +155,7 @@ The `handlerFn` takes five arguments, `(ctx, req, head, body, cb(err, response))
     object that is serialized as a thrift struct to arg3.
     If `response.ok` is false then this must be an error that
     is serialized as a thrift exception to  arg3.
- - `response.typeName` if you response with `response.ok` set as
+ - `response.typeName` if you respond with `response.ok` set as
     `false` you must specify a `typeName` to determine how
     the exception will be serialized. This `typeName` must match
     the name of your exception in the thrift specification

--- a/node/docs/as-thrift.md
+++ b/node/docs/as-thrift.md
@@ -119,7 +119,7 @@ request to send to.
     is an object with three fields; `ok`, `head` and `body`.
  - `response.ok` is the `ok` field from the call response.
  - `response.head` is an object with string key value pairs that is parsed from arg2
- - `response.body` is an an object or error that we parsed from a thrift struct. If the response is ok then its a struct; if the response is not
+ - `response.body` is an object or error that we parsed from a thrift struct. If the response is ok then it's a struct; if the response is not
  ok then it's an error object.
 
 ### `tchannelThrift.register(tchannel, arg1, ctx, handlerFn)`


### PR DESCRIPTION
@Raynos @kriskowal @jcorbin 