### PR TITLE
go: fix for testutils.SetTimeout not clearing timeout at end of test

### DIFF
--- a/golang/frame_pool_test.go
+++ b/golang/frame_pool_test.go
@@ -70,7 +70,7 @@ func TestFramesReleased(t *testing.T) {
 		return
 	}
 
-	testutils.SetTimeout(t, time.Second*10)
+	defer testutils.SetTimeout(t, 10*time.Second)()
 	const (
 		requestsPerGoroutine = 10
 		numGoroutines        = 10

--- a/golang/hyperbahn/advertise_test.go
+++ b/golang/hyperbahn/advertise_test.go
@@ -111,7 +111,7 @@ func (r *retryTest) setAdvertiseFailure() {
 
 func runRetryTest(t *testing.T, f func(r *retryTest)) {
 	r := &retryTest{}
-	testutils.SetTimeout(t, time.Second)
+	defer testutils.SetTimeout(t, time.Second)()
 	r.setup()
 	defer testutils.ResetSleepStub(&timeSleep)
 


### PR DESCRIPTION
Timeouts were not cleared once tests complete - fix interface to return a func that can be used to clear the timeout.
Track the test name, which is useful when calling panic, as otherwise there's no indication which test failed.

r @mmihic 