### PR TITLE
Create an OutRequest options constructor

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -47,10 +47,16 @@ var TChannelConnection = require('./connection');
 var TChannelPeers = require('./peers');
 var TChannelServices = require('./services');
 var TChannelStatsd = require('./lib/statsd');
+var RetryFlags = require('./retry-flags.js');
 
 var TracingAgent = require('./trace/agent');
 
 var CONN_STALE_PERIOD = 1500;
+var DEFAULT_RETRY_FLAGS = new RetryFlags(
+    /*never:*/ false,
+    /*onConnectionError*/ true,
+    /*onTimeout*/ false
+);
 
 function StatTags(statTags) {
     var self = this;
@@ -492,29 +498,28 @@ function RequestOptions(channel, opts) {
     var self = this;
 
     self.channel = channel;
-    self.services = channel.services;
-    self.logger = channel.logger;
-    self.random = channel.random;
-    self.timers = channel.timers;
-    self.tracer = channel.tracer;
 
     self.host = opts.host || '';
     self.streamed = opts.streamed || false;
-    self.headers = new RequestOptionsHeaders(opts.headers);
     self.timeout = opts.timeout || 0;
     self.retryLimit = opts.retryLimit || 0;
     self.trackPending = opts.trackPending || false;
     self.serviceName = opts.serviceName || '';
-    self.shouldApplicationRetry = opts.shouldApplicationRetry;
     self.checksumType = opts.checksumType || null;
-    self.parent = opts.parent || null;
     self.hasNoParent = opts.hasNoParent || false;
-    self.tracing = opts.tracing || null;
     self.forwardTrace = opts.forwardTrace || false;
     self.trace = typeof opts.trace === 'boolean' ? opts.trace : true;
-    self.retryFlags = opts.retryFlags || null;
+    self.retryFlags = opts.retryFlags || DEFAULT_RETRY_FLAGS;
+    self.shouldApplicationRetry = opts.shouldApplicationRetry || null;
+    self.parent = opts.parent || null;
+    self.tracing = opts.tracing || null;
+    self.peer = opts.peer || null;
+    self.timeoutPerAttempt = opts.timeoutPerAttempt || 0;
 
-    self.retryCount = null;
+    // TODO optimize?
+    self.headers = opts.headers || new RequestHeaders();
+
+    self.retryCount = 0;
     self.logical = false;
     self.peerState = null;
     self.remoteAddr = null;
@@ -522,21 +527,12 @@ function RequestOptions(channel, opts) {
     self.checksum = null;
 }
 
-function RequestOptionsHeaders(headers) {
+function RequestHeaders() {
     var self = this;
 
-    self.cn = headers ? headers.cn : '';
-    self.re = headers ? headers.re : '';
-    self.as = headers ? headers.as : '';
-
-    if (headers) {
-        var keys = Object.keys(headers);
-        for (var i = 0; i < keys.length; i++) {
-            var headerKey = keys[i];
-
-            self[headerKey] = headers[headerKey];
-        }
-    }
+    self.cn = '';
+    self.as = '';
+    self.re = '';
 }
 
 TChannel.prototype._request = function _request(opts) {

--- a/node/connection.js
+++ b/node/connection.js
@@ -424,10 +424,6 @@ TChannelConnection.prototype.onSocketError = function onSocketError(err) {
 TChannelConnection.prototype.buildOutRequest = function buildOutRequest(options) {
     var self = this;
 
-    // TODO: ensure that options has a real constructor
-    options.logger = self.logger;
-    options.random = self.random;
-    options.timers = self.timers;
     return self.handler.buildOutRequest(options);
 };
 

--- a/node/connection.js
+++ b/node/connection.js
@@ -342,7 +342,7 @@ TChannelConnection.prototype.onCallError = function onCallError(err) {
             return;
         }
 
-        req.errorEvent.emit(req, err);
+        req.emitError(err);
     }
 };
 
@@ -550,7 +550,7 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
             err = errors.TChannelConnectionResetError(err, info);
         }
 
-        req.errorEvent.emit(req, err);
+        req.emitError(err);
     });
 
     self.ops.clear();

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -28,7 +28,6 @@ var errors = require('./errors');
 var States = require('./reqres_states');
 var Operations = require('./operations');
 
