### PR TITLE
Provide access to transport metadata in Thrift request handlers.

### DIFF
--- a/python/CHANGES.rst
+++ b/python/CHANGES.rst
@@ -4,9 +4,11 @@ Changelog for tchannel.py
 0.9.2 (unreleased)
 ------------------
 
-- Add exponential backoff to `TChannel.advertise`
+- Add exponential backoff to ``TChannel.advertise``.
+- Make transport metadata available under ``request.transport`` on the
+  server-side.
 
-  
+
 0.9.1 (2015-07-09)
 ------------------
 

--- a/python/GUIDE.rst
+++ b/python/GUIDE.rst
@@ -46,7 +46,7 @@ Create a `Thrift <https://thrift.apache.org/>`_ file under
     $ cat thrift/service.thrift
 
 
-.. code-block:: thrift
+.. code-block:: idl
 
     exception NotFoundError {
         1: string key,
@@ -67,8 +67,11 @@ Create a `Thrift <https://thrift.apache.org/>`_ file under
 
 \
 This defines a service named ``KeyValue`` with two functions:
-    - ``get``: a function which takes one string parameter, and returns a string.
-    - ``set``: a void function that takes in two parameters.
+
+``get``
+    a function which takes one string parameter, and returns a string.
+``set``
+    a void function that takes in two parameters.
 
 Once you have defined your service, generate corresponding Thrift types by
 running the following:
@@ -96,6 +99,7 @@ will register handlers against. Open up ``keyvalue/server.py`` and write
 something like this:
 
 .. code-block:: python
+
     from __future__ import absolute_import
 
     from tornado import ioloop
@@ -222,6 +226,23 @@ The `tchannel` object contains context about the current request (such as
 Zipkin tracing information) and should be used to make requests to other
 TChannel services. (Note that this API may change in the future.)
 
+~~~~~~~~~~~~~~~~~
+Transport Headers
+~~~~~~~~~~~~~~~~~
+
+In addition to the call arguments and headers, the ``request`` object also
+provides some additional information about the current request under the
+``request.transport`` object:
+
+``transport.flags``
+    Request flags used by the protocol for fragmentation and streaming.
+``transport.ttl``
+    The time (in milliseconds) within which the caller expects a response.
+``transport.headers``
+    Protocol level headers for the request. For more information on transport
+    headers check the
+    `Transport Headers <../docs/protocol.md#transport-headers>`_ section of the
+    protocol document.
 
 ---------
 Hyperbahn

--- a/python/tchannel/tornado/request.py
+++ b/python/tchannel/tornado/request.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 
+from collections import namedtuple
+
 import tornado
 import tornado.gen
 
@@ -183,3 +185,19 @@ class Request(object):
             return retry_flag is not RetryType.TIMEOUT
         else:
             return False
+
+
+class TransportMetadata(
+    namedtuple('_Metadata', 'flags ttl service id headers')
+):
+    """A read-only representation of the metadata contained in the Request."""
+
+    @classmethod
+    def from_request(cls, request):
+        return cls(
+            flags=request.flags,
+            ttl=request.ttl,
+            service=request.service,
+            id=request.id,
+            headers=request.headers,
+        )

--- a/python/tests/tornado/test_request.py
+++ b/python/tests/tornado/test_request.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from tchannel.messages.common import FlagsType
+from tchannel.tornado.request import Request, TransportMetadata
+
+
+def test_transport_metadata_creation():
+    request = Request(
+        id=42,
+        flags=FlagsType.fragment,
+        ttl=100,
+        service='some_service',
+        headers={'cn': 'another_service', 'as': 'thrift'}
+    )
+
+    meta = TransportMetadata.from_request(request)
+    assert 42 == meta.id
+    assert FlagsType.fragment == meta.flags
+    assert 100 == meta.ttl
+    assert 'some_service' == meta.service
+    assert {'cn': 'another_service', 'as': 'thrift'} == meta.headers


### PR DESCRIPTION
Resolves #904.

CC @blampe @breerly @junchaowu @Raynos 