### PR TITLE
Ensure endpoint-handler always builds response

### DIFF
--- a/node/request-handler.js
+++ b/node/request-handler.js
@@ -54,7 +54,8 @@ RequestCallbackHandler.prototype.handleRequest = function handleRequest(req, bui
     var res;
     if (req.streamed) {
         req.withArg23(function onArg23(err, arg2, arg3) {
-            return self.callback.call(self.thisp, req, buildResponse, arg2, arg3);
+            res = buildResponse({streamed: false});
+            return self.callback.call(self.thisp, req, res, arg2, arg3);
         });
     } else {
         res = buildResponse({streamed: false});

--- a/node/test/anechoic-chamber.thrift
+++ b/node/test/anechoic-chamber.thrift
@@ -34,4 +34,5 @@ service Chamber {
         1: NoEchoError noEcho
         2: NoEchoTypedError noEchoTyped
     )
+    i32 echo_big(0: required list<string> value)
 }


### PR DESCRIPTION
The endpoint-handler was being non-deterministic and
either building the response for you or not.

It should always build the response.

This fixes #875

r: @wolski @kriskowal @shannili