### PR TITLE
Node: optimize buildResponse() code path

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -428,19 +428,13 @@ TChannelConnection.prototype.buildOutRequest = function buildOutRequest(options)
 
 TChannelConnection.prototype.buildOutResponse = function buildOutResponse(req, options) {
     var self = this;
-    var opts = {
-        logger: self.logger,
-        random: self.random,
-        timers: self.timers
-    };
-    if (options) {
-        // jshint forin:false
-        for (var prop in options) {
-            opts[prop] = options[prop];
-        }
-        // jshint forin:true
-    }
-    return self.handler.buildOutResponse(req, opts);
+
+    options = options || {};
+    options.logger = self.logger;
+    options.random = self.random;
+    options.timers = self.timers;
+
+    return self.handler.buildOutResponse(req, options);
 };
 
 // this connection is completely broken, and is going away

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var assert = require('assert');
-var extend = require('xtend');
 var inherits = require('util').inherits;
 var EventEmitter = require('./lib/event_emitter');
 
@@ -217,7 +216,7 @@ function captureResponseSpans(res) {
     function handleSpanFromRes(span) {
         self.handleSpanFromRes(span);
     }
-}
+};
 
 function isStringOrBuffer(x) {
     return typeof x === 'string' || Buffer.isBuffer(x);


### PR DESCRIPTION
This one is more non-trivial. Here we rely on not making
any copies of the options passed into buildResponse() to
improve performance.

r: @kriskowal @rf @shannili