### PR TITLE
Operations cleanup for perf

### DIFF
--- a/node/operations.js
+++ b/node/operations.js
@@ -46,8 +46,8 @@ function Operations(opts) {
         out: []
     };
     self.requests = {
-        in: {},
-        out: {}
+        in: Object.create(null),
+        out: Object.create(null)
     };
     self.pending = {
         in: 0,

--- a/node/operations.js
+++ b/node/operations.js
@@ -162,13 +162,13 @@ function logMissingOutRequest(id, context) {
     }
 
     // context is err or res
-    if (context.originalId) {
+    if (context && context.originalId) {
         context = {
             error: context,
             id: context.originalId,
             info: 'got error frame for unknown id'
         };
-    } else if (context.id) {
+    } else if (context && context.id) {
         context = {
             responseId: context.id,
             code: context.code,


### PR DESCRIPTION
Another chunk of perf work.

This generally moves some code out of connection and
into operations to avoid creating an anonymous
objects unless we really want to log them.

r: @kriskowal @rf @shannili