### PR TITLE
Add explicit section for reserved:1 frame byte

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -215,6 +215,11 @@ size to 64KiB to allow better interleaving of frames across a shared TCP
 connection. In order to handle most operations implementations will need to
 decode some part of the payload.
 
+### reserved:1
+
+Unused space for future protocol revisions, padded for read alignment, which
+may or may not help on modern Intel processors.
+
 ### id:4
 
 An identifier for this message that is chosen by the sender of a request. This


### PR DESCRIPTION
There was a section on the `reserved` padding of 8 bytes in the frame head but the `reserved` frame space of 1 byte was missing from the docs. I'm not sure what the docs should/would say on this lonely byte, so I just copy-pasta'd the blurb from the `reserved:8` section.