### PR TITLE
Use a binary heap to store peers, making peer choice do less work

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -162,7 +162,13 @@ TChannelPeer.prototype.close = function close(callback) {
     }
 };
 
-TChannelPeer.prototype.setState = StateMachine.prototype.setState;
+TChannelPeer.prototype.setState = function setState(StateType) {
+    var self = this;
+
+    if (StateMachine.prototype.setState.call(self, StateType)) {
+        self.invalidateScore();
+    }
+};
 
 TChannelPeer.prototype.getInConnection = function getInConnection() {
     var self = this;

--- a/node/peer_heap.js
+++ b/node/peer_heap.js
@@ -1,0 +1,294 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports = PeerHeap;
+
+// A max-score (pre-computed) for peer selection
+
+function PeerHeap() {
+    var self = this;
+
+    self.array = [];
+    // TODO: worth it to keep a tail free list like TimeHeap?
+    // self.end = 0;
+    self._stack = [];
+}
+
+PeerHeap.prototype.choose = function choose(threshold, filter) {
+    var self = this;
+
+    if (!self.array.length) {
+        return null;
+    }
+
+    var el;
+    if (filter) {
+        el = self._chooseFilteredEl(threshold, filter);
+    } else {
+        el = self._chooseEl(threshold);
+    }
+
+    if (!el) {
+        return null;
+    }
+
+    // TODO: rescore could be deferred:
+    // - store a pendingRescore bit
+    // - set a next tick to rescore and clear bit
+    // - if asked to choose a peer while pendingRescore is still set, take the
+    //   hit and rescore then (do not clear bit)
+    //
+    // However such cleverness might just slow down the throughput of a very
+    // busy server rather than help.
+    el.score = el.peer.state.shouldRequest();
+    self.siftdown(0);
+
+    return el.peer;
+
+};
+
+PeerHeap.prototype._chooseEl = function _chooseEl(threshold) {
+    var self = this;
+
+    var el = self.array[0];
+    if (el.score <= threshold) { // TODO: why inclusive?
+        return null;
+    }
+
+    return el;
+};
+
+PeerHeap.prototype._chooseFilteredEl = function _chooseFilteredEl(threshold, filter) {
+    var self = this;
+
+    // TODO: is it worth it to unroll the first iteration of the loop below so
+    // that we incur minimal overhead for "the top of heap is okay" case?
+
+    // NOTE: assumes self._stack starts off empty
+    self._stack.push(0);
+    while (self._stack.length) {
+        var i = self._stack.shift();
+
+        var el = self.array[i];
+        if (el.score <= threshold) { // TODO: why inclusive?
+            break;
+        }
+
+        if (!filter || filter(el.peer)) {
+            return el;
+        }
+
+        var left = 2 * i + 1;
+        if (left < self.array.length) {
+            var right = left + 1;
+            if (right < self.array.length) {
+                if (self.array[right].score > self.array[left].score) {
+                    self._stack.push(right, left);
+                } else {
+                    self._stack.push(left, left);
+                }
+            } else {
+                self._stack.push(left);
+            }
+        }
+    }
+    self._stack.length = 0;
+
+    return null;
+};
+
+PeerHeap.prototype.clear = function clear() {
+    var self = this;
+
+    for (var i = 0; i < self.array.length; i++) {
+        var el = self.array[i];
+        el.heap = null;
+        el.peer = null;
+        el.score = 0;
+        el.index = 0;
+    }
+    self.array.length = 0;
+};
+
+PeerHeap.prototype.add = function add(peer) {
+    var self = this;
+
+    var score = peer.state.shouldRequest();
+    var i = self.push(peer, score);
+    var el = self.array[i];
+    return el;
+};
+
+PeerHeap.prototype.rescore = function rescore() {
+    var self = this;
+
+    for (var i = 0; i < self.array.length; i++) {
+        var el = self.array[i];
+        el.score = el.peer.state.shouldRequest();
+    }
+    self.heapify();
+};
+
+PeerHeap.prototype.heapify = function heapify() {
+    var self = this;
+
+    if (self.array.length <= 1) {
+        return;
+    }
+
+    for (var i = Math.floor(self.array.length / 2 - 1); i >= 0; i--) {
+        self.siftdown(i);
+    }
+};
+
+PeerHeap.prototype.remove = function remove(i) {
+    var self = this;
+
+    if (i >= self.array.length) {
+        return;
+    }
+
+    if (self.array.length === 1) {
+        self.array.pop();
+        return;
+    }
+
+    var j = self.array.length - 1;
+    if (i === j) {
+        self.array.pop();
+        return;
+    }
+
+    self.swap(i, j);
+    self.array.pop();
+    self.siftup(i);
+};
+
+PeerHeap.prototype.push = function push(peer, score) {
+    var self = this;
+
+    var el = new PeerHeapElement(self);
+    el.peer = peer;
+    el.score = score;
+    el.index = self.array.length;
+
+    self.array.push(el);
+    return self.siftup(el.index);
+};
+
+PeerHeap.prototype.pop = function pop() {
+    var self = this;
+    var peer = null;
+
+    if (!self.array.length) {
+        return peer;
+    }
+
+    if (self.array.length === 1) {
+        peer = self.array.pop();
+        return peer;
+    }
+
+    peer = self.array[0].peer;
+    self.array[0] = self.array.pop();
+    self.siftdown(0);
+
+    return peer;
+};
+
+PeerHeap.prototype.siftdown = function siftdown(i) {
+    var self = this;
+
+    while (true) {
+        var left = (2 * i) + 1;
+        if (left >= self.array.length) {
+            return i;
+        }
+
+        var right = left + 1;
+        var child = left;
+        if (right < self.array.length &&
+            self.array[right].score > self.array[left].score) {
+            child = right;
+        }
+
+        if (self.array[child].score > self.array[i].score) {
+            self.swap(i, child);
+            i = child;
+        } else {
+            return i;
+        }
+    }
+};
+
+PeerHeap.prototype.siftup = function siftup(i) {
+    var self = this;
+
+    while (i > 0) {
+        var par = Math.floor((i - 1) / 2);
+        if (self.array[i].score > self.array[par].score) {
+            self.swap(i, par);
+            i = par;
+        } else {
+            return i;
+        }
+    }
+
+    return 0;
+};
+
+PeerHeap.prototype.swap = function swap(i, j) {
+    var self = this;
+
+    var a = self.array[i];
+    var b = self.array[j];
+
+    self.array[i] = b;
+    self.array[j] = a;
+    b.index = i;
+    a.index = j;
+};
+
+function PeerHeapElement(heap) {
+    var self = this;
+
+    self.heap = heap;
+    self.peer = null;
+    self.score = 0;
+    self.index = 0;
+}
+
+PeerHeapElement.prototype.rescore = function rescore(score) {
+    var self = this;
+
+    if (!self.heap) {
+        return;
+    }
+
+    if (score === undefined) {
+        score = self.peer.state.shouldRequest();
+    }
+
+    self.score = score;
+    self.index = self.heap.siftup(self.index);
+    self.index = self.heap.siftdown(self.index);
+};

--- a/node/root_peers.js
+++ b/node/root_peers.js
@@ -102,8 +102,7 @@ TChannelRootPeers.prototype.clear = function clear() {
     var names = Object.keys(self.channel.subChannels);
     for (var i = 0; i < names.length; i++) {
         var subChannel = self.channel.subChannels[names[i]];
-        subChannel.peers._map = Object.create(null);
-        subChannel.peers._keys = [];
+        subChannel.peers.clear();
     }
 
     self._map = Object.create(null);

--- a/node/states.js
+++ b/node/states.js
@@ -285,7 +285,14 @@ UnhealthyState.prototype.locked = false;
 UnhealthyState.prototype.onNewPeriod = function onNewPeriod(now) {
     var self = this;
 
+    var triedLastPeriod = self.triedThisPeriod;
     self.triedThisPeriod = false;
+
+    if (triedLastPeriod) {
+        // score only changes if we had gone back to "closed" state, otherwise
+        // we simply are remaining "open" for a single probe
+        self.invalidate();
+    }
 };
 
 UnhealthyState.prototype.toString = function healthyToString() {

--- a/node/states.js
+++ b/node/states.js
@@ -97,6 +97,14 @@ State.prototype.close = function close(callback) {
     callback(null);
 };
 
+State.prototype.invalidate = function invalidate() {
+    var self = this;
+
+    if (self.stateMachine.invalidateScore) {
+        self.stateMachine.invalidateScore();
+    }
+};
+
 State.prototype.shouldRequest = function shouldRequest(req, options) {
     var self = this;
 

--- a/node/test/retry.js
+++ b/node/test/retry.js
@@ -52,10 +52,25 @@ allocCluster.test('request retries', {
     var client = TChannel({
         timeoutFuzz: 0,
         random: randSeq([
-            1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
-                 1.0, 0.1, 0.1, // .request, chan 2 wins (1 is skipped)
-                      1.0, 0.1, // .request, chan 3 wins (1-2 are skipped)
-                           0.1  // .request, chan 4 wins (only one left)
+            0.0, // chan 1: add peer
+            0.0, // chan 2: add peer
+            0.0, // chan 3: add peer
+            0.0, // chan 4: add peer
+                 //
+            0.0, // chan 1: connect
+            0.0, // chan 2: connect
+            0.0, // chan 3: connect
+            0.0, // chan 4: connect
+                 //
+            1.0, // chan 1: identified
+            0.9, // chan 2: identified
+            0.8, // chan 3: identified
+            0.7, // chan 4: identified
+                 //
+            0.0, // top of heap is chan 1: rescore to last
+            0.0, // top of heap is chan 2: restore to last
+            0.0, // top of heap is chan 3: restore to last
+            0.0, // top of heap is chan 4: restore to last
         ], false /* NOTE: set true to print debug traces */)
     });
     var chan = client.makeSubChannel({
@@ -171,8 +186,17 @@ allocCluster.test('request application retries', {
     var client = TChannel({
         timeoutFuzz: 0,
         random: randSeq([
-            1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
-                 1.0, 0.1, 0.1  // .request, chan 2 wins (1 is skipped)
+            0.0, // chan 1: add peer
+            0.0, // chan 2: add peer
+                 //
+            0.0, // chan 1: connect
+            0.0, // chan 2: connect
+                 //
+            1.0, // chan 1: identified
+            0.9, // chan 2: identified
+                 //
+            0.0, // top of heap is chan 1: rescore to last
+            0.0, // top of heap is chan 2: restore to last
         ], false /* NOTE: set true to print debug traces */)
     });
     var chan = client.makeSubChannel({
@@ -288,10 +312,19 @@ allocCluster.test('retryFlags work', {
     var client = TChannel({
         timeoutFuzz: 0,
         random: randSeq([
-            1.0, 0.1, // .request, chan 1 wins
-            1.0, 0.1, // .request, chan 1 wins
-                 1.0, // .request, chan 2 wins (1 is skipped)
-            1.0, 0.1  // .request, chan 1 wins
+            0.0,  // chan 1: add peer
+            0.0,  // chan 2: add peer
+                  //
+            0.0,  // chan 1: connect
+            0.0,  // chan 2: connect
+                  //
+            1.0,  // chan 1: identified
+            0.9,  // chan 2: identified
+                  //
+            1.0,  // top of heap is chan 1: stays at top
+            1.0,  // top of heap is chan 1: stays at top
+            0.9,  // top of heap is chan 2: stays in place
+            1.0   // top of heap is chan 1: stays at top
         ], false /* NOTE: set true to print debug traces */)
     });
     var chan = client.makeSubChannel({

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -190,14 +190,25 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
     var client = TChannel({
         timeoutFuzz: 0,
         random: randSeq([
-            1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
-            0.1, 1.0, 0.1, 0.1, // .request, chan 2 wins
-            0.1, 0.1, 1.0, 0.1, // .request, chan 3 wins
-            0.1, 0.1, 0.1, 1.0, // .request, chan 4 wins
-            1.0, 0.1, 0.1, 0.1, // .request, chan 1 wins
-            0.1, 1.0, 0.1, 0.1, // .request, chan 2 wins
-            0.1, 0.1, 1.0, 0.1, // .request, chan 3 wins
-            0.1, 0.1, 0.1, 1.0  // .request, chan 4 wins
+            0.0, 0.0, // chan 1: add peer, add conn
+            0.0, 0.0, // chan 2: add peer, add conn
+            0.0, 0.0, // chan 3: add peer, add conn
+            0.0, 0.0, // chan 4: add peer, add conn
+                      //
+            0.8,      // chan 1: onIdentified
+            0.7,      // chan 2: onIdentified
+            0.6,      // chan 3: onIdentified
+            0.5,      // chan 4: onIdentified
+                      //
+            0.4,      // chan 1 is top of heap, rescores to last
+            0.3,      // chan 2 is top of heap, rescores to last
+            0.2,      // chan 3 is top of heap, rescores to last
+            0.1,      // chan 4 is top of heap, rescores to last
+                      //
+            0.0,      // chan 1 is top of heap, rescores to last
+            0.0,      // chan 2 is top of heap, rescores to last
+            0.0,      // chan 3 is top of heap, rescores to last
+            0.0       // chan 4 is top of heap, rescores to last
         ], false /* NOTE: set true to print debug traces */)
     });
 


### PR DESCRIPTION
The cost of `TChannelPeers#choosePeer` should run on the order of log-number of peers now.  The choice itself is constant time, but to maintain semantics, a rescore must be done, which implies a log-time heap siftdown.  However it now only runs the score function once, rather than N times, so the scaling amount of work in each request is greatly reduced.

TODO:
- [x] fix existing tests that are broken; probably missed semantics
- [x] implement an out of band rescore hook as noted
- ~~[ ] add a unit test for the heap (an exhaustive search test on all 6-trees should do)~~ (integration coverage proved Good Enough (tm) )