### PR TITLE
go: Use fields for logging instead of prefix

### DIFF
--- a/golang/connection.go
+++ b/golang/connection.go
@@ -196,7 +196,11 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, on
 	}
 
 	connID := atomic.AddUint32(&nextConnID, 1)
-	log := PrefixedLogger(fmt.Sprintf("C%v ", connID), ch.log)
+	log := ch.log.WithFields(LogFields{
+		"connID":     connID,
+		"localPeer":  conn.LocalAddr(),
+		"remotePeer": conn.RemoteAddr(),
+	})
 	peerInfo := ch.PeerInfo()
 	log.Debugf("created for %v (%v) local: %v remote: %v",
 		peerInfo.ServiceName, peerInfo.ProcessName, conn.LocalAddr(), conn.RemoteAddr())

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -22,7 +22,6 @@ package tchannel
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"time"
 
@@ -64,7 +63,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.contents = newFragmentingWriter(response, initialFragment.checksumType.New())
 	response.cancel = cancel
 	response.span = callReq.Tracing
-	response.log = PrefixedLogger(fmt.Sprintf("In%v-Response ", callReq.ID()), c.log)
+	response.log = c.log.WithFields(LogFields{"In-Response": callReq.ID()})
 	response.headers = callHeaders{}
 	response.messageForFragment = func(initial bool) message {
 		if initial {
@@ -86,7 +85,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call.headers = callReq.Headers
 	call.span = callReq.Tracing
 	call.response = response
-	call.log = PrefixedLogger(fmt.Sprintf("In%v-Call ", callReq.ID()), c.log)
+	call.log = c.log.WithFields(LogFields{"In-Call": callReq.ID()})
 	call.messageForFragment = func(initial bool) message { return new(callReqContinue) }
 	call.contents = newFragmentingReader(call)
 	call.statsReporter = c.statsReporter

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -21,7 +21,6 @@ package tchannel
 // THE SOFTWARE.
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -78,7 +77,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	}
 	call.statsReporter = c.statsReporter
 	call.createStatsTags(c.commonStatsTags)
-	call.log = PrefixedLogger(fmt.Sprintf("Out%v-Call ", requestID), c.log)
+	call.log = c.log.WithFields(LogFields{"Out-Call": requestID})
 
 	// TODO(mmihic): It'd be nice to do this without an fptr
 	call.messageForFragment = func(initial bool) message {
@@ -101,7 +100,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	response := new(OutboundCallResponse)
 	response.startedAt = timeNow()
 	response.mex = mex
-	response.log = PrefixedLogger(fmt.Sprintf("Out%v-Response ", requestID), c.log)
+	response.log = c.log.WithFields(LogFields{"Out-Response": requestID})
 	response.messageForFragment = func(initial bool) message {
 		if initial {
 			return &response.callRes


### PR DESCRIPTION
r @mmihic 