### PR TITLE
Fix file output multiplexing bug in benchmarks

### DIFF
--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -217,11 +217,6 @@ function startClient(clientPort) {
                 self.fileStream.write(JSON.stringify(result) + '\n');
             }
         })
-        .on('end', function onEnd() {
-            if (self.fileStream) {
-                self.fileStream.end();
-            }
-        });
 
     benchProc.once('close', function onClose() {
         if (--self.benchCounter === 0) {
@@ -240,6 +235,8 @@ BenchmarkRunner.prototype.close = function close() {
     if (self.traceProc) {
         self.traceProc.kill();
     }
+
+    self.fileStream.end();
 
     for (i = 0; i < self.relayProcs.length; i++) {
         self.relayProcs[i].kill();

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -216,7 +216,7 @@ function startClient(clientPort) {
             if (self.fileStream) {
                 self.fileStream.write(JSON.stringify(result) + '\n');
             }
-        })
+        });
 
     benchProc.once('close', function onClose() {
         if (--self.benchCounter === 0) {

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -236,7 +236,9 @@ BenchmarkRunner.prototype.close = function close() {
         self.traceProc.kill();
     }
 
-    self.fileStream.end();
+    if (self.fileStream) {
+        self.fileStream.end();
+    }
 
     for (i = 0; i < self.relayProcs.length; i++) {
         self.relayProcs[i].kill();

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -63,6 +63,7 @@ function BenchmarkRunner(opts) {
     self.traceProc = null;
     self.benchProcs = [];
     self.benchCounter = 0;
+    self.fileStream = null;
 }
 
 BenchmarkRunner.prototype.start = function start() {
@@ -98,6 +99,8 @@ BenchmarkRunner.prototype.start = function start() {
     }
 
     function startClient() {
+        self.openFileStream();
+
         if (self.opts.multiProc) {
             self.startClient(CLIENT_PORT);
             self.startClient(CLIENT_PORT + 200);
@@ -163,6 +166,17 @@ function startRelay(type) {
     relayProc.stderr.pipe(process.stderr);
 };
 
+BenchmarkRunner.prototype.openFileStream =
+function openFileStream() {
+    var self = this;
+
+    if (self.opts.output) {
+        self.fileStream = fs.createWriteStream(self.opts.output, {
+            encoding: 'utf8'
+        });
+    }
+};
+
 BenchmarkRunner.prototype.startClient =
 function startClient(clientPort) {
     var self = this;
@@ -198,14 +212,16 @@ function startClient(clientPort) {
                     result.rate.toFixed(2) : 'NaN', 8
                 )
             ));
-        });
 
-    if (self.opts.output) {
-        benchProc.stdout
-            .pipe(fs.createWriteStream(self.opts.output, {
-                encoding: 'utf8'
-            }));
-    }
+            if (self.fileStream) {
+                self.fileStream.write(JSON.stringify(result) + '\n');
+            }
+        })
+        .on('end', function onEnd() {
+            if (self.fileStream) {
+                self.fileStream.end();
+            }
+        });
 
     benchProc.once('close', function onClose() {
         if (--self.benchCounter === 0) {


### PR DESCRIPTION
The way the benchmarks are written the JSON lines are
being interleaved in output which makes it garbage output

r: @shannili @jcorbin @kriskowal