### PR TITLE
Improve benchmarks to be more like prod

### DIFF
--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -39,13 +39,14 @@ assert(argv.traceRelayHostPort, 'traceRelayHostPort needed');
 assert(argv.port, 'port needed');
 assert(argv.instances, 'instances needed');
 
-function BenchServer() {
+function BenchServer(port) {
     if (!(this instanceof BenchServer)) {
-        return new BenchServer();
+        return new BenchServer(port);
     }
 
     var self = this;
 
+    self.port = port;
     self.server = TChannel({
         statTags: {
             app: 'my-server'
@@ -120,10 +121,10 @@ BenchServer.prototype.registerEndpoints = function registerEndpoints() {
 BenchServer.prototype.listen = function listen() {
     var self = this;
 
-    self.server.listen(argv.port, '127.0.0.1');
+    self.server.listen(self.port, '127.0.0.1');
 };
 
-var benchServer = BenchServer();
+var benchServer = BenchServer(argv.port);
 benchServer.listen();
 
 // setInterval(function () {

--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -39,6 +39,8 @@ assert(argv.traceRelayHostPort, 'traceRelayHostPort needed');
 assert(argv.port, 'port needed');
 assert(argv.instances, 'instances needed');
 
+var INSTANCES = parseInt(argv.instances, 10);
+
 function BenchServer(port) {
     if (!(this instanceof BenchServer)) {
         return new BenchServer(port);
@@ -124,8 +126,12 @@ BenchServer.prototype.listen = function listen() {
     self.server.listen(self.port, '127.0.0.1');
 };
 
-var benchServer = BenchServer(argv.port);
-benchServer.listen();
+for (var i = 0; i < INSTANCES; i++) {
+    var port = parseInt(argv.port, 10) + i;
+
+    var benchServer = BenchServer(port);
+    benchServer.listen();
+}
 
 // setInterval(function () {
 //  Object.keys(keys).forEach(function (key) {

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -54,9 +54,18 @@ function run(script, args) {
     return child;
 }
 
+var SERVER_PORT = 7100;
+var TRACE_SERVER_PORT = 7039;
+var RELAY_SERVER_PORT = 7038;
+var RELAY_TRACE_PORT = 7037;
+var STATSD_PORT = 7036;
+var INSTANCE_COUNT = 72;
+
 var serverProc = run(server, [
     argv.trace ? '--trace' : '--no-trace',
-    '--traceRelayHostPort', '127.0.0.1:7037'
+    '--traceRelayHostPort', '127.0.0.1:' + RELAY_TRACE_PORT,
+    '--port', String(SERVER_PORT),
+    '--instances', String(INSTANCE_COUNT)
 ]);
 serverProc.stdout.pipe(process.stderr);
 serverProc.stderr.pipe(process.stderr);
@@ -78,10 +87,10 @@ if (argv.relay || argv.trace) {
 
 function startRelayServers() {
     benchRelayProc = run(relay, [
-        '--benchPort', '7040',
-        '--tracePort', '7039',
-        '--benchRelayPort', '7038',
-        '--traceRelayPort', '7037',
+        '--benchPort', String(SERVER_PORT),
+        '--tracePort', String(TRACE_SERVER_PORT),
+        '--benchRelayPort', String(RELAY_SERVER_PORT),
+        '--traceRelayPort', String(RELAY_TRACE_PORT),
         '--type', 'bench-relay',
         argv.trace ? '--trace' : '--no-trace',
         argv.debug ? '--debug' : '--no-debug'
@@ -91,10 +100,10 @@ function startRelayServers() {
 
     if (argv.trace) {
         traceRelayProc = run(relay, [
-            '--benchPort', '7040',
-            '--tracePort', '7039',
-            '--benchRelayPort', '7038',
-            '--traceRelayPort', '7037',
+            '--benchPort', String(SERVER_PORT),
+            '--tracePort', String(TRACE_SERVER_PORT),
+            '--benchRelayPort', String(RELAY_SERVER_PORT),
+            '--traceRelayPort', String(RELAY_TRACE_PORT),
             '--type', 'trace-relay',
             argv.trace ? '--trace' : '--no-trace',
             argv.debug ? '--debug' : '--no-debug'
@@ -107,7 +116,11 @@ function startRelayServers() {
 }
 
 function startBench() {
-    var benchProc = run(bench, argv['--']);
+    var args = argv['--'];
+    args = args.concat([
+        '--benchPort', String(SERVER_PORT)
+    ]);
+    var benchProc = run(bench, args);
     benchProc.stderr.pipe(process.stderr);
 
     benchProc.stdout

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -31,6 +31,7 @@ var process = require('process');
 var console = require('console');
 var setTimeout = require('timers').setTimeout;
 var assert = require('assert');
+var dgram = require('dgram');
 
 var server = path.join(__dirname, 'bench_server.js');
 var relay = path.join(__dirname, 'relay_server.js');
@@ -60,6 +61,9 @@ var RELAY_SERVER_PORT = 7038;
 var RELAY_TRACE_PORT = 7037;
 var STATSD_PORT = 7036;
 var INSTANCE_COUNT = 72;
+
+var statsdServer = dgram.createSocket('udp4');
+statsdServer.bind(STATSD_PORT);
 
 var serverProc = run(server, [
     argv.trace ? '--trace' : '--no-trace',
@@ -197,6 +201,7 @@ function startBench() {
         if (benchRelayProc) {
             benchRelayProc.kill();
         }
+        statsdServer.close();
     });
 }
 

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -96,6 +96,7 @@ function startRelayServers() {
         '--benchRelayPort', String(RELAY_SERVER_PORT),
         '--traceRelayPort', String(RELAY_TRACE_PORT),
         '--type', 'bench-relay',
+        '--instances', String(INSTANCE_COUNT),
         argv.trace ? '--trace' : '--no-trace',
         argv.debug ? '--debug' : '--no-debug'
     ]);
@@ -109,6 +110,7 @@ function startRelayServers() {
             '--benchRelayPort', String(RELAY_SERVER_PORT),
             '--traceRelayPort', String(RELAY_TRACE_PORT),
             '--type', 'trace-relay',
+            '--instances', String(INSTANCE_COUNT),
             argv.trace ? '--trace' : '--no-trace',
             argv.debug ? '--debug' : '--no-debug'
         ]);

--- a/node/benchmarks/multi_bench.js
+++ b/node/benchmarks/multi_bench.js
@@ -64,7 +64,7 @@ var TRACE_SERVER;
 if (argv.relay) {
     DESTINATION_SERVER = '127.0.0.1:7038';
 } else {
-    DESTINATION_SERVER = '127.0.0.1:7040';
+    DESTINATION_SERVER = '127.0.0.1:' + argv.benchPort;
 }
 
 if (argv.trace) {

--- a/node/benchmarks/multi_bench.js
+++ b/node/benchmarks/multi_bench.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var async = require('async');
-var NullStatsd = require('uber-statsd-client/null');
+var Statsd = require('uber-statsd-client');
 var metrics = require('metrics');
 var parseArgs = require('minimist');
 var process = require('process');
@@ -126,7 +126,10 @@ Test.prototype.newClient = function (id, callback) {
             app: 'my-client'
         },
         trace: true,
-        statsd: NullStatsd()
+        statsd: new Statsd({
+            host: '127.0.0.1',
+            port: 7036
+        })
     });
     if (argv.trace) {
         var reporter = Reporter({

--- a/node/benchmarks/relay_server.js
+++ b/node/benchmarks/relay_server.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var NullStatsd = require('uber-statsd-client/null');
+var Statsd = require('uber-statsd-client');
 var parseArgs = require('minimist');
 var process = require('process');
 var assert = require('assert');
@@ -72,7 +72,10 @@ function RelayServer(opts) {
         },
         logger: opts.debug ? require('debug-logtron')('relay') : null,
         trace: false,
-        statsd: NullStatsd()
+        statsd: new Statsd({
+            host: '127.0.0.1',
+            port: 7036
+        })
     });
     self.relay.handler = ServiceProxy({
         channel: self.relay,

--- a/node/benchmarks/relay_server.js
+++ b/node/benchmarks/relay_server.js
@@ -98,6 +98,7 @@ function RelayServer(opts) {
         null;
 
     self.type = opts.type;
+    self.instances = opts.instances;
 
     self.relay.handler.createServiceChannel(self.serviceName);
     self.relay.listen(self.port, '127.0.0.1', onListen);
@@ -111,10 +112,13 @@ RelayServer.prototype.connect = function connect() {
     var self = this;
 
     var basePort = parseInt(self.targetPort, 10);
-    var targetHostPort = '127.0.0.1:' + basePort;
 
-    var peer = self.relay.handler.getServicePeer(
-        self.serviceName, targetHostPort
-    );
-    peer.connect();
+    for (var i = 0; i < self.instances; i++) {
+        var targetHostPort = '127.0.0.1:' + (basePort + i);
+
+        var peer = self.relay.handler.getServicePeer(
+            self.serviceName, targetHostPort
+        );
+        peer.connect();
+    }
 };

--- a/node/benchmarks/relay_server.js
+++ b/node/benchmarks/relay_server.js
@@ -26,7 +26,6 @@ var process = require('process');
 var assert = require('assert');
 
 var TChannel = require('../channel.js');
-var Reporter = require('../tcollector/reporter.js');
 var ServiceProxy = require('../hyperbahn/service_proxy.js');
 var FakeEgressNodes = require('../test/lib/fake-egress-nodes.js');
 
@@ -89,31 +88,6 @@ function RelayServer(opts) {
             }
         })
     });
-
-    self.tcollectorChannel = TChannel({
-        trace: false,
-        statsd: NullStatsd(),
-        logger: self.relay.logger,
-        statTags: {
-            app: 'relay-server'
-        }
-    });
-    self.reporter = Reporter({
-        channel: self.tcollectorChannel.makeSubChannel({
-            serviceName: 'tcollector',
-            peers: [traceRelayHostPort]
-        }),
-        logger: self.relay.logger,
-        callerName: opts.type
-    });
-
-    // if (opts.trace) {
-    //     self.relay.tracer.reporter = function report(span) {
-    //         self.reporter.report(span, {
-    //             timeout: 10 * 1000
-    //         });
-    //     };
-    // }
 
     if (opts.type === 'bench-relay') {
         self.relay.handler.createServiceChannel('benchmark');

--- a/node/benchmarks/trace_server.js
+++ b/node/benchmarks/trace_server.js
@@ -23,7 +23,7 @@
 var process = require('process');
 process.title = 'nodejs-benchmarks-trace_server';
 
-var NullStatsd = require('uber-statsd-client/null');
+var Statsd = require('uber-statsd-client');
 var Buffer = require('buffer').Buffer;
 
 var TChannel = require('../channel');
@@ -32,7 +32,10 @@ var server = TChannel({
         app: 'tcollector'
     },
     trace: false,
-    statsd: NullStatsd()
+    statsd: new Statsd({
+        host: '127.0.0.1',
+        port: 7036
+    })
 });
 
 var tcollectorChan = server.makeSubChannel({


### PR DESCRIPTION
Another attempt at making the local flames and the
production flames look the same

 - Use a real statsd client
 - Use N instances rather then 1.

r: @kriskowal @shannili @jcorbin