### PR TITLE
go: Move logic for tests into testutils/ and raw/ and move tests into _test package

### DIFF
--- a/golang/Makefile
+++ b/golang/Makefile
@@ -3,6 +3,7 @@ OLDGOPATH := $(GOPATH)
 PATH := $(GODEPS)/bin:$(PATH)
 EXAMPLES=./examples/hello/server ./examples/hello/client ./examples/ping ./examples/thrift ./examples/hyperbahn/echo-server
 PKGS := . ./json ./hyperbahn ./thrift ./typed $(EXAMPLES)
+TEST_PKGS := $(addprefix github.com/uber/tchannel/golang/,$(PKGS))
 BUILD := ./build
 SRCS := $(foreach pkg,$(PKGS),$(wildcard $(pkg)/*.go))
 export GOPATH = $(GODEPS):$(OLDGOPATH)
@@ -39,7 +40,7 @@ test_ci: test
 
 test: clean setup
 	echo Testing packages:
-	go test $(PKGS) $(TEST_ARG) -parallel=4
+	go test $(TEST_PKGS) $(TEST_ARG) -parallel=4
 
 benchmark: clean setup
 	echo Running benchmarks:

--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -1,4 +1,4 @@
-package tchannel
+package tchannel_test
 
 // Copyright (c) 2015 Uber Technologies, Inc.
 
@@ -26,7 +26,11 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/uber/tchannel/golang"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel/golang/raw"
+	"github.com/uber/tchannel/golang/testutils"
 )
 
 type channelState struct {
@@ -39,7 +43,7 @@ func makeCall(ch *Channel, hostPort, service string) error {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	_, _, _, err := sendRecv(ctx, ch, hostPort, service, "test", nil, nil)
+	_, _, _, err := raw.Call(ctx, ch, hostPort, service, "test", nil, nil)
 	return err
 }
 
@@ -57,8 +61,8 @@ func TestClose(t *testing.T) {
 	// Start numHandlers servers, and don't close the connections till they are signalled.
 	for i := 0; i < numHandlers; i++ {
 		go func() {
-			assert.NoError(t, withServerChannel(nil, func(ch *Channel, hostPort string) {
-				ch.Register(AsRaw(handler), "test")
+			assert.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+				ch.Register(raw.Wrap(handler), "test")
 
 				chState := &channelState{
 					ch:      ch,

--- a/golang/frame_utils_test.go
+++ b/golang/frame_utils_test.go
@@ -1,0 +1,80 @@
+package tchannel
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+type RecordingFramePool struct {
+	mut         sync.Mutex
+	allocations map[*Frame]string
+	badRelease  []string
+}
+
+func NewRecordingFramePool() *RecordingFramePool {
+	return &RecordingFramePool{
+		allocations: make(map[*Frame]string),
+	}
+}
+
+func CheckEmptyExchanges(c *Connection) string {
+	if exchangesLeft := len(c.outbound.exchanges) + len(c.inbound.exchanges); exchangesLeft > 0 {
+		return fmt.Sprintf("connection %p had %v leftover exchanges", c, exchangesLeft)
+	}
+	return ""
+}
+
+func recordStack() string {
+	buf := make([]byte, 4096)
+	runtime.Stack(buf, false)
+	return string(buf)
+}
+
+func (p *RecordingFramePool) Get() *Frame {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	frame := NewFrame(MaxFramePayloadSize)
+	p.allocations[frame] = recordStack()
+	return frame
+}
+
+func zeroOut(bs []byte) {
+	for i := range bs {
+		bs[i] = 0
+	}
+}
+
+func (p *RecordingFramePool) Release(f *Frame) {
+	// Make sure the payload is not used after this point by clearing the frame.
+	zeroOut(f.Payload)
+	f.Payload = nil
+	zeroOut(f.buffer)
+	f.buffer = nil
+	zeroOut(f.headerBuffer)
+	f.headerBuffer = nil
+	f.Header = FrameHeader{}
+
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	if _, ok := p.allocations[f]; !ok {
+		p.badRelease = append(p.badRelease, "bad Release at "+recordStack())
+		return
+	}
+
+	delete(p.allocations, f)
+}
+
+func (p *RecordingFramePool) CheckEmpty() (int, string) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	var badCalls []string
+	badCalls = append(badCalls, p.badRelease...)
+	for f, s := range p.allocations {
+		badCalls = append(badCalls, fmt.Sprintf("frame %p: %v not released, get from: %v", f, f.Header, s))
+	}
+	return len(p.allocations), strings.Join(badCalls, "\n")
+}

--- a/golang/frame_utils_test.go
+++ b/golang/frame_utils_test.go
@@ -1,5 +1,25 @@
 package tchannel
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"fmt"
 	"runtime"

--- a/golang/raw/call.go
+++ b/golang/raw/call.go
@@ -1,5 +1,25 @@
 package raw
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"github.com/uber/tchannel/golang"
 	"golang.org/x/net/context"

--- a/golang/raw/call.go
+++ b/golang/raw/call.go
@@ -1,0 +1,42 @@
+package raw
+
+import (
+	"github.com/uber/tchannel/golang"
+	"golang.org/x/net/context"
+)
+
+// WriteArgs writes the given arguments to the call, and returns the response args.
+func WriteArgs(call *tchannel.OutboundCall, arg2, arg3 []byte) ([]byte, []byte, *tchannel.OutboundCallResponse, error) {
+	if err := tchannel.NewArgWriter(call.Arg2Writer()).Write(arg2); err != nil {
+		return nil, nil, nil, err
+	}
+
+	if err := tchannel.NewArgWriter(call.Arg3Writer()).Write(arg3); err != nil {
+		return nil, nil, nil, err
+	}
+
+	resp := call.Response()
+	var respArg2 []byte
+	if err := tchannel.NewArgReader(resp.Arg2Reader()).Read(&respArg2); err != nil {
+		return nil, nil, nil, err
+	}
+
+	var respArg3 []byte
+	if err := tchannel.NewArgReader(resp.Arg3Reader()).Read(&respArg3); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return respArg2, respArg3, resp, nil
+}
+
+// Call makes a call to the given hostPort with the given arguments and returns the response args.
+func Call(ctx context.Context, ch *tchannel.Channel, hostPort string, serviceName, operation string,
+	arg2, arg3 []byte) ([]byte, []byte, *tchannel.OutboundCallResponse, error) {
+
+	call, err := ch.BeginCall(ctx, hostPort, serviceName, operation, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return WriteArgs(call, arg2, arg3)
+}

--- a/golang/raw/handler.go
+++ b/golang/raw/handler.go
@@ -1,5 +1,25 @@
 package raw
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"github.com/uber/tchannel/golang"
 	"golang.org/x/net/context"

--- a/golang/raw/handler.go
+++ b/golang/raw/handler.go
@@ -1,0 +1,81 @@
+package raw
+
+import (
+	"github.com/uber/tchannel/golang"
+	"golang.org/x/net/context"
+)
+
+// Handler is the interface for a raw handler.
+type Handler interface {
+	// Handle is called on incoming calls, and contains all the arguments.
+	// If an error is returned, it will set ApplicationError Arg3 will be the error string.
+	Handle(ctx context.Context, args *Args) (*Res, error)
+	OnError(ctx context.Context, err error)
+}
+
+// Args parses the arguments from an incoming call req.
+type Args struct {
+	Caller    string
+	Format    tchannel.Format
+	Operation string
+	Arg2      []byte
+	Arg3      []byte
+}
+
+// Res represents the response to an incoming call req.
+type Res struct {
+	SystemErr error
+	// IsErr is used to set an application error on the underlying call res.
+	IsErr bool
+	Arg2  []byte
+	Arg3  []byte
+}
+
+// Wrap wraps a Handler as a tchannel.Handler that can be passed to tchannel.Register.
+func Wrap(handler Handler) tchannel.Handler {
+	return tchannel.HandlerFunc(func(ctx context.Context, call *tchannel.InboundCall) {
+		var args Args
+		args.Caller = call.CallerName()
+		args.Format = call.Format()
+		args.Operation = string(call.Operation())
+		if err := tchannel.NewArgReader(call.Arg2Reader()).Read(&args.Arg2); err != nil {
+			handler.OnError(ctx, err)
+			return
+		}
+		if err := tchannel.NewArgReader(call.Arg3Reader()).Read(&args.Arg3); err != nil {
+			handler.OnError(ctx, err)
+			return
+		}
+
+		resp, err := handler.Handle(ctx, &args)
+		response := call.Response()
+		if err != nil {
+			resp = &Res{
+				IsErr: true,
+				Arg2:  nil,
+				Arg3:  []byte(err.Error()),
+			}
+		}
+
+		if resp.SystemErr != nil {
+			if err := response.SendSystemError(resp.SystemErr); err != nil {
+				handler.OnError(ctx, err)
+			}
+			return
+		}
+		if resp.IsErr {
+			if err := response.SetApplicationError(); err != nil {
+				handler.OnError(ctx, err)
+				return
+			}
+		}
+		if err := tchannel.NewArgWriter(response.Arg2Writer()).Write(resp.Arg2); err != nil {
+			handler.OnError(ctx, err)
+			return
+		}
+		if err := tchannel.NewArgWriter(response.Arg3Writer()).Write(resp.Arg3); err != nil {
+			handler.OnError(ctx, err)
+			return
+		}
+	})
+}

--- a/golang/stats_utils_test.go
+++ b/golang/stats_utils_test.go
@@ -1,5 +1,28 @@
 package tchannel_test
 
+// This file contains test setup logic, and is named with a _test.go suffix to
+// ensure it's only compiled with tests.
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"fmt"
 	"reflect"

--- a/golang/stats_utils_test.go
+++ b/golang/stats_utils_test.go
@@ -1,4 +1,4 @@
-package tchannel
+package tchannel_test
 
 import (
 	"fmt"

--- a/golang/testutils/channel.go
+++ b/golang/testutils/channel.go
@@ -1,0 +1,124 @@
+package testutils
+
+// This file contains test setup logic, and is named with a _test.go suffix to
+// ensure it's only compiled with tests.
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"sync/atomic"
+
+	"github.com/uber/tchannel/golang"
+)
+
+var connectionLog = flag.Bool("connectionLog", false, "Enables connection logging in tests")
+
+// Default service names for the test channels.
+const (
+	DefaultServerName = "testService"
+	DefaultClientName = "testService-client"
+)
+
+// ChannelOpts contains options to create a test channel using WithServer
+type ChannelOpts struct {
+	// ServiceName defaults to "testServer"
+	ServiceName string
+
+	// ProcessName defaults to ServiceName + "-[port]"
+	ProcessName string
+
+	// EnableLog defaults to false.
+	EnableLog bool
+
+	// StatsReporter specifies the StatsReporter to use.
+	StatsReporter tchannel.StatsReporter
+
+	// DefaultConnectionOptions specifies the channel's default connection options.
+	DefaultConnectionOptions tchannel.ConnectionOptions
+}
+
+func defaultString(v string, defaultValue string) string {
+	if v == "" {
+		return defaultValue
+	}
+	return v
+}
+
+func getChannelOptions(opts *ChannelOpts, processName string) *tchannel.ChannelOptions {
+	var logger tchannel.Logger
+	if opts.EnableLog || *connectionLog {
+		logger = tchannel.SimpleLogger
+	}
+
+	return &tchannel.ChannelOptions{
+		ProcessName: processName,
+		Logger:      logger,
+		DefaultConnectionOptions: opts.DefaultConnectionOptions,
+		StatsReporter:            opts.StatsReporter,
+	}
+}
+
+// WithServer sets up a TChannel that is listening and runs the given function with the channel.
+func WithServer(opts *ChannelOpts, f func(ch *tchannel.Channel, hostPort string)) error {
+	if opts == nil {
+		opts = &ChannelOpts{}
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("failed to listen: %v", err)
+	}
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return fmt.Errorf("could not get listening port from %v: %v", l.Addr().String(), err)
+	}
+
+	serviceName := defaultString(opts.ServiceName, DefaultServerName)
+	processName := defaultString(opts.ProcessName, serviceName+"-"+port)
+	ch, err := tchannel.NewChannel(serviceName, getChannelOptions(opts, processName))
+	if err != nil {
+		return fmt.Errorf("NewChannel failed: %v", err)
+	}
+
+	if err := ch.Serve(l); err != nil {
+		return fmt.Errorf("Serve failed: %v", err)
+	}
+	f(ch, l.Addr().String())
+	ch.Close()
+	return nil
+}
+
+var totalClients uint32
+
+// NewClient creates a TChannel that is not listening.
+func NewClient(opts *ChannelOpts) (*tchannel.Channel, error) {
+	if opts == nil {
+		opts = &ChannelOpts{}
+	}
+
+	clientNum := atomic.AddUint32(&totalClients, 1)
+	serviceName := defaultString(opts.ServiceName, DefaultClientName)
+	processName := defaultString(opts.ProcessName, serviceName+"-"+fmt.Sprint(clientNum))
+	return tchannel.NewChannel(serviceName, getChannelOptions(opts, processName))
+}

--- a/golang/tracing_test.go
+++ b/golang/tracing_test.go
@@ -1,4 +1,4 @@
-package tchannel
+package tchannel_test
 
 // Copyright (c) 2015 Uber Technologies, Inc.
 
@@ -24,8 +24,11 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/uber/tchannel/golang"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang/testutils"
 	"golang.org/x/net/context"
 )
 
@@ -41,7 +44,7 @@ type TracingResponse struct {
 type Headers map[string]string
 
 func TestTracingPropagates(t *testing.T) {
-	withTestChannel(t, testServiceName, func(ch *Channel, hostPort string) {
+	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
 		srv1 := func(ctx context.Context, incall *InboundCall) {
 			headers := Headers{}
 
@@ -137,5 +140,5 @@ func TestTracingPropagates(t *testing.T) {
 		require.NotNil(t, nestedResponse)
 		assert.Equal(t, clientSpan.TraceID(), nestedResponse.TraceID)
 		assert.Equal(t, response.SpanID, nestedResponse.ParentID)
-	})
+	}))
 }


### PR DESCRIPTION
Refactoring packages for tests (no logic changes). Prefactor to allow subpackages (json/ thrift/ etc) to use same test setup logic as tchannel, and allow tchannel tests to use json/

- Creates a raw package exposing raw call/handler functionality.
- Move test tchannel creation into testutils so other packages can also use it
- Move tchannel tests into tchannel_test so they can use above packages without circular dependencies
- Run tests in godeps directory so tests in tchannel_test package can still access tchannel package functions that are in _test.go.

cc: @mmihic 