### PR TITLE
Improve benchmarks

### DIFF
--- a/node/benchmarks/Makefile
+++ b/node/benchmarks/Makefile
@@ -7,7 +7,7 @@ torch-server-bench:
 		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
 
 torch-relay-bench:
-	node index.js --multiProc --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
+	node index.js --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
 		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
 
 flame-torch-relay-bench:
@@ -35,7 +35,7 @@ take:
 	ln -sf $$(git rev-parse --short HEAD).json $$(git symbolic-ref HEAD | basename).json
 
 take_relay:
-	node index.js --multiProc --relay -o relay-$$(git rev-parse --short HEAD).json \
+	node index.js --relay -o relay-$$(git rev-parse --short HEAD).json \
 		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(git symbolic-ref HEAD | basename).json
 

--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -54,6 +54,7 @@ function BenchServer(port) {
             app: 'my-server'
         },
         trace: true,
+        emitConnectionMetrics: false,
         statsd: new Statsd({
             host: '127.0.0.1',
             port: 7036

--- a/node/benchmarks/multi_bench.js
+++ b/node/benchmarks/multi_bench.js
@@ -126,6 +126,7 @@ Test.prototype.newClient = function (id, callback) {
         statTags: {
             app: 'my-client'
         },
+        emitConnectionMetrics: false,
         trace: true,
         statsd: new Statsd({
             host: '127.0.0.1',

--- a/node/benchmarks/relay_server.js
+++ b/node/benchmarks/relay_server.js
@@ -67,6 +67,7 @@ function RelayServer(opts) {
         statTags: {
             app: 'relay-server'
         },
+        emitConnectionMetrics: false,
         logger: opts.debug ? require('debug-logtron')('relay') : null,
         trace: false,
         statsd: new Statsd({

--- a/node/benchmarks/trace_server.js
+++ b/node/benchmarks/trace_server.js
@@ -31,6 +31,7 @@ var server = TChannel({
     statTags: {
         app: 'tcollector'
     },
+    emitConnectionMetrics: false,
     trace: false,
     statsd: new Statsd({
         host: '127.0.0.1',


### PR DESCRIPTION
Two small fixes:

 - remove multiProc default, relay is still the bottleneck
 - Do not emit connection metrics in benchmark

r: @kriskowal @shannili