### PR TITLE
Don't write ECONNREFUSED to info log

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -520,7 +520,8 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
         self.errorEvent.emit(self, err);
     } else if (
         err.type !== 'tchannel.socket-closed' &&
-        err.type !== 'tchannel.socket-local-closed'
+        err.type !== 'tchannel.socket-local-closed' &&
+        (err.type !== 'tchannel.socket' && err.code !== 'ECONNREFUSED')
     ) {
         logInfo.error = extend(err);
         logInfo.error.message = err.message;


### PR DESCRIPTION
This log is quite spammy, especially on ringpop startup and ping failures

@Raynos @kriskowal @jcorbin 