### PR TITLE
Operations: defer connection timed out emit out of check

### DIFF
--- a/node/operations.js
+++ b/node/operations.js
@@ -74,9 +74,9 @@ Operations.prototype.checkLastTimeoutTime = function checkLastTimeoutTime(now) {
         var err = errors.ConnectionStaleTimeoutError({
             lastTimeoutTime: self.lastTimeoutTime
         });
-        self.connection.timedOutEvent.emit(self.connection, err);
-        // TODO: y u no:
-        // self.lastTimeoutTime = now;
+        process.nextTick(function opCheckLastTimedout() {
+            self.connection.timedOutEvent.emit(self.connection, err);
+        });
     } else if (!self.lastTimeoutTime) {
         self.lastTimeoutTime = now;
     }


### PR DESCRIPTION
r @Raynos 

Fixes bug through `TChannelOutRequest#onTImeout`:
- connection timed out event calls connection resetAll
- resetAll calls popOutReq
- popOutReq clears req.operations
- which makes line 567 fail in TChannelOutRequest after checkLastTimeoutTime returns