### PR TITLE
v2/handler: remove unneeded callbacks

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -262,14 +262,12 @@ TChannelConnection.prototype.handlePingResponse = function handlePingResponse(re
 
 TChannelConnection.prototype.handleReadFrame = function handleReadFrame(frame) {
     var self = this;
+
     if (!self.closing) {
         self.ops.lastTimeoutTime = 0;
     }
-    self.handler.handleFrame(frame, handledFrame);
-    function handledFrame(err) {
-        // TODO: move if check to onHandlerError
-        if (err) self.onHandlerError(err);
-    }
+
+    self.handler.handleFrame(frame);
 };
 
 TChannelConnection.prototype.onCallResponse = function onCallResponse(res) {


### PR DESCRIPTION
This one is another one from the perf book.

This one is more dubious; we are removing a callback from
the hot path and replacing the entire error path with a bunch
of event emission.

I'm not sure whether this is ideal (cc @jcorbin)

r: @kriskowal @rf @shannili