### PR TITLE
hyperbahn-cluster: add namedRemotes option

### DIFF
--- a/node/test/hyperbahn/forward.js
+++ b/node/test/hyperbahn/forward.js
@@ -33,10 +33,12 @@ if (require.main === module) {
 
 function runTests(HyperbahnCluster) {
     HyperbahnCluster.test('advertise and forward', {
-        size: 5
+        size: 5,
+        namedRemotes: ['august']
     }, function t(cluster, assert) {
+        console.log('wtf', cluster.namedRemotes);
         var steve = cluster.remotes.steve;
-        var bob = cluster.remotes.bob;
+        var august = cluster.namedRemotes[0];
 
         var tchannelJSON = TChannelJSON({
             logger: cluster.logger
@@ -60,7 +62,7 @@ function runTests(HyperbahnCluster) {
 
             assert.equal(typeof result.body.connectionCount, 'number');
 
-            tchannelJSON.send(bob.clientChannel.request({
+            tchannelJSON.send(august.clientChannel.request({
                 timeout: 5000,
                 serviceName: steve.serviceName
             }), 'echo', null, 'oh hi lol', onForwarded);

--- a/node/test/hyperbahn/forward.js
+++ b/node/test/hyperbahn/forward.js
@@ -36,7 +36,6 @@ function runTests(HyperbahnCluster) {
         size: 5,
         namedRemotes: ['august']
     }, function t(cluster, assert) {
-        console.log('wtf', cluster.namedRemotes);
         var steve = cluster.remotes.steve;
         var august = cluster.namedRemotes[0];
 


### PR DESCRIPTION
This allows people to create a hyperbahn cluster with
remotes that have different names then bob and steve.

r: @kriskowal @shannili @rf @jeloi