### PR TITLE
test: use different ports from examples

### DIFF
--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -134,8 +134,7 @@ function allocHTTPBridge(opts) {
     // egress( HTTP -> TChannel ) -> ingress( TChannel -> HTTP )
 
     var cluster = allocCluster({
-        numPeers: 2,
-        listen: [4040, 4041]
+        numPeers: 2
     });
     var tready = cluster.ready;
     var tdestroy = cluster.destroy;

--- a/node/test/connection-stats.js
+++ b/node/test/connection-stats.js
@@ -117,7 +117,7 @@ allocCluster.test('emits connection stats with failure', {
         serviceName: 'server',
         // there should be nothing running on this port
         // the connection is supposed to fail
-        peers: ['localhost:4040']
+        peers: ['localhost:9999']
     });
 
     subClient.request({
@@ -128,7 +128,7 @@ allocCluster.test('emits connection stats with failure', {
     });
 
     client.waitForIdentified({
-        host: 'localhost:4040'
+        host: 'localhost:9999'
     }, onIdentified);
 
     function onIdentified(err) {
@@ -141,7 +141,7 @@ allocCluster.test('emits connection stats with failure', {
                 tags:
                 {
                     'host-port': clientHost,
-                    'peer-host-port': 'localhost:4040',
+                    'peer-host-port': 'localhost:9999',
                     app: 'server',
                     host: os.hostname()
                }
@@ -152,7 +152,7 @@ allocCluster.test('emits connection stats with failure', {
                 tags:
                 {
                     'host-port': clientHost,
-                    'peer-host-port': 'localhost:4040',
+                    'peer-host-port': 'localhost:9999',
                     app: 'server',
                     host: os.hostname()
                }

--- a/node/test/connection-with-statsd.js
+++ b/node/test/connection-with-statsd.js
@@ -104,7 +104,7 @@ allocCluster.test('emits connection stats with failure', {
     client.channelStatsd = new TChannelStatsd(client, statsd);
     var subClient = client.makeSubChannel({
         serviceName: 'reservoir',
-        peers: ['localhost:4040']
+        peers: ['localhost:9999']
     });
     subClient.request({
         serviceName: 'reservoir',
@@ -114,7 +114,7 @@ allocCluster.test('emits connection stats with failure', {
     });
 
     client.waitForIdentified({
-        host: 'localhost:4040'
+        host: 'localhost:9999'
     }, onIdentified);
 
     function onIdentified(err) {

--- a/node/test/tchannel.js
+++ b/node/test/tchannel.js
@@ -23,9 +23,9 @@
 var test = require('tape');
 var TChannel = require('../channel.js');
 
-var serverOptions = {host: '127.0.0.1', port: 4040};
-var clientOptions = {host: '127.0.0.1', port: 4041};
-var client1Options = {host: '127.0.0.1', port: 4042};
+var serverOptions = {host: '127.0.0.1', port: 14045};
+var clientOptions = {host: '127.0.0.1', port: 14046};
+var client1Options = {host: '127.0.0.1', port: 14047};
 var clientName = clientOptions.host + ':' + clientOptions.port;
 var client1Name = client1Options.host + ':' + client1Options.port;
 
@@ -47,7 +47,7 @@ test('add peer: get connection', function t(assert) {
     var connection = server.peers.add(clientName).connect();
 
     assert.ok(connection, 'A connection object should be returned');
-    assert.equals(connection.socketRemoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    assert.equals(connection.socketRemoteAddr, '127.0.0.1:14046', 'Remote address should match the client');
     server.quit(assert.end);
   });
 });
@@ -58,7 +58,7 @@ test('peer add, connect', function t(assert) {
   server.listen(serverOptions.port, serverOptions.host, function listening() {
     var connection = server.peers.add(clientName).connect();
     assert.ok(connection, 'A connection object should be returned');
-    assert.equals(connection.socketRemoteAddr, '127.0.0.1:4041', 'Remote address should match the client');
+    assert.equals(connection.socketRemoteAddr, '127.0.0.1:14046', 'Remote address should match the client');
     server.quit(assert.end);
   });
 });

--- a/node/test/tcollector-reporter.js
+++ b/node/test/tcollector-reporter.js
@@ -83,7 +83,7 @@ test('test of thriftify spec', function t1(assert) {
         ],
         'host': {
             'ipv4': 2130706433,
-            'port': 4040,
+            'port': 9999,
             'serviceName': 'server'
         },
         'binaryAnnotations': [

--- a/node/test/trace/basic_server.js
+++ b/node/test/trace/basic_server.js
@@ -57,7 +57,7 @@ test('basic tracing test', function (assert) {
     });
     var subServiceChan = server.makeSubChannel({
         serviceName: 'subservice',
-        peers: ['127.0.0.1:4042']
+        peers: ['127.0.0.1:9997']
     });
 
     var client = new TChannel({
@@ -67,7 +67,7 @@ test('basic tracing test', function (assert) {
     });
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: ['127.0.0.1:4040']
+        peers: ['127.0.0.1:9999']
     });
 
     subChan.register('/foobar', function (req, res) {
@@ -140,9 +140,9 @@ test('basic tracing test', function (assert) {
         });
     });
 
-    server.listen(4040, '127.0.0.1', ready.signal);
-    client.listen(4041, '127.0.0.1', ready.signal);
-    subservice.listen(4042, '127.0.0.1', ready.signal);
+    server.listen(9999, '127.0.0.1', ready.signal);
+    client.listen(9998, '127.0.0.1', ready.signal);
+    subservice.listen(9997, '127.0.0.1', ready.signal);
 
     requestsDone(function () {
         setTimeout(function () {

--- a/node/test/trace/basic_server_fixture.js
+++ b/node/test/trace/basic_server_fixture.js
@@ -27,7 +27,7 @@ module.exports = [
         "name": "/foobar",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -39,7 +39,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -48,7 +48,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -59,7 +59,7 @@ module.exports = [
         "name": "/foobar",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -71,7 +71,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -80,7 +80,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -91,7 +91,7 @@ module.exports = [
         "name": "/top_level_endpoint",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4040,
+            "port": 9999,
             "serviceName": "server"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -103,7 +103,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4040,
+                    "port": 9999,
                     "serviceName": "server"
                 }
             },
@@ -112,7 +112,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4040,
+                    "port": 9999,
                     "serviceName": "server"
                 }
             }

--- a/node/test/trace/server_2_requests.js
+++ b/node/test/trace/server_2_requests.js
@@ -57,7 +57,7 @@ test('server 2 requests tracing test', function (assert) {
     });
     var subServiceClientChan = server.makeSubChannel({
         serviceName: 'subservice',
-        peers: ['127.0.0.1:4042']
+        peers: ['127.0.0.1:9997']
     });
 
     var client = new TChannel({
@@ -67,7 +67,7 @@ test('server 2 requests tracing test', function (assert) {
     });
     var clientChan = client.makeSubChannel({
         serviceName: 'server',
-        peers: ['127.0.0.1:4040']
+        peers: ['127.0.0.1:9999']
     });
 
     subChan.register('/foobar', function (req, res) {
@@ -173,9 +173,9 @@ test('server 2 requests tracing test', function (assert) {
         });
     });
 
-    server.listen(4040, '127.0.0.1', ready.signal);
-    client.listen(4041, '127.0.0.1', ready.signal);
-    subservice.listen(4042, '127.0.0.1', ready.signal);
+    server.listen(9999, '127.0.0.1', ready.signal);
+    client.listen(9998, '127.0.0.1', ready.signal);
+    subservice.listen(9997, '127.0.0.1', ready.signal);
 
     requestsDone(function () {
         setTimeout(function () {

--- a/node/test/trace/server_2_requests_fixture.js
+++ b/node/test/trace/server_2_requests_fixture.js
@@ -27,7 +27,7 @@ module.exports = [
         "name": "/barbaz",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -39,7 +39,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -48,7 +48,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -59,7 +59,7 @@ module.exports = [
         "name": "/barbaz",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -71,7 +71,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -80,7 +80,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -91,7 +91,7 @@ module.exports = [
         "name": "/foobar",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -103,7 +103,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -112,7 +112,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -123,7 +123,7 @@ module.exports = [
         "name": "/foobar",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4042,
+            "port": 9997,
             "serviceName": "subservice"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -135,7 +135,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             },
@@ -144,7 +144,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4042,
+                    "port": 9997,
                     "serviceName": "subservice"
                 }
             }
@@ -155,7 +155,7 @@ module.exports = [
         "name": "/top_level_endpoint",
         "endpoint": {
             "ipv4": "127.0.0.1",
-            "port": 4040,
+            "port": 9999,
             "serviceName": "server"
         },
         "traceid": validators.checkId(idStore, 'traceid'),
@@ -167,7 +167,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4040,
+                    "port": 9999,
                     "serviceName": "server"
                 }
             },
@@ -176,7 +176,7 @@ module.exports = [
                 "timestamp": validators.timestamp,
                 "host": {
                     "ipv4": "127.0.0.1",
-                    "port": 4040,
+                    "port": 9999,
                     "serviceName": "server"
                 }
             }


### PR DESCRIPTION
This is a simple fixup commit that changes the ports.

Now we can run benchmarks, tests & examples at the
same time.

r: @kriskowal @rf @shannili