### PR TITLE
batch emit all of our stats

### DIFF
--- a/node/test/connection-stats.js
+++ b/node/test/connection-stats.js
@@ -134,6 +134,7 @@ allocCluster.test('emits connection stats with failure', {
     function onIdentified(err) {
         assert.notEqual(err, null, 'should be an error');
         process.nextTick(function next() {
+            client.flushStats();
             assert.deepEqual(stats, [{
                 name: 'connections.initiated',
                 type: 'counter',

--- a/node/test/connection-with-statsd.js
+++ b/node/test/connection-with-statsd.js
@@ -120,6 +120,7 @@ allocCluster.test('emits connection stats with failure', {
     function onIdentified(err) {
         assert.notEqual(err, null, 'should be an error');
         process.nextTick(function next() {
+            client.flushStats();
             assert.deepEqual(statsd._buffer._elements, [{
                 type: 'c',
                 name: 'tchannel.connections.initiated.' + hostKey,

--- a/node/test/permissions_cache.js
+++ b/node/test/permissions_cache.js
@@ -60,6 +60,8 @@ allocCluster.test('permissionsCache: counts service request counts', {
             return assert.end(err);
         }
 
+        server.flushStats();
+
         assert.ok(cache.lru.keys().indexOf('client_server') >= 0);
         assert.end();
         cache.clearBuckets();

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -71,6 +71,8 @@ allocCluster.test('emits stats', {
     }).send('echo', 'a', 'b', onResponse);
 
     function onResponse(err, res, arg2, arg3) {
+        client.flushStats();
+
         assert.ifError(err);
         assert.ok(res.ok);
         assert.deepEqual(stats, [{

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -82,6 +82,9 @@ allocCluster.test('emits stats on call success', {
         if (err) {
             return assert.end(err);
         }
+
+        client.flushStats();
+
         assert.ok(res.ok, 'res should be ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
@@ -204,6 +207,9 @@ allocCluster.test('emits stats on p2p call success', {
         if (err) {
             return assert.end(err);
         }
+
+        client.flushStats();
+
         assert.ok(res.ok, 'res should be ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
@@ -311,6 +317,9 @@ allocCluster.test('emits stats with no connection metrics', {
         if (err) {
             return assert.end(err);
         }
+
+        client.flushStats();
+
         assert.ok(res.ok, 'res should be ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
@@ -408,6 +417,9 @@ allocCluster.test('emits stats on call failure', {
         if (err) {
             return assert.end(err);
         }
+
+        client.flushStats();
+
         assert.ok(res.ok === false, 'res should be not ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -75,6 +75,9 @@ allocCluster.test('emits response stats with ok', {
         if (err) {
             return assert.end(err);
         }
+
+        server.flushStats();
+
         assert.ok(res.ok, 'res should be ok');
         assert.deepEqual(stats, [{
             name: 'connections.accepted',
@@ -235,6 +238,9 @@ allocCluster.test('emits response stats with not ok', {
         if (err) {
             return assert.end(err);
         }
+
+        server.flushStats();
+
         assert.equal(res.ok, false, 'res should be not ok');
         assert.deepEqual(stats, [{
             name: 'connections.accepted',
@@ -392,6 +398,8 @@ allocCluster.test('emits response stats with error', {
     }).send('echo', 'c', 'd', onResponse);
 
     function onResponse(err, res, arg2, arg3) {
+        server.flushStats();
+        
         assert.notEqual(err, null, 'err should not be null');
         assert.equal(res, null, 'res should be null');
         assert.deepEqual(stats, [{

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -85,6 +85,9 @@ allocCluster.test('emits stats on response ok', {
         if (err) {
             return assert.end(err);
         }
+
+        server.flushStats();
+
         assert.ok(res.ok, 'res should be ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
@@ -197,6 +200,9 @@ allocCluster.test('emits stats on response not ok', {
         if (err) {
             return assert.end(err);
         }
+
+        server.flushStats();
+
         assert.equal(res.ok, false, 'res should be not ok');
         assert.deepEqual(statsd._buffer._elements, [{
             type: 'c',
@@ -304,6 +310,8 @@ allocCluster.test('emits stats on response error', {
     }).send('Reservoir::get', 'ton', '20', onResponse);
 
     function onResponse(err, res, arg2, arg3) {
+        server.flushStats();
+
         assert.notEqual(err, null, 'err should not be null');
         assert.equal(res, null, 'res should be null');
         assert.deepEqual(statsd._buffer._elements, [{


### PR DESCRIPTION
This is a simple change to flush every 100ms.

```
$ node compare.js relay-master.json relay-one-stat.json 
GET 16KiB, 1000/0  rate: hi-diff:   -225.04 ( -5.8%)
GET 16KiB, 10000/0 rate: hi-diff:    173.30 (  5.2%)
GET 16KiB, 20000/0 rate: hi-diff:    451.99 ( 16.2%)
GET 4KiB, 1000/0   rate: hi-diff:    672.82 ( 16.5%)
GET 4KiB, 10000/0  rate: hi-diff:    381.16 (  8.1%)
GET 4KiB, 20000/0  rate: hi-diff:    492.67 ( 11.0%)
SET 16KiB, 1000/0  rate: hi-diff:     81.56 (  2.7%)
SET 16KiB, 10000/0 rate: hi-diff:    -80.01 ( -2.6%)
SET 16KiB, 20000/0 rate: hi-diff:    139.10 (  5.0%)
SET 4KiB, 1000/0   rate: hi-diff:    121.66 (  4.0%)
SET 4KiB, 10000/0  rate: hi-diff:    232.36 (  5.6%)
SET 4KiB, 20000/0  rate: hi-diff:   -251.48 ( -5.2%)
```

I uploaded a flamegraph ( https://people.uberinternal.com/~jakev/tchannel-one-stat.svg )

This will make optimizing stats eaier.

r: @jcorbin @shannili @kriskowal