### PR TITLE
Add endpoint overhead

### DIFF
--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -99,20 +99,24 @@ BenchServer.prototype.setupReporter = function setupReporter() {
 BenchServer.prototype.registerEndpoints = function registerEndpoints() {
     var self = this;
 
-    self.serverChan.register('ping', function onPing(req, res) {
+    self.serverChan.register('ping', onPing);
+    self.serverChan.register('set', onSet);
+    self.serverChan.register('get', onGet);
+
+    function onPing(req, res) {
         res.headers.as = 'raw';
         res.sendOk('pong', null);
-    });
+    }
 
-    self.serverChan.register('set', function onSet(req, res, arg2, arg3) {
+    function onSet(req, res, arg2, arg3) {
         var key = arg2.toString('utf8');
         var val = arg3.toString('utf8');
         self.keys[key] = val;
         res.headers.as = 'raw';
         res.sendOk('ok', 'really ok');
-    });
+    }
 
-    self.serverChan.register('get', function onGet(req, res, arg2, arg3) {
+    function onGet(req, res, arg2, arg3) {
         var key = arg2.toString('utf8');
         res.headers.as = 'raw';
         if (self.keys[key] !== undefined) {
@@ -121,7 +125,7 @@ BenchServer.prototype.registerEndpoints = function registerEndpoints() {
         } else {
             res.sendNotOk('key not found', key);
         }
-    });
+    }
 };
 
 BenchServer.prototype.listen = function listen() {

--- a/node/benchmarks/bench_server.js
+++ b/node/benchmarks/bench_server.js
@@ -34,10 +34,13 @@ var argv = parseArgs(process.argv.slice(2), {
     boolean: ['trace']
 });
 
-assert('trace' in argv, 'trace option needed');
-assert(argv.traceRelayHostPort, 'traceRelayHostPort needed');
 assert(argv.port, 'port needed');
 assert(argv.instances, 'instances needed');
+
+assert('trace' in argv, 'trace option needed');
+if (argv.trace) {
+    assert(argv.traceRelayHostPort, 'traceRelayHostPort needed');
+}
 
 var INSTANCES = parseInt(argv.instances, 10);
 

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -130,7 +130,10 @@ function startServer(serverPort, instances) {
         self.opts.trace ? '--trace' : '--no-trace',
         '--traceRelayHostPort', '127.0.0.1:' + RELAY_TRACE_PORT,
         '--port', String(serverPort),
-        '--instances', String(instances)
+        '--instances', String(instances),
+        '--pingOverhead', 'norm:10,5',
+        '--setOverhead', 'norm:200,20',
+        '--getOverhead', 'norm:100,10'
     ]);
     self.serverProcs.push(serverProc);
     serverProc.stdout.pipe(process.stderr);

--- a/node/benchmarks/random_sample.js
+++ b/node/benchmarks/random_sample.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Random sampling functions borrowed from python standard library
+
+var RandomSample = module.exports;
+RandomSample.variate = {};
+
+RandomSample.variate.norm = function normalvariate(mu, sigma, random) {
+    var nvMagicConst = 4 * Math.exp(-0.5) / Math.sqrt(2.0);
+    return function sampleNormalRandom() {
+        while (true) {
+            var u1 = random();
+            var u2 = 1.0 - random();
+            var z = nvMagicConst * (u1 - 0.5) / u2;
+            var zz = z * z / 4.0;
+            if (zz <= -Math.log(u2)) {
+                return mu + z * sigma;
+            }
+        }
+    };
+};
+
+RandomSample.variate.expo = function expovariate(mu, random) {
+    return function sampleExponentialRandom() {
+        return -Math.log(1 - random()) * mu;
+    };
+};
+
+RandomSample.fromString = function fromString(str, random) {
+    if (!random) {
+        random = Math.random;
+    }
+
+    // norm:mu,sigma
+    // expo:mu
+    var match = /^(\w+):(.+)$/.exec(str);
+    if (!match) {
+        throw new Error('invalid random sample spec, expected "kind:arg[,arg[,...]]"');
+    }
+    var kind = match[1];
+    str = match[2];
+
+    var variate = RandomSample.variate[kind];
+    if (!variate) {
+        throw new Error('invalid random sample kind ' + kind);
+    }
+
+    var args = str.split(',');
+    if (args.length !== variate.length-1) {
+        throw new Error('wrong number of args for random sample kind ' + kind);
+    }
+
+    for (var i = 0; i < args.length; i++) {
+        var n = parseFloat(args[i]);
+        if (isNaN(n)) {
+            throw new Error('invalid argument, not a number: ' + args[i]);
+        }
+        args[i] = n;
+    }
+
+    args.push(random);
+    return variate.apply(null, args);
+};

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,7 @@
     "lint": "jshint .",
     "test": "npm run check-licence && npm run lint -s && npm run cover -s && npm run check-benchmark -s",
     "benchmark": "echo '!!! DEPRECATED: Better to just run `node benchmarks` directly' >&2; node benchmarks",
-    "check-benchmark": "node benchmarks -- -r 10",
+    "check-benchmark": "node benchmarks -- -r 10000 -p 10000",
     "take-benchmark": "make -C benchmarks take",
     "take-relay-benchmark": "make -C benchmarks take_relay",
     "take-trace-benchmark": "amke -C benchmarks take_trace",


### PR DESCRIPTION
Turns out that in reality endpoints don't usually turn around and send / finish a response immediately.

This adds support for adding random-sampled delay into the node benchmark server.