### PR TITLE
Node: make connection metrics optional

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -140,6 +140,9 @@ function TChannel(options) {
     self.initTimeout = self.options.initTimeout || 2000;
     self.requireAs = self.options.requireAs;
     self.requireCn = self.options.requireCn;
+    self.emitConnectionMetrics =
+        typeof self.options.emitConnectionMetrics === 'boolean' ?
+        self.options.emitConnectionMetrics : true;
 
     // Filled in by the listen call:
     self.host = null;

--- a/node/peer.js
+++ b/node/peer.js
@@ -82,10 +82,12 @@ function TChannelPeer(channel, hostPort, options) {
         }
 
         var count = self.countConnections('out');
-        self.channel.connectionsActiveStat.update(count, {
-            'host-port': self.channel.hostPort,
-            'peer-host-port': self.hostPort
-        });
+        if (self.channel.emitConnectionMetrics) {
+            self.channel.connectionsActiveStat.update(count, {
+                'host-port': self.channel.hostPort,
+                'peer-host-port': self.hostPort
+            });
+        }
 
         self.reportTimer = self.stateOptions.timers.setTimeout(
             onReport, self.reportInterval

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -268,9 +268,6 @@ allocCluster.test('emits stats with no connection metrics', {
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
     var client = cluster.channels[1];
-    var serverHost = cluster.hosts[0]
-        .split(':')[0]
-        .replace(/\./g, '-');
     var statsd = nullStatsd(9);
 
     server.makeSubChannel({
@@ -318,12 +315,6 @@ allocCluster.test('emits stats with no connection metrics', {
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
             name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',
-            value: null,
-            delta: 1,
-            time: null
-        }, {
-            type: 'c',
-            name: 'tchannel.connections.initiated.' + serverHost,
             value: null,
             delta: 1,
             time: null

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -259,6 +259,110 @@ allocCluster.test('emits stats on p2p call success', {
     }
 });
 
+allocCluster.test('emits stats with no connection metrics', {
+    numPeers: 2,
+    channelOptions: {
+        timers: timers,
+        emitConnectionMetrics: false
+    }
+}, function t(cluster, assert) {
+    var server = cluster.channels[0];
+    var client = cluster.channels[1];
+    var serverHost = cluster.hosts[0]
+        .split(':')[0]
+        .replace(/\./g, '-');
+    var statsd = nullStatsd(9);
+
+    server.makeSubChannel({
+        serviceName: 'reservoir'
+    }).register('Reservoir::get', function get(req, res, h, b) {
+        timers.setTimeout(function onSend() {
+            res.headers.as = 'raw';
+            res.sendOk(h, b);
+        }, 500);
+        timers.advance(500);
+    });
+
+    client.statTags = client.options.statTags = {
+        app: 'pool',
+        host: os.hostname(),
+        cluster: 'c0',
+        version: '1.0'
+    };
+    client.channelStatsd = new TChannelStatsd(client, statsd);
+    var clientChan = client.makeSubChannel({
+        serviceName: 'reservoir',
+        peers: [server.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            },
+            timeout: 1000
+        }
+    });
+
+    clientChan.request({
+        serviceName: 'reservoir',
+        hasNoParent: true,
+        headers: {
+            cn: 'inPipe'
+        }
+    }).send('Reservoir::get', 'ton', '20', onResponse);
+
+    function onResponse(err, res, arg2, arg3) {
+        if (err) {
+            return assert.end(err);
+        }
+        assert.ok(res.ok, 'res should be ok');
+        assert.deepEqual(statsd._buffer._elements, [{
+            type: 'c',
+            name: 'tchannel.outbound.calls.sent.inPipe.reservoir.Reservoir--get',
+            value: null,
+            delta: 1,
+            time: null
+        }, {
+            type: 'c',
+            name: 'tchannel.connections.initiated.' + serverHost,
+            value: null,
+            delta: 1,
+            time: null
+        }, {
+            type: 'c',
+            name: 'tchannel.outbound.request.size.inPipe.reservoir.Reservoir--get',
+            value: null,
+            delta: 109,
+            time: null
+        }, {
+            type: 'c',
+            name: 'tchannel.inbound.response.size.inPipe.reservoir.Reservoir--get',
+            value: null,
+            delta: 67,
+            time: null
+        }, {
+            type: 'ms',
+            name: 'tchannel.outbound.calls.per-attempt-latency.inPipe.reservoir.Reservoir--get.0',
+            value: null,
+            delta: null,
+            time: 500
+        }, {
+            type: 'c',
+            name: 'tchannel.outbound.calls.success.inPipe.reservoir.Reservoir--get',
+            value: null,
+            delta: 1,
+            time: null
+        }, {
+            type: 'ms',
+            name: 'tchannel.outbound.calls.latency.inPipe.reservoir.Reservoir--get',
+            value: null,
+            delta: null,
+            time: 500
+        }], 'stats keys/values as expected');
+
+        assert.end();
+    }
+});
+
 allocCluster.test('emits stats on call failure', {
     numPeers: 2,
     channelOptions: {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -220,15 +220,17 @@ function emitBytesRecvd(frame) {
     var self = this;
 
     var channel = self.connection.channel;
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-recvd',
-        'counter',
-        frame.size,
-        new ConnectionsBytesRcvdTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    if (channel.emitConnectionMetrics) {
+        channel.emitFastStat(channel.buildStat(
+            'connections.bytes-recvd',
+            'counter',
+            frame.size,
+            new ConnectionsBytesRcvdTags(
+                channel.hostPort || '0.0.0.0:0',
+                self.connection.socketRemoteAddr
+            )
+        ));
+    }
 };
 
 function InboundRequestSizeTags(cn, serviceName, endpoint) {
@@ -604,15 +606,17 @@ function emitBytesSent(result) {
     var self = this;
 
     var channel = self.connection.channel;
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-sent',
-        'counter',
-        result.size,
-        new ConnectionsBytesSentTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    if (channel.emitConnectionMetrics) {
+        channel.emitFastStat(channel.buildStat(
+            'connections.bytes-sent',
+            'counter',
+            result.size,
+            new ConnectionsBytesSentTags(
+                channel.hostPort || '0.0.0.0:0',
+                self.connection.socketRemoteAddr
+            )
+        ));
+    }
 };
 
 TChannelV2Handler.prototype.verifyCallRequestFrame =

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -212,16 +212,23 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         )
     ));
 
+    self.emitBytesRecvd(reqFrame);
+};
+
+TChannelV2Handler.prototype.emitBytesRecvd =
+function emitBytesRecvd(frame) {
+    var self = this;
+
+    var channel = self.connection.channel;
     channel.emitFastStat(channel.buildStat(
         'connections.bytes-recvd',
         'counter',
-        reqFrame.size,
+        frame.size,
         new ConnectionsBytesRcvdTags(
             channel.hostPort || '0.0.0.0:0',
             self.connection.socketRemoteAddr
         )
     ));
-
 };
 
 function InboundRequestSizeTags(cn, serviceName, endpoint) {
@@ -333,15 +340,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-recvd',
-        'counter',
-        resFrame.size,
-        new ConnectionsBytesRcvdTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    self.emitBytesRecvd(resFrame);
 
     res.remoteAddr = self.remoteName;
     var handled = self._handleCallFrame(res, resFrame);
@@ -433,16 +432,7 @@ TChannelV2Handler.prototype.handleCallRequestCont = function handleCallRequestCo
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-recvd',
-        'counter',
-        reqFrame.size,
-        new ConnectionsBytesRcvdTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
-
+    self.emitBytesRecvd(reqFrame);
 };
 
 TChannelV2Handler.prototype.handleCallResponseCont = function handleCallResponseCont(resFrame) {
@@ -470,15 +460,7 @@ TChannelV2Handler.prototype.handleCallResponseCont = function handleCallResponse
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-recvd',
-        'counter',
-        resFrame.size,
-        new ConnectionsBytesRcvdTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    self.emitBytesRecvd(resFrame);
 
     self._handleCallFrame(res, resFrame);
 };
@@ -614,6 +596,14 @@ function sendCallRequestFrame(req, flags, args) {
         )
     ));
 
+    self.emitBytesSent(result);
+};
+
+TChannelV2Handler.prototype.emitBytesSent =
+function emitBytesSent(result) {
+    var self = this;
+
+    var channel = self.connection.channel;
     channel.emitFastStat(channel.buildStat(
         'connections.bytes-sent',
         'counter',
@@ -720,15 +710,7 @@ TChannelV2Handler.prototype.sendCallResponseFrame = function sendCallResponseFra
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-sent',
-        'counter',
-        result.size,
-        new ConnectionsBytesSentTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    self.emitBytesSent(result);
 };
 
 function OutboundResponseSizeTags(serviceName, cn, endpoint) {
@@ -785,15 +767,7 @@ TChannelV2Handler.prototype.sendCallRequestContFrame = function sendCallRequestC
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-sent',
-        'counter',
-        result.size,
-        new ConnectionsBytesSentTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    self.emitBytesSent(result);
 };
 
 TChannelV2Handler.prototype.sendCallResponseContFrame = function sendCallResponseContFrame(res, flags, args) {
@@ -820,15 +794,7 @@ TChannelV2Handler.prototype.sendCallResponseContFrame = function sendCallRespons
         )
     ));
 
-    channel.emitFastStat(channel.buildStat(
-        'connections.bytes-sent',
-        'counter',
-        result.size,
-        new ConnectionsBytesSentTags(
-            channel.hostPort || '0.0.0.0:0',
-            self.connection.socketRemoteAddr
-        )
-    ));
+    self.emitBytesSent(result);
 };
 
 TChannelV2Handler.prototype._sendCallBodies = function _sendCallBodies(id, body, checksum) {


### PR DESCRIPTION
This PR allows you to turn connection metrics off. Specifically
the bytes recvd/sent and the gauge are expensive.

r: @kriskowal @shannili @rf