-var DEFAULT_OUTGOING_REQ_TIMEOUT = 100;
 var CONNECTION_BASE_IDENTIFIER = 0;
 
 function TChannelConnectionBase(channel, direction, socketRemoteAddr) {
@@ -73,27 +72,20 @@ function TChannelConnectionBase(channel, direction, socketRemoteAddr) {
 inherits(TChannelConnectionBase, EventEmitter);
 
 // create a request
-TChannelConnectionBase.prototype.request = function connBaseRequest(options) {
+TChannelConnectionBase.prototype.request =
+function connBaseRequest(options) {
     var self = this;
-    if (!options) options = {};
 
     assert(self.remoteName, 'cannot make request unless identified');
     options.remoteAddr = self.remoteName;
-
-    options.channel = self.channel;
 
     // TODO: use this to protect against >4Mi outstanding messages edge case
     // (e.g. zombie operation bug, incredible throughput, or simply very long
     // timeout
     // assert(!self.requests.out[id], 'duplicate frame id in flight');
-    // TODO: provide some sort of channel default for "service"
-    // TODO: generate tracing if empty?
-    // TODO: refactor callers
-    options.checksumType = options.checksum;
 
-    // TODO: better default, support for dynamic
-    options.ttl = options.timeout || DEFAULT_OUTGOING_REQ_TIMEOUT;
-    options.tracer = self.tracer;
+    // options.checksumType = options.checksum;
+
     var req = self.buildOutRequest(options);
 
     return self.ops.addOutReq(req);

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -36,7 +36,7 @@ function TChannelInRequest(id, options) {
     self.finishEvent = self.defineEvent('finish');
     self.channel = options.channel;
 
-    self.ttl = options.timeout || 0;
+    self.timeout = options.timeout || 0;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
     self.headers = options.headers || {};
@@ -123,7 +123,7 @@ TChannelInRequest.prototype.checkTimeout = function checkTimeout() {
     var self = this;
     if (!self.timedOut) {
         var elapsed = self.channel.timers.now() - self.start;
-        if (elapsed > self.ttl) {
+        if (elapsed > self.timeout) {
             self.timedOut = true;
             // TODO: send an error frame response?
             // TODO: emit error on self.res instead / in additon to?
@@ -133,7 +133,7 @@ TChannelInRequest.prototype.checkTimeout = function checkTimeout() {
                     id: self.id,
                     start: self.start,
                     elapsed: elapsed,
-                    timeout: self.ttl
+                    timeout: self.timeout
                 }));
             });
         }

--- a/node/operations.js
+++ b/node/operations.js
@@ -131,7 +131,7 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
     delete self.requests.out[id];
 
     var now = self.timers.now();
-    var timeout = now + TOMBSTONE_TTL_OFFSET + req.ttl +
+    var timeout = now + TOMBSTONE_TTL_OFFSET + req.timeout +
         self._getTimeoutFuzz();
 
     self.tombstones.out.push(new OperationTombstone(

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+module.exports = TChannelOutRequest;
+
 var assert = require('assert');
 var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
@@ -27,7 +29,6 @@ var parallel = require('run-parallel');
 
 var errors = require('./errors');
 var States = require('./reqres_states');
-var TChannelRequest = require('./request.js');
 
 function TChannelOutRequest(id, options) {
     /*max-statements: [2, 50]*/
@@ -49,7 +50,7 @@ function TChannelOutRequest(id, options) {
     self.hasNoParent = options.hasNoParent || false;
 
     self.remoteAddr = options.remoteAddr || '';
-    self.timeout = options.timeout || TChannelRequest.defaultTimeout;
+    self.timeout = options.timeout || 0;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
     self.headers = options.headers || {};
@@ -574,5 +575,3 @@ TChannelOutRequest.prototype.checkTimeout = function checkTimeout() {
     }
     return self.timedOut;
 };
-
-module.exports = TChannelOutRequest;

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -27,10 +27,11 @@ var parallel = require('run-parallel');
 
 var errors = require('./errors');
 var States = require('./reqres_states');
+var TChannelRequest = require('./request.js');
 
 function TChannelOutRequest(id, options) {
-    options = options || {};
     var self = this;
+
     EventEmitter.call(self);
     self.errorEvent = self.defineEvent('error');
     self.responseEvent = self.defineEvent('response');
@@ -52,7 +53,7 @@ function TChannelOutRequest(id, options) {
     self.remoteAddr = options.remoteAddr;
     self.state = States.Initial;
     self.id = id || 0;
-    self.ttl = options.ttl || 0;
+    self.timeout = options.timeout || TChannelRequest.defaultTimeout;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
     self.headers = options.headers || {};
@@ -558,7 +559,7 @@ TChannelOutRequest.prototype.checkTimeout = function checkTimeout() {
     if (!self.timedOut) {
         var now = self.timers.now();
         var elapsed = now - self.start;
-        if (elapsed > self.ttl) {
+        if (elapsed > self.timeout) {
             self.end = now;
             self.timedOut = true;
             process.nextTick(function deferOutReqTimeoutErrorEmit() {
@@ -566,8 +567,8 @@ TChannelOutRequest.prototype.checkTimeout = function checkTimeout() {
                     id: self.id,
                     start: self.start,
                     elapsed: elapsed,
-                    timeout: self.ttl,
-                    logical: self.logical
+                    logical: self.logical,
+                    timeout: self.timeout
                 }));
             });
         }

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -30,6 +30,7 @@ var States = require('./reqres_states');
 var TChannelRequest = require('./request.js');
 
 function TChannelOutRequest(id, options) {
+    /*max-statements: [2, 50]*/
     var self = this;
 
     EventEmitter.call(self);
@@ -38,21 +39,16 @@ function TChannelOutRequest(id, options) {
     self.finishEvent = self.defineEvent('finish');
 
     assert(options.channel, 'channel required');
+    assert(id, 'id is required');
 
-    self.logger = options.logger;
-    self.random = options.random;
-    self.timers = options.timers;
-    self.retryCount = options.retryCount;
-    self.channel = options.channel;
-    self.logical = !!options.logical;
-    self.parent = options.parent;
-    self.hasNoParent = options.hasNoParent;
+    self.peerState = options.peerState || null;
+    self.retryCount = options.retryCount || 0;
+    self.channel = options.channel || null;
+    self.logical = options.logical || false;
+    self.parent = options.parent || null;
+    self.hasNoParent = options.hasNoParent || false;
 
-    self.start = 0;
-    self.end = 0;
-    self.remoteAddr = options.remoteAddr;
-    self.state = States.Initial;
-    self.id = id || 0;
+    self.remoteAddr = options.remoteAddr || '';
     self.timeout = options.timeout || TChannelRequest.defaultTimeout;
     self.tracing = options.tracing || null;
     self.serviceName = options.serviceName || '';
@@ -61,25 +57,27 @@ function TChannelOutRequest(id, options) {
     self.checksum = options.checksum || null;
     self.forwardTrace = options.forwardTrace || false;
 
+    // All self requests have id 0
+    self.id = id;
+    self.state = States.Initial;
+    self.start = 0;
+    self.end = 0;
     self.streamed = false;
     self.arg1 = null;
-    self.endpoint = null;
+    self.endpoint = '';
     self.arg2 = null;
     self.arg3 = null;
-
-    if (options.tracer && !self.forwardTrace) {
-        // new span with new ids
-        self.setupTracing(options);
-    } else {
-        self.span = null;
-    }
-
+    self.span = null;
     self.err = null;
     self.res = null;
     self.timedOut = false;
 
-    self.errorEvent.on(self.onError);
-    self.responseEvent.on(self.onResponse);
+    if (options.channel.tracer && !self.forwardTrace) {
+        // new span with new ids
+        self.setupTracing(options);
+    }
+
+    self.peerState.onRequest(self);
 }
 
 inherits(TChannelOutRequest, EventEmitter);
@@ -89,7 +87,7 @@ TChannelOutRequest.prototype.type = 'tchannel.outgoing-request';
 TChannelOutRequest.prototype.setupTracing = function setupTracing(options) {
     var self = this;
 
-    self.span = options.tracer.setupNewSpan({
+    self.span = options.channel.tracer.setupNewSpan({
         outgoing: true,
         parentSpan: options.parent && options.parent.span,
         hasNoParent: options.hasNoParent,
@@ -119,25 +117,6 @@ TChannelOutRequest.prototype._sendCallRequestCont = function _sendCallRequestCon
         className: self.constructor.name,
         methodName: '_sendCallRequestCont'
     });
-};
-
-TChannelOutRequest.prototype.onError = function onError(err, self) {
-    if (!self.end) self.end = self.timers.now();
-    self.err = err;
-    self.emitPerAttemptLatency();
-    self.emitPerAttemptErrorStat(err);
-};
-
-TChannelOutRequest.prototype.onResponse = function onResponse(res, self) {
-    if (!self.end) {
-        self.end = self.timers.now();
-    }
-
-    self.res = res;
-    self.res.span = self.span;
-
-    self.emitPerAttemptLatency();
-    self.emitPerAttemptResponseStat(res);
 };
 
 TChannelOutRequest.prototype.emitPerAttemptErrorStat =
@@ -359,11 +338,31 @@ function OutboundCallsLatencyTags(serviceName, cn, endpoint) {
 TChannelOutRequest.prototype.emitError = function emitError(err) {
     var self = this;
 
+    if (!self.end) {
+        self.end = self.channel.timers.now();
+    }
+
+    self.err = err;
+    self.emitPerAttemptLatency();
+    self.emitPerAttemptErrorStat(err);
+    self.peerState.onRequestError(err);
+
     self.errorEvent.emit(self, err);
 };
 
 TChannelOutRequest.prototype.emitResponse = function emitResponse(res) {
     var self = this;
+
+    self.peerState.onRequestHealthy(self);
+    if (!self.end) {
+        self.end = self.channel.timers.now();
+    }
+
+    self.res = res;
+    self.res.span = self.span;
+
+    self.emitPerAttemptLatency();
+    self.emitPerAttemptResponseStat(res);
 
     self.responseEvent.emit(self, res);
 };
@@ -395,7 +394,7 @@ TChannelOutRequest.prototype.sendCallRequestFrame = function sendCallRequestFram
     var self = this;
     switch (self.state) {
         case States.Initial:
-            self.start = self.timers.now();
+            self.start = self.channel.timers.now();
             if (self.span) {
                 self.span.annotate('cs');
             }
@@ -557,7 +556,7 @@ TChannelOutRequest.prototype.hookupCallback = function hookupCallback(callback) 
 TChannelOutRequest.prototype.checkTimeout = function checkTimeout() {
     var self = this;
     if (!self.timedOut) {
-        var now = self.timers.now();
+        var now = self.channel.timers.now();
         var elapsed = now - self.start;
         if (elapsed > self.timeout) {
             self.end = now;

--- a/node/peer.js
+++ b/node/peer.js
@@ -226,8 +226,12 @@ function _waitForIdentified(conn, callback) {
 
 TChannelPeer.prototype.request = function peerRequest(options) {
     var self = this;
+
+    options.peerState = self.state;
+
     var req = self.connect().request(options);
 
+    // TODO remove this and push it down into OutRequest
     self.state.onRequest(req);
 
     req.errorEvent.on(onError);

--- a/node/peer.js
+++ b/node/peer.js
@@ -29,6 +29,7 @@ var net = require('net');
 var TChannelConnection = require('./connection');
 var errors = require('./errors');
 var states = require('./states');
+var Request = require('./request');
 
 var DEFAULT_REPORT_INTERVAL = 1000;
 
@@ -228,6 +229,7 @@ TChannelPeer.prototype.request = function peerRequest(options) {
     var self = this;
 
     options.peerState = self.state;
+    options.timeout = options.timeout || Request.defaultTimeout;
     return self.connect().request(options);
 };
 

--- a/node/peer.js
+++ b/node/peer.js
@@ -228,24 +228,7 @@ TChannelPeer.prototype.request = function peerRequest(options) {
     var self = this;
 
     options.peerState = self.state;
-
-    var req = self.connect().request(options);
-
-    // TODO remove this and push it down into OutRequest
-    self.state.onRequest(req);
-
-    req.errorEvent.on(onError);
-    req.responseEvent.on(onResponse);
-
-    function onError(err) {
-        self.state.onRequestError(err);
-    }
-
-    function onResponse(res) {
-        self.state.onRequestHealthy(req);
-    }
-
-    return req;
+    return self.connect().request(options);
 };
 
 TChannelPeer.prototype.addConnection = function addConnection(conn) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -41,6 +41,7 @@ function TChannelPeers(channel, options) {
     self.logger = self.channel.logger;
     self.options = options || {};
     self.peerOptions = self.options.peerOptions || {};
+    self.peerScoreThreshold = self.options.peerScoreThreshold || 0;
     self._map = Object.create(null);
     self._keys = [];
     self.selfPeer = null;
@@ -187,36 +188,17 @@ function waitForIdentified(options, callback) {
     peer.waitForIdentified(callback);
 };
 
-TChannelPeers.prototype.request = function peersRequest(req, options) {
-    var self = this;
-    var peer = self.choosePeer(req, options);
-    if (!peer) throw errors.NoPeerAvailable(); // TODO: operational error?
-    return peer.request(options);
-};
-
-TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
+TChannelPeers.prototype.choosePeer =
+function choosePeer(req) {
     /*eslint complexity: [2, 15]*/
     var self = this;
 
-    if (!options) {
-        options = {};
-    }
-
-    var hosts = null;
-    if (options.host) {
-        return self.add(options.host);
-    } else {
-        hosts = self._keys;
-    }
-
+    var hosts = self._keys;
     if (!hosts || !hosts.length) {
         return null;
     }
 
-    var threshold = options.peerScoreThreshold;
-    if (threshold === undefined) {
-        threshold = self.options.peerScoreThreshold || 0;
-    }
+    var threshold = self.peerScoreThreshold;
 
     var selectedPeer = null;
     var selectedScore = 0;
@@ -224,7 +206,7 @@ TChannelPeers.prototype.choosePeer = function choosePeer(req, options) {
         var hostPort = hosts[i];
         var peer = self._map[hostPort];
         if (!req || !req.triedRemoteAddrs[hostPort]) {
-            var score = peer.state.shouldRequest(req, options);
+            var score = peer.state.shouldRequest(req);
             var want = score > threshold &&
                        (selectedPeer === null || score > selectedScore);
             if (want) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -25,7 +25,6 @@ var inherits = require('util').inherits;
 var extend = require('xtend');
 var EventEmitter = require('./lib/event_emitter');
 
-var errors = require('./errors');
 var TChannelPeer = require('./peer');
 var TChannelSelfPeer = require('./self_peer');
 

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -111,6 +111,7 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
         timeout: timeout,
         parent: self.inreq,
         tracing: self.inreq.tracing,
+        checksum: self.inreq.checksum,
         forwardTrace: true,
         serviceName: self.inreq.serviceName,
         headers: self.inreq.headers,

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -52,9 +52,11 @@ RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
         });
     }
 
-    self.peer = self.channel.peers.choosePeer(null, {
-        host: host
-    });
+    if (host) {
+        self.peer = self.channel.peers.add(host);
+    } else {
+        self.peer = self.channel.peers.choosePeer(null);
+    }
 
     if (!self.peer) {
         self.onError(errors.NoPeerAvailable());
@@ -101,8 +103,9 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
     }
 
     var elapsed = self.channel.timers.now() - self.inreq.start;
-    var timeout = Math.max(self.inreq.ttl - elapsed, 1);
-    self.outreq = self.peer.request({
+    var timeout = Math.max(self.inreq.timeout - elapsed, 1);
+    // TODO use a type for this literal
+    self.outreq = self.channel.request({
         peer: self.peer,
         streamed: self.inreq.streamed,
         timeout: timeout,

--- a/node/request.js
+++ b/node/request.js
@@ -25,8 +25,8 @@ var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
 
 var TChannelOutRequest = require('./out_request.js');
-var errors = require('./errors');
 var RetryFlags = require('./retry-flags.js');
+var errors = require('./errors');
 
 function TChannelRequest(options) {
     /*eslint max-statements: [2, 40]*/
@@ -39,26 +39,18 @@ function TChannelRequest(options) {
     self.responseEvent = self.defineEvent('response');
 
     self.channel = options.channel;
-    self.services = options.services;
-    self.logger = options.logger;
-    self.random = options.random;
-    self.timers = options.timers;
 
     self.options = options;
-
-    if (!self.options.retryFlags) {
-        self.options.retryFlags = new RetryFlags(
-            /*never:*/ false,
-            /*onConnectionError*/ true,
-            /*onTimeout*/ false
-        );
-    }
 
     self.triedRemoteAddrs = {};
     self.outReqs = [];
     self.timeout = self.options.timeout || TChannelRequest.defaultTimeout;
     if (self.options.timeoutPerAttempt) {
-        self.options.retryFlags.onTimeout = true;
+        self.options.retryFlags = new RetryFlags(
+            self.options.retryFlags.never,
+            self.options.retryFlags.onConnectionError,
+            true
+        );
     }
     self.timeoutPerAttempt = self.options.timeoutPerAttempt || self.timeout;
     self.limit = self.options.retryLimit || TChannelRequest.defaultRetryLimit;
@@ -90,25 +82,25 @@ TChannelRequest.prototype.type = 'tchannel.request';
 
 TChannelRequest.prototype.emitError = function emitError(err) {
     var self = this;
-    if (!self.end) self.end = self.timers.now();
+    if (!self.end) self.end = self.channel.timers.now();
     self.err = err;
 
     TChannelOutRequest.prototype.emitErrorStat.call(self, err);
     TChannelOutRequest.prototype.emitLatency.call(self);
 
-    self.services.onRequestError(self);
+    self.channel.services.onRequestError(self);
     self.errorEvent.emit(self, err);
 };
 
 TChannelRequest.prototype.emitResponse = function emitResponse(res) {
     var self = this;
-    if (!self.end) self.end = self.timers.now();
+    if (!self.end) self.end = self.channel.timers.now();
     self.res = res;
 
     TChannelOutRequest.prototype.emitResponseStat.call(self, res);
     TChannelOutRequest.prototype.emitLatency.call(self);
 
-    self.services.onRequestResponse(self);
+    self.channel.services.onRequestResponse(self);
     self.responseEvent.emit(self, res);
 };
 
@@ -159,12 +151,12 @@ TChannelRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     if (callback) {
         self.hookupCallback(callback);
     }
-    self.start = self.timers.now();
+    self.start = self.channel.timers.now();
     self.resendSanity = self.limit + 1;
 
     TChannelOutRequest.prototype.emitOutboundCallsSent.call(self);
 
-    self.services.onRequest(self);
+    self.channel.services.onRequest(self);
     self.resend();
 };
 
@@ -281,7 +273,7 @@ TChannelRequest.prototype.deferResend = function deferResend() {
 
 TChannelRequest.prototype.checkPending = function checkPending() {
     var self = this;
-    var err = self.services.errorIfExceedsMaxPending(self);
+    var err = self.channel.services.errorIfExceedsMaxPending(self);
     if (err) {
         self.emitError(err);
         return true;
@@ -291,7 +283,7 @@ TChannelRequest.prototype.checkPending = function checkPending() {
 
 TChannelRequest.prototype.checkTimeout = function checkTimeout(err, res) {
     var self = this;
-    var now = self.timers.now();
+    var now = self.channel.timers.now();
     self.elapsed = now - self.start;
     if (self.elapsed < self.timeout) return false;
 
@@ -346,7 +338,7 @@ TChannelRequest.prototype.shouldRetryError = function shouldRetryError(err) {
                 return !!self.options.retryFlags.onConnectionError;
 
             default:
-                self.logger.error('unknown error type in request retry', {
+                self.channel.logger.error('unknown error type in request retry', {
                     error: err
                 });
                 return true;

--- a/node/request.js
+++ b/node/request.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+module.exports = TChannelRequest;
+
 var assert = require('assert');
 var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
@@ -365,5 +367,3 @@ TChannelRequest.prototype.maybeAppRetry = function maybeAppRetry(res) {
         }
     }
 };
-
-module.exports = TChannelRequest;

--- a/node/retry-flags.js
+++ b/node/retry-flags.js
@@ -20,33 +20,12 @@
 
 'use strict';
 
-var allocCluster = require('./lib/alloc-cluster.js');
+module.exports = RetryFlags;
 
-allocCluster.test('ping with a remote connection', 2, function t(cluster, assert) {
-    var client = cluster.channels[0];
-    var server = cluster.channels[1];
-    var peer = client.peers.add(server.hostPort);
-    var conn = peer.connect();
-    conn.pingResponseEvent.on(function onResponse(res) {
-        assert.equals(res.id, conn.handler.lastSentFrameId,
-            'validate ping response id');
-        server.close();
-        assert.end();
-    });
+function RetryFlags(never, onConnectionError, onTimeout) {
+    var self = this;
 
-    conn.ping();
-});
-
-allocCluster.test('ping with a self connection', 1, function t(cluster, assert) {
-    var server = cluster.channels[0];
-    var peer = server.peers.add(server.hostPort);
-    var conn = peer.connect();
-    conn.pingResponseEvent.on(function onResponse(res) {
-        assert.equals(res.id, conn.idCount - 1,
-            'validate ping response id');
-        server.close();
-        assert.end();
-    });
-
-    conn.ping();
-});
+    self.never = never;
+    self.onConnectionError = onConnectionError;
+    self.onTimeout = onTimeout;
+}

--- a/node/self_connection.js
+++ b/node/self_connection.js
@@ -45,11 +45,7 @@ inherits(TChannelSelfConnection, TChannelConnectionBase);
 TChannelSelfConnection.prototype.buildOutRequest = function buildOutRequest(options) {
     var self = this;
     var id = self.idCount++;
-    if (!options) options = {};
-    options.logger = self.logger;
-    options.random = self.random;
-    options.timers = self.timers;
-    options.tracer = self.tracer;
+
     options.hostPort = self.channel.hostPort;
     var outreq;
     if (options.streamed) {

--- a/node/self_connection.js
+++ b/node/self_connection.js
@@ -35,7 +35,7 @@ function TChannelSelfConnection(channel) {
     }
     var self = this;
     TChannelConnectionBase.call(self, channel, 'in', channel.hostPort);
-    self.idCount = 0;
+    self.idCount = 1;
 
     // populate the remoteName as self
     self.remoteName = channel.hostPort;
@@ -47,6 +47,7 @@ TChannelSelfConnection.prototype.buildOutRequest = function buildOutRequest(opti
     var id = self.idCount++;
 
     options.hostPort = self.channel.hostPort;
+
     var outreq;
     if (options.streamed) {
         outreq = new StreamingOutRequest(self, id, options);

--- a/node/self_out_response.js
+++ b/node/self_out_response.js
@@ -93,7 +93,7 @@ function passError(codeString, message) {
     process.nextTick(emitError);
 
     function emitError() {
-        self.inreq.outreq.errorEvent.emit(self.inreq.outreq, err);
+        self.inreq.outreq.emitError(err);
     }
 };
 

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -42,9 +42,11 @@ allocCluster.test('request() with zero timeout', {
         var peer = subTwo.peers.add(one.hostPort);
         var conn = peer.connect();
 
+        // fff magic test
         var req = conn.buildOutRequest({
             channel: conn.channel,
             remoteAddr: conn.remoteName,
+            peerState: peer.state,
             timeout: 0,
             tracer: conn.tracer,
             serviceName: 'server',
@@ -105,6 +107,7 @@ allocCluster.test('request() with zero timeout', {
         var req = conn.buildOutRequest({
             channel: conn.channel,
             remoteAddr: conn.remoteName,
+            peerState: peer.state,
             timeout: -10,
             tracer: conn.tracer,
             serviceName: 'server',

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -45,11 +45,13 @@ allocCluster.test('request() with zero timeout', {
         var req = conn.buildOutRequest({
             channel: conn.channel,
             remoteAddr: conn.remoteName,
-            ttl: 0,
+            timeout: 0,
             tracer: conn.tracer,
             serviceName: 'server',
             host: one.hostPort,
             hasNoParent: true,
+            checksumType: null,
+            timers: conn.channel.timers,
             headers: {
                 'as': 'raw',
                 'cn': 'wat'
@@ -103,10 +105,12 @@ allocCluster.test('request() with zero timeout', {
         var req = conn.buildOutRequest({
             channel: conn.channel,
             remoteAddr: conn.remoteName,
-            ttl: -10,
+            timeout: -10,
             tracer: conn.tracer,
             serviceName: 'server',
             host: one.hostPort,
+            checksumType: null,
+            timers: conn.channel.timers,
             hasNoParent: true,
             headers: {
                 'as': 'raw',

--- a/node/test/peer.js
+++ b/node/test/peer.js
@@ -56,8 +56,14 @@ allocCluster.test('peer should use the identified connection', {
             function noThrow() {
                 subClient.request({
                     host: peer.hostPort,
-                    hasNoParent: true
-                });
+                    hasNoParent: true,
+                    headers: {
+                        as: 'wat',
+                        cn: 'hi'
+                    }
+                }).send('', '', '', noop);
+
+                function noop() {}
             },
             'should use the identified connection'
         );

--- a/node/test/peer.js
+++ b/node/test/peer.js
@@ -54,7 +54,10 @@ allocCluster.test('peer should use the identified connection', {
         peer.addConnection(conn);
         assert.doesNotThrow(
             function noThrow() {
-                peer.request({hasNoParent: true});
+                subClient.request({
+                    host: peer.hostPort,
+                    hasNoParent: true
+                });
             },
             'should use the identified connection'
         );

--- a/node/test/relay.js
+++ b/node/test/relay.js
@@ -142,7 +142,7 @@ allocCluster.test('relay respects ttl', {
     });
     destChan.register('echoTTL', function echoTTL(req, res) {
         res.headers.as = 'raw';
-        res.sendOk(null, String(req.ttl));
+        res.sendOk(null, String(req.timeout));
     });
 
     var sourceChan = source.makeSubChannel({

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -221,13 +221,13 @@ allocCluster.test('emits stats on p2p call success', {
             type: 'c',
             name: 'tchannel.outbound.request.size.inPipe.reservoir.Reservoir--get',
             value: null,
-            delta: 108,
+            delta: 109,
             time: null
         }, {
             type: 'c',
             name: 'tchannel.connections.bytes-sent.localhost',
             value: null,
-            delta: 108,
+            delta: 109,
             time: null
         }, {
             type: 'c',

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -86,7 +86,6 @@ allocCluster.test('emits stats on response ok', {
             return assert.end(err);
         }
         assert.ok(res.ok, 'res should be ok');
-        console.log(statsd._buffer._elements);
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
             name: 'tchannel.connections.accepted.' + clientHost,

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -441,7 +441,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
                 isErrorFrame: true,
                 codeName: 'Cancelled',
                 errorCode: 2,
-                originalId: 0,
+                originalId: 1,
                 name: 'TchannelCancelledError',
                 message: 'bye lol'
             });
@@ -467,7 +467,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
                 isErrorFrame: true,
                 codeName: 'Unhealthy',
                 errorCode: 8,
-                originalId: 1,
+                originalId: 2,
                 name: 'TchannelUnhealthyError',
                 message: 'smallest violin'
             });

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -588,11 +588,13 @@ function sendCallRequestFrame(req, flags, args) {
         return;
     }
     var reqBody = new v2.CallRequest(
-        flags, req.ttl, req.tracing, req.serviceName, req.headers,
+        flags, req.timeout, req.tracing, req.serviceName, req.headers,
         req.checksum.type, args
     );
 
-    self.verifyCallRequestFrame(req);
+    if (!self.verifyCallRequestFrame(req, args)) {
+        return;
+    }
 
     var result = self._sendCallBodies(req.id, reqBody, null);
     req.checksum = result.checksum;
@@ -622,7 +624,7 @@ function sendCallRequestFrame(req, flags, args) {
 };
 
 TChannelV2Handler.prototype.verifyCallRequestFrame =
-function verifyCallRequestFrame(req) {
+function verifyCallRequestFrame(req, args) {
     var self = this;
 
     var message;
@@ -656,6 +658,8 @@ function verifyCallRequestFrame(req) {
             socketRemoteAddr: self.connection.socketRemoteAddr
         });
     }
+
+    return true;
 };
 
 function OutboundRequestSizeTags(serviceName, cn, endpoint) {
@@ -886,12 +890,14 @@ TChannelV2Handler.prototype.sendErrorFrame = function sendErrorFrame(r, codeStri
 TChannelV2Handler.prototype.buildOutRequest = function buildOutRequest(options) {
     var self = this;
     var id = self.nextFrameId();
-    if (options.checksumType === undefined || options.checksumType === null) {
+
+    if (options.checksumType === null) {
         options.checksumType = v2.Checksum.Types.CRC32C;
     }
+
     options.checksum = new v2.Checksum(options.checksumType);
-    if (!options.headers) options.headers = {};
     options.headers.re = v2.encodeRetryFlags(options.retryFlags);
+
     if (options.streamed) {
         return new StreamingOutRequest(self, id, options);
     } else {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -894,9 +894,12 @@ TChannelV2Handler.prototype.buildOutRequest = function buildOutRequest(options) 
     if (options.checksumType === null) {
         options.checksumType = v2.Checksum.Types.CRC32C;
     }
-
-    options.checksum = new v2.Checksum(options.checksumType);
-    options.headers.re = v2.encodeRetryFlags(options.retryFlags);
+    if (!options.checksum) {
+        options.checksum = new v2.Checksum(options.checksumType);
+    }
+    if (!options.headers.re) {
+        options.headers.re = v2.encodeRetryFlags(options.retryFlags);
+    }
 
     if (options.streamed) {
         return new StreamingOutRequest(self, id, options);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -39,6 +39,8 @@ var errors = require('../errors');
 
 var SERVER_TIMEOUT_DEFAULT = 100;
 
+/* jshint maxparams:10 */
+
 module.exports = TChannelV2Handler;
 
 function TChannelV2Handler(options) {

--- a/node/v2/index.js
+++ b/node/v2/index.js
@@ -25,6 +25,7 @@ module.exports.VERSION = 2;
 var Types = {};
 module.exports.Types = Types;
 
+var RetryFlags = require('../retry-flags.js');
 var Frame = require('./frame');
 
 module.exports.CallFlags = require('./call_flags');
@@ -90,14 +91,6 @@ module.exports.parseRetryFlags = function parseRetryFlags(val) {
         never, onConnectionError, onTimeout
     );
 };
-
-function RetryFlags(never, onConnectionError, onTimeout) {
-    var self = this;
-
-    self.never = never;
-    self.onConnectionError = onConnectionError;
-    self.onTimeout = onTimeout;
-}
 
 module.exports.encodeRetryFlags = function encodeRetryFlags(retryFlags) {
     if (!retryFlags) return '';

--- a/node/v2/out_request.js
+++ b/node/v2/out_request.js
@@ -32,6 +32,7 @@ var errors = require('../errors');
 function V2OutRequest(handler, id, options) {
     var self = this;
     OutRequest.call(self, id, options);
+
     self.handler = handler;
 }
 
@@ -40,6 +41,7 @@ inherits(V2OutRequest, OutRequest);
 function V2StreamingOutRequest(handler, id, options) {
     var self = this;
     StreamingOutRequest.call(self, id, options);
+
     self.handler = handler;
 }
 
@@ -50,14 +52,18 @@ V2StreamingOutRequest.prototype._sendCallRequest =
 function _sendCallRequest(args, isLast) {
     var self = this;
     var flags = 0;
-    if (!isLast) flags |= CallFlags.Fragment;
+    if (!isLast) {
+        flags |= CallFlags.Fragment;
+    }
+
     if (args && args[0] && args[0].length > v2.CallRequest.MaxArg1Size) {
         self.errorEvent.emit(self, errors.Arg1OverLengthLimit({
                 length: '0x' + args[0].length.toString(16),
                 limit: '0x' + v2.CallRequest.MaxArg1Size.toString(16)
         }));
-        return;
+        return false;
     }
+
     self.handler.sendCallRequestFrame(self, flags, args);
 };
 
@@ -66,7 +72,10 @@ V2StreamingOutRequest.prototype._sendCallRequestCont =
 function _sendCallRequestCont(args, isLast) {
     var self = this;
     var flags = 0;
-    if (!isLast) flags |= CallFlags.Fragment;
+    if (!isLast) {
+        flags |= CallFlags.Fragment;
+    }
+
     self.handler.sendCallRequestContFrame(self, flags, args);
 };
 


### PR DESCRIPTION
This is the most significant change after the stats
change in the perf branch. This is also the last PR
related to the perf branch

 - Use a constructor for out request options; this should
    give a lot more stability
 - Optimize the request defaults code path by avoiding
    copies and unrolling the loop.

r: @shannili @rf @kriskowal