### PR TITLE
out_response: move onFinish into an emitFinish method

### DIFF
--- a/node/streaming_out_response.js
+++ b/node/streaming_out_response.js
@@ -52,7 +52,7 @@ function StreamingOutResponse(id, options) {
     }
 
     function onFinish() {
-        self.finishEvent.emit(self);
+        self.emitFinish();
     }
 }
 
@@ -76,7 +76,7 @@ StreamingOutResponse.prototype.sendError = function sendError(codeString, messag
         self.arg2.end();
         self.arg3.end();
         self._sendError(codeString, message);
-        self.finishEvent.emit(self);
+        self.emitFinish();
     }
 };
 


### PR DESCRIPTION
This is another chunk of perf work. I'm simply inline an
event listener to get rid of a closure

r: @kriskowal @rf @shannili