### PR TITLE
Cleanup the peers logic

### DIFF
--- a/node/peers.js
+++ b/node/peers.js
@@ -207,9 +207,6 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
         return self.add(options.host);
     } else {
         hosts = Object.keys(self._map);
-        if (self.selfPeer) {
-            hosts.push(self.selfPeer.hostPort);
-        }
     }
 
     if (!hosts || !hosts.length) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -198,7 +198,10 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
     /*eslint complexity: [2, 15]*/
     var self = this;
 
-    if (!options) options = {};
+    if (!options) {
+        options = {};
+    }
+
     var hosts = null;
     if (options.host) {
         return self.add(options.host);
@@ -208,13 +211,18 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
             hosts.push(self.selfPeer.hostPort);
         }
     }
-    if (!hosts || !hosts.length) return null;
+
+    if (!hosts || !hosts.length) {
+        return null;
+    }
 
     var threshold = options.peerScoreThreshold;
-    if (threshold === undefined) threshold = self.options.peerScoreThreshold;
-    if (threshold === undefined) threshold = 0;
+    if (threshold === undefined) {
+        threshold = self.options.peerScoreThreshold || 0;
+    }
 
-    var selectedPeer = null, selectedScore = 0;
+    var selectedPeer = null;
+    var selectedScore = 0;
     for (var i = 0; i < hosts.length; i++) {
         var hostPort = hosts[i];
         var peer = self.add(hostPort);

--- a/node/peers.js
+++ b/node/peers.js
@@ -222,7 +222,7 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
     var selectedScore = 0;
     for (var i = 0; i < hosts.length; i++) {
         var hostPort = hosts[i];
-        var peer = self.add(hostPort);
+        var peer = self._map[hostPort];
         if (!req || !req.triedRemoteAddrs[hostPort]) {
             var score = peer.state.shouldRequest(req, options);
             var want = score > threshold &&

--- a/node/peers.js
+++ b/node/peers.js
@@ -42,6 +42,7 @@ function TChannelPeers(channel, options) {
     self.options = options || {};
     self.peerOptions = self.options.peerOptions || {};
     self._map = Object.create(null);
+    self._keys = [];
     self.selfPeer = null;
 }
 
@@ -97,6 +98,7 @@ TChannelPeers.prototype.add = function add(hostPort, options) {
             self.allocPeerEvent.emit(self, peer);
         }
         self._map[hostPort] = peer;
+        self._keys.push(hostPort);
     }
     return peer;
 };
@@ -107,17 +109,18 @@ TChannelPeers.prototype.addPeer = function addPeer(peer) {
     assert(!self._map[peer.hostPort], 'peer already defined');
     if (peer.hostPort !== self.channel.hostPort) {
         self._map[peer.hostPort] = peer;
+        self._keys.push(peer.hostPort);
     }
 };
 
 TChannelPeers.prototype.keys = function keys() {
     var self = this;
-    return Object.keys(self._map);
+    return self._keys.slice();
 };
 
 TChannelPeers.prototype.values = function values() {
     var self = this;
-    var keys = Object.keys(self._map);
+    var keys = self._keys;
     var ret = new Array(keys.length);
     for (var i = 0; i < keys.length; i++) {
         ret[i] = self._map[keys[i]];
@@ -127,7 +130,7 @@ TChannelPeers.prototype.values = function values() {
 
 TChannelPeers.prototype.entries = function entries() {
     var self = this;
-    var keys = Object.keys(self._map);
+    var keys = self._keys;
     var ret = new Array(keys.length);
     for (var i = 0; i < keys.length; i++) {
         ret[i] = [keys[i], self._map[keys[i]]];
@@ -144,23 +147,33 @@ TChannelPeers.prototype.clear = function clear() {
         for (var i = 0; i < names.length; i++) {
             var subChannel = self.channel.subChannels[names[i]];
             subChannel.peers._map = Object.create(null);
+            subChannel.peers._keys = [];
         }
     }
     self._map = Object.create(null);
+    self._keys = [];
     return vals;
 };
 
 TChannelPeers.prototype.delete = function del(hostPort) {
     var self = this;
     var peer = self._map[hostPort];
+
+    if (!peer) {
+        return;
+    }
+
     if (self.channel.subChannels) {
         var names = Object.keys(self.channel.subChannels);
         for (var i = 0; i < names.length; i++) {
             var subChannel = self.channel.subChannels[names[i]];
-            delete subChannel.peers._map[hostPort];
+            subChannel.peers.delete(hostPort);
         }
     }
     delete self._map[hostPort];
+    var index = self._keys.indexOf(hostPort);
+    self._keys.splice(index, 1);
+
     return peer;
 };
 
@@ -182,6 +195,7 @@ TChannelPeers.prototype.request = function peersRequest(req, options) {
 };
 
 TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
+    /*eslint complexity: [2, 15]*/
     var self = this;
 
     if (!options) options = {};

--- a/node/peers.js
+++ b/node/peers.js
@@ -206,7 +206,7 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
     if (options.host) {
         return self.add(options.host);
     } else {
-        hosts = Object.keys(self._map);
+        hosts = self._keys;
     }
 
     if (!hosts || !hosts.length) {


### PR DESCRIPTION
This is another chunk of perf work.

 - Optimize peers to get rid of Object.keys()
 - Make choosePeer() simpler.

r: @kriskowal @shannili @rf