### PR TITLE
go: Use a random active peer and random active connection rather than first

### DIFF
--- a/golang/peer.go
+++ b/golang/peer.go
@@ -2,14 +2,18 @@ package tchannel
 
 import (
 	"errors"
-	"math/rand"
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 )
 
-// ErrInvalidConnectionState indicates that the connection is not in a valid state.
-var ErrInvalidConnectionState = errors.New("connection is in an invalid state")
+var (
+	// ErrInvalidConnectionState indicates that the connection is not in a valid state.
+	ErrInvalidConnectionState = errors.New("connection is in an invalid state")
+
+	peerRng = NewRand(time.Now().UnixNano())
+)
 
 // PeerList maintains a list of Peers.
 type PeerList struct {
@@ -43,7 +47,7 @@ func (l *PeerList) Add(hostPort string) *Peer {
 }
 
 func randPeer(peers []*Peer) *Peer {
-	return peers[rand.Intn(len(peers))]
+	return peers[peerRng.Intn(len(peers))]
 }
 
 // Get returns a peer from the peer list, or nil if none can be found.
@@ -117,7 +121,7 @@ func (p *Peer) getActive() []*Connection {
 }
 
 func randConn(conns []*Connection) *Connection {
-	return conns[rand.Intn(len(conns))]
+	return conns[peerRng.Intn(len(conns))]
 }
 
 // GetConnection returns an active connection to this peer. If no active connections

--- a/golang/rand.go
+++ b/golang/rand.go
@@ -1,5 +1,25 @@
 package tchannel
 
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 import (
 	"math/rand"
 	"sync"

--- a/golang/rand.go
+++ b/golang/rand.go
@@ -1,0 +1,31 @@
+package tchannel
+
+import (
+	"math/rand"
+	"sync"
+)
+
+// lockedSource allows a random number generator to be used by multiple goroutines concurrently.
+// The code is very similar to math/rand.lockedSource, which is unfortunately not exposed.
+type lockedSource struct {
+	mut sync.Mutex
+	src rand.Source
+}
+
+// NewRand returns a rand.Rand that is threadsafe.
+func NewRand(seed int64) *rand.Rand {
+	return rand.New(&lockedSource{src: rand.NewSource(seed)})
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.mut.Lock()
+	n = r.src.Int63()
+	r.mut.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.mut.Lock()
+	r.src.Seed(seed)
+	r.mut.Unlock()
+}


### PR DESCRIPTION
Use separate random number generators for tracing vs peer/connection selection to avoid contention.

r @mmihic 