### PR TITLE
Ensure all peers exist on root channel

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -370,9 +370,7 @@ TChannel.prototype.makeSubChannel = function makeSubChannel(options) {
     if (options.peers) {
         for (i = 0; i < options.peers.length; i++) {
             if (typeof options.peers[i] === 'string') {
-                chan.peers.addPeer(self.peers.add(options.peers[i]));
-            } else {
-                chan.peers.addPeer(options.peers[i]);
+                chan.peers.add(options.peers[i]);
             }
         }
     }

--- a/node/peers.js
+++ b/node/peers.js
@@ -80,16 +80,20 @@ TChannelPeers.prototype.get = function get(hostPort) {
 };
 
 TChannelPeers.prototype.add = function add(hostPort, options) {
+    /*eslint max-statements: [2, 25]*/
     var self = this;
     var peer = self._map[hostPort];
     if (!peer) {
-        if (hostPort === self.channel.hostPort) {
-            if (!self.selfPeer) {
-                self.selfPeer = TChannelSelfPeer(self.channel);
+        var topChannel = self.channel.topChannel || self.channel;
+
+        if (hostPort === topChannel.hostPort) {
+            if (!topChannel.peers.selfPeer) {
+                topChannel.peers.selfPeer = TChannelSelfPeer(topChannel);
             }
 
-            return self.selfPeer;
+            return topChannel.peers.selfPeer;
         }
+
         if (self.channel.topChannel) {
             peer = self.channel.topChannel.peers.add(hostPort, options);
         } else {
@@ -101,16 +105,6 @@ TChannelPeers.prototype.add = function add(hostPort, options) {
         self._keys.push(hostPort);
     }
     return peer;
-};
-
-TChannelPeers.prototype.addPeer = function addPeer(peer) {
-    var self = this;
-    assert(peer instanceof TChannelPeer, 'invalid peer');
-    assert(!self._map[peer.hostPort], 'peer already defined');
-    if (peer.hostPort !== self.channel.hostPort) {
-        self._map[peer.hostPort] = peer;
-        self._keys.push(peer.hostPort);
-    }
 };
 
 TChannelPeers.prototype.keys = function keys() {

--- a/node/test/hyperbahn/rate-limiter.js
+++ b/node/test/hyperbahn/rate-limiter.js
@@ -85,7 +85,7 @@ function runTests(HyperbahnCluster) {
                 send.bind(null, opts),
                 function check(done) {
                     cluster.relayNetwork.relayChannels.forEach(function (relayChannel, index) {
-                        assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 7, 'total request');
+                        assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 8, 'total request');
                         assert.equals(relayChannel.handler.rateLimiter.counters.steve.rps, 3, 'request for steve');
                         assert.equals(relayChannel.handler.rateLimiter.counters.tcollector.rps, 3, 'request for tcollector');
                     });
@@ -131,7 +131,7 @@ function runTests(HyperbahnCluster) {
                 send.bind(null, opts),
                 function check1(done) {
                     cluster.relayNetwork.relayChannels.forEach(function (relayChannel, index) {
-                        assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 7, 'check1: total request');
+                        assert.equals(relayChannel.handler.rateLimiter.totalRequestCounter.rps, 8, 'check1: total request');
                         assert.equals(relayChannel.handler.rateLimiter.counters.steve.rps, 3, 'check1: request for steve');
                         assert.equals(relayChannel.handler.rateLimiter.counters.tcollector.rps, 3, 'check1: request for tcollector');
                     });
@@ -212,7 +212,7 @@ function runTests(HyperbahnCluster) {
         timers: timers,
         kValue: 1,
         rateLimiterBuckets: 2,
-        totalRpsLimit: 2,
+        totalRpsLimit: 3,
         rateLimiterEnabled: true
     }, function t(cluster, assert) {
         var steve = cluster.remotes.steve;
@@ -247,7 +247,7 @@ function runTests(HyperbahnCluster) {
                         serviceName: steve.serviceName
                     }), 'echo', null, 'hello', function onResponse(err, res) {
                         assert.ok(err && err.type === 'tchannel.busy' &&
-                            err.message === 'hyperbahn node is rate-limited by the total rps of 2',
+                            err.message === 'hyperbahn node is rate-limited by the total rps of 3',
                             'should be rate limited');
                         done();
                     });

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -299,7 +299,8 @@ allocCluster.test('request().send() to self', 1, function t(cluster, assert) {
         reqHead: 'head1', reqBody: 'msg1',
         resHead: 'head1', resBody: 'msg1',
         opts: {
-            host: one.hostPort
+            host: one.hostPort,
+            serviceName: 'one'
         }
     },
     {
@@ -308,7 +309,8 @@ allocCluster.test('request().send() to self', 1, function t(cluster, assert) {
         resHead: 'head2', resBody: 'msg2',
         resOk: false,
         opts: {
-            host: one.hostPort
+            host: one.hostPort,
+            serviceName: 'one'
         }
     }].map(function eachTestCase(testCase) {
         testCase = extend({
@@ -348,6 +350,7 @@ allocCluster.test('send to self', {
     });
 
     subOne.request({
+        host: one.hostPort,
         serviceName: 'one'
     }).send('foo', '', '', onResponse);
 
@@ -426,6 +429,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
     function cancelCase(callback) {
         subOne.request({
             host: one.hostPort,
+            serviceName: 'one',
             hasNoParent: true,
             headers: {
                 'as': 'raw',
@@ -452,6 +456,7 @@ allocCluster.test('self send() with error frame', 1, function t(cluster, assert)
     function unhealthyCase(callback) {
         subOne.request({
             host: one.hostPort,
+            serviceName: 'one',
             hasNoParent: true,
             headers: {
                 'as': 'raw',

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -232,7 +232,7 @@ var search = clusterSearch.ClusterIsolateSearch(extend({
     setupClient: function setupClient(cluster, callback) {
         cluster.testRawClient = cluster.client.makeSubChannel({
             peers: cluster.client.peers.values().map(function h(p) {
-                return p.hostPort
+                return p.hostPort;
             }),
             serviceName: 'test_as_raw',
             requestDefaults: {

--- a/node/test/streaming_bisect.js
+++ b/node/test/streaming_bisect.js
@@ -231,7 +231,9 @@ var search = clusterSearch.ClusterIsolateSearch(extend({
     // creates a client for the test service
     setupClient: function setupClient(cluster, callback) {
         cluster.testRawClient = cluster.client.makeSubChannel({
-            peers: cluster.client.peers.values(),
+            peers: cluster.client.peers.values().map(function h(p) {
+                return p.hostPort
+            }),
             serviceName: 'test_as_raw',
             requestDefaults: {
                 serviceName: 'test_as_raw',


### PR DESCRIPTION
This is part 1 of a timers change

For sanity we enforce that all peers must exist on the
root channel.

r: @jcorbin @kriskowal @shannili