### PR TITLE
Allow pulling out new IncomingCall object by a custom key.

### DIFF
--- a/golang/context.go
+++ b/golang/context.go
@@ -37,7 +37,12 @@ func newIncomingContext(call IncomingCall, timeout time.Duration, span *Span) (c
 
 // CurrentCall returns the current incoming call, or nil if this is not an incoming call context.
 func CurrentCall(ctx context.Context) IncomingCall {
-	if v := ctx.Value(contextKeyCall); v != nil {
+	return CurrentCallWithKey(ctx, contextKeyCall)
+}
+
+// CurrentCall given a key, returns the current incoming call, or nil if this is not an incoming call context.
+func CurrentCallWithKey(ctx context.Context, key interface{}) IncomingCall {
+	if v := ctx.Value(key); v != nil {
 		return v.(IncomingCall)
 	}
 	return nil

--- a/golang/context.go
+++ b/golang/context.go
@@ -43,12 +43,7 @@ func newIncomingContext(call IncomingCall, timeout time.Duration, span *Span) (c
 
 // CurrentCall returns the current incoming call, or nil if this is not an incoming call context.
 func CurrentCall(ctx context.Context) IncomingCall {
-	return CurrentCallWithKey(ctx, contextKeyCall)
-}
-
-// CurrentCall given a key, returns the current incoming call, or nil if this is not an incoming call context.
-func CurrentCallWithKey(ctx context.Context, key interface{}) IncomingCall {
-	if v := ctx.Value(key); v != nil {
+	if v := ctx.Value(contextKeyCall); v != nil {
 		return v.(IncomingCall)
 	}
 	return nil

--- a/golang/context_test.go
+++ b/golang/context_test.go
@@ -24,7 +24,7 @@ func TestWrapContextForTest(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 	actual := WrapContextForTest(ctx, call)
-	assert.Equal(t, call, actual.Value(contextKeyCall), "Incorrect call object returned.")
+	assert.Equal(t, call, CurrentCall(actual), "Incorrect call object returned.")
 }
 
 func TestCurrentCallWithNilResult(t *testing.T) {

--- a/golang/context_test.go
+++ b/golang/context_test.go
@@ -1,0 +1,45 @@
+package tchannel_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/uber/tchannel/golang"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+type mockIncomingCall struct {
+	callerName string
+}
+
+func (mic *mockIncomingCall) CallerName() string {
+	return mic.callerName
+}
+
+var (
+	cn   = "hello"
+	key1 = "foo"
+	key2 = "bar"
+)
+
+func TestCurrentCallWithMatchingKey(t *testing.T) {
+	expected := mockIncomingCall{callerName: cn}
+	ctx, cancel := NewContext(time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, key1, &expected)
+
+	actual := CurrentCallWithKey(ctx, key1)
+
+	assert.Equal(t, &expected, actual)
+}
+
+func TestCurrentCallWithoutMatchingKey(t *testing.T) {
+	expected := mockIncomingCall{callerName: cn}
+	ctx, cancel := NewContext(time.Second)
+	defer cancel()
+	ctx = context.WithValue(ctx, key1, &expected)
+
+	assert.Nil(t, CurrentCallWithKey(ctx, key2))
+}

--- a/golang/testutils/call.go
+++ b/golang/testutils/call.go
@@ -34,6 +34,6 @@ func (f *FakeIncomingCall) CallerName() string {
 	return f.callerName
 }
 
-func CreateIncomingCall(callerName string) tchannel.IncomingCall {
+func NewIncomingCall(callerName string) tchannel.IncomingCall {
 	return &FakeIncomingCall{callerName: callerName}
 }

--- a/golang/thrift/context.go
+++ b/golang/thrift/context.go
@@ -70,12 +70,10 @@ func NewContext(timeout time.Duration) (Context, context.CancelFunc) {
 	}, cancel
 }
 
-// WrapContextForTest returns a Context that is associated with the call.
-// This should be used in units test only.
-func WrapContextForTest(ctx context.Context, call tchannel.IncomingCall) Context {
-	tctx := tchannel.WrapContextForTest(ctx, call)
+// Wrap returns a Thrift Context that wraps around a Context
+func Wrap(ctx context.Context) Context {
 	return &thriftCtx{
-		Context: tctx,
+		Context: ctx,
 	}
 }
 

--- a/golang/thrift/context_test.go
+++ b/golang/thrift/context_test.go
@@ -5,17 +5,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/tchannel/golang/testutils"
-)
-
-var (
-	cn = "hello"
 )
 
 func TestWrapContextForTest(t *testing.T) {
-	call := testutils.CreateIncomingCall(cn)
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
-	actual := WrapContextForTest(ctx, call)
+	actual := Wrap(ctx)
 	assert.NotNil(t, actual, "Should not return nil.")
 }

--- a/golang/thrift/context_test.go
+++ b/golang/thrift/context_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWrapContextForTest(t *testing.T) {
+func TestWrapContext(t *testing.T) {
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 	actual := Wrap(ctx)


### PR DESCRIPTION
The main purpose is to provide a way to stub out the IncomingCall object in unit tests.

Main changes include:
- Add a new method to allow custom key for pulling out the IncomingCall object.
- Add unit tests.