### PR TITLE
Relay performance cleanup

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -480,6 +480,7 @@ function waitForIdentified(options, callback) {
 
 TChannel.prototype.request = function channelRequest(options) {
     var self = this;
+
     assert(!self.destroyed, 'cannot request() to destroyed tchannel');
     var opts = self.requestOptions(options);
 
@@ -488,7 +489,10 @@ TChannel.prototype.request = function channelRequest(options) {
     }
 
     var req = null;
-    if (opts.host || // retries are only between hosts
+    if (opts.peer) {
+        opts.retryCount = 0;
+        req = opts.peer.request(opts);
+    } else if (opts.host || // retries are only between hosts
         opts.streamed // streaming retries not yet implemented
     ) {
         opts.retryCount = 0;

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -66,7 +66,7 @@ function TChannelConnectionBase(channel, direction, socketRemoteAddr) {
         connection: self
     });
 
-    self.guid = ++CONNECTION_BASE_IDENTIFIER;
+    self.guid = ++CONNECTION_BASE_IDENTIFIER + '~';
 
     self.tracer = self.channel.tracer;
     self.ops.startTimeoutTimer();

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -69,7 +69,7 @@ RelayHandler.prototype.clearRequest = function clearRequest(reqKey) {
 };
 
 function getReqKey(req) {
-    return req.connection.guid + '~' + req.id;
+    return req.connection.guid + String(req.id);
 }
 
 module.exports = RelayHandler;

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -52,10 +52,9 @@ RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
         return;
     }
 
-    rereq = new RelayRequest(self.channel, req, buildRes);
+    rereq = new RelayRequest(self.channel, req, buildRes, rereqFinished);
 
     self.reqs[reqKey] = rereq;
-    rereq.finishEvent.on(rereqFinished);
     rereq.createOutRequest();
 
     function rereqFinished() {

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -25,7 +25,6 @@ var RelayRequest = require('./relay_request');
 function RelayHandler(channel) {
     var self = this;
     self.channel = channel;
-    self.reqs = {};
 }
 
 RelayHandler.prototype.type = 'tchannel.relay-handler';
@@ -33,43 +32,25 @@ RelayHandler.prototype.type = 'tchannel.relay-handler';
 RelayHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
     var self = this;
 
-    var reqKey = getReqKey(req);
-    var rereq = self.reqs[reqKey];
+    // TODO add this back in a performant way ??
+    // if (rereq) {
+    //     self.channel.logger.error('relay request already exists for incoming request', {
+    //         inReqId: req.id,
+    //         priorInResId: rereq.inres && rereq.inres.id,
+    //         priorOutResId: rereq.outres && rereq.outres.id,
+    //         priorOutReqId: rereq.outreq && rereq.outreq.id
+    //         // TODO more context, like outreq remote addr
+    //     });
+    //     buildRes().sendError(
+    //         'UnexpectedError', 'request id exists in relay handler'
+    //     );
+    //     return;
+    // }
 
     req.forwardTrace = true;
+    var rereq = new RelayRequest(self.channel, req, buildRes);
 
-    if (rereq) {
-        self.channel.logger.error('relay request already exists for incoming request', {
-            inReqId: req.id,
-            priorInResId: rereq.inres && rereq.inres.id,
-            priorOutResId: rereq.outres && rereq.outres.id,
-            priorOutReqId: rereq.outreq && rereq.outreq.id
-            // TODO more context, like outreq remote addr
-        });
-        buildRes().sendError(
-            'UnexpectedError', 'request id exists in relay handler'
-        );
-        return;
-    }
-
-    rereq = new RelayRequest(self.channel, req, buildRes, rereqFinished);
-
-    self.reqs[reqKey] = rereq;
     rereq.createOutRequest();
-
-    function rereqFinished() {
-        self.clearRequest(reqKey);
-    }
 };
-
-RelayHandler.prototype.clearRequest = function clearRequest(reqKey) {
-    var self = this;
-
-    delete self.reqs[reqKey];
-};
-
-function getReqKey(req) {
-    return req.connection.guid + String(req.id);
-}
 
 module.exports = RelayHandler;

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -22,10 +22,8 @@
 
 var errors = require('./errors');
 
-function RelayRequest(channel, inreq, buildRes, onfinish) {
+function RelayRequest(channel, inreq, buildRes) {
     var self = this;
-
-    self.onfinish = onfinish;
 
     self.channel = channel;
     self.inreq = inreq;
@@ -132,13 +130,8 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     }
 
     self.outres = self.buildRes(options);
-    self.outres.finishEvent.on(emitFinish);
 
     return self.outres;
-
-    function emitFinish() {
-        self.onfinish();
-    }
 };
 
 RelayRequest.prototype.onResponse = function onResponse(res) {

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -20,8 +20,6 @@
 
 'use strict';
 
-var inherits = require('util').inherits;
-
 var errors = require('./errors');
 
 function RelayRequest(channel, inreq, buildRes, onfinish) {

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -46,9 +46,16 @@ RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
         return;
     }
 
+    if (self.peer) {
+        self.logger.error('createOutRequest: overwritting peers', {
+            hostPort: self.peer.hostPort
+        });
+    }
+
     self.peer = self.channel.peers.choosePeer(null, {
         host: host
     });
+
     if (!self.peer) {
         self.onError(errors.NoPeerAvailable());
         return;
@@ -67,6 +74,30 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
     if (err1) {
         self.onError(err1);
         return;
+    }
+
+    var identified = false;
+    var closing = false;
+    for (var i = 0; i < self.peer.connections.length; i++) {
+        if (self.peer.connections[i].remoteName) {
+            identified = true;
+            closing = self.peer.connections[i].closing;
+            if (!closing) break;
+        }
+    }
+
+    if (!identified) {
+        // we get the problem
+        self.logger.error('onIdentified called on no connection identified', {
+            hostPort: self.peer.hostPort
+        });
+    }
+
+    if (closing) {
+        // most likely
+        self.logger.error('onIdentified called on connection closing', {
+            hostPort: self.peer.hostPort
+        });
     }
 
     var elapsed = self.channel.timers.now() - self.inreq.start;

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -72,6 +72,7 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
     var elapsed = self.channel.timers.now() - self.inreq.start;
     var timeout = Math.max(self.inreq.ttl - elapsed, 1);
     self.outreq = self.peer.request({
+        peer: self.peer,
         streamed: self.inreq.streamed,
         timeout: timeout,
         parent: self.inreq,

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -114,7 +114,7 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
             remoteAddr: self.inreq.remoteAddr,
             id: self.inreq.id
         });
-        return;
+        return null;
     }
 
     // It is possible that the inreq gets reaped with a timeout
@@ -130,11 +130,12 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
             inRemoteAddr: self.inreq.remoteAddr,
             inSocketRemoteAddr: self.inreq.connection.socketRemoteAddr
         });
-        return;
+        return null;
     }
 
     self.outres = self.buildRes(options);
     self.outres.finishEvent.on(emitFinish);
+
     return self.outres;
 
     function emitFinish() {

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -22,13 +22,12 @@
 
 var inherits = require('util').inherits;
 
-var EventEmitter = require('./lib/event_emitter');
 var errors = require('./errors');
 
-function RelayRequest(channel, inreq, buildRes) {
+function RelayRequest(channel, inreq, buildRes, onfinish) {
     var self = this;
-    EventEmitter.call(self);
-    self.finishEvent = self.defineEvent('finish');
+
+    self.onfinish = onfinish;
 
     self.channel = channel;
     self.inreq = inreq;
@@ -38,7 +37,6 @@ function RelayRequest(channel, inreq, buildRes) {
     self.buildRes = buildRes;
     self.peer = null;
 }
-inherits(RelayRequest, EventEmitter);
 
 RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
     var self = this;
@@ -140,7 +138,7 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     return self.outres;
 
     function emitFinish() {
-        self.finishEvent.emit(self);
+        self.onfinish();
     }
 };
 


### PR DESCRIPTION
This is a subset of the perf branch.

 - Remove double id protection to gain performance
 - Simplify code.
 - Re-use peer to gaurd against cannot req until identified edgecase

r: @kriskowal @shannili @rf