### PR TITLE
Cleanup TChannelPeers a bit

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -515,7 +515,9 @@ function waitForIdentified(options, callback) {
     if (self.destroyed) {
         callback(errors.TChannelDestroyedError());
     } else {
-        self.peers.waitForIdentified(options, callback);
+        assert(typeof options.host === 'string', 'options.host is required');
+        var peer = self.peers.add(options.host);
+        peer.waitForIdentified(callback);
     }
 };
 

--- a/node/hyperbahn/service_proxy.js
+++ b/node/hyperbahn/service_proxy.js
@@ -342,7 +342,9 @@ function changeToForward(exitNodes, svcchan) {
     svcchan.peers.clear();
     // TODO: transmit prior known registration data to new owner(s) to
     // speed convergence / deal with transitions better:
-    //     var oldPeers = svcchan.peers.clear();
+    //     var oldHostPorts = svcchan.peers.keys();
+    //     var oldPeers = svcchan.peers.values();
+    //     svcchan.peers.clear();
     //     ... send rpc to new exit nodes
     var exitNames = Object.keys(exitNodes);
     for (var i = 0; i < exitNames.length; i++) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -105,27 +105,31 @@ TChannelPeers.prototype.add = function add(hostPort, options) {
     /*eslint max-statements: [2, 25]*/
     var self = this;
     var peer = self._map[hostPort];
-    if (!peer) {
-        var topChannel = self.channel.topChannel || self.channel;
-
-        if (hostPort === topChannel.hostPort) {
-            if (!topChannel.peers.selfPeer) {
-                topChannel.peers.selfPeer = TChannelSelfPeer(topChannel);
-            }
-
-            return topChannel.peers.selfPeer;
-        }
-
-        if (self.channel.topChannel) {
-            peer = self.channel.topChannel.peers.add(hostPort, options);
-        } else {
-            options = options || extend({}, self.peerOptions);
-            peer = TChannelPeer(self.channel, hostPort, options);
-            self.allocPeerEvent.emit(self, peer);
-        }
-        self._map[hostPort] = peer;
-        self._keys.push(hostPort);
+    if (peer) {
+        return peer;
     }
+
+    var topChannel = self.channel.topChannel || self.channel;
+
+    if (hostPort === topChannel.hostPort) {
+        if (!topChannel.peers.selfPeer) {
+            topChannel.peers.selfPeer = TChannelSelfPeer(topChannel);
+        }
+
+        return topChannel.peers.selfPeer;
+    }
+
+    if (self.channel.topChannel) {
+        peer = self.channel.topChannel.peers.add(hostPort, options);
+    } else {
+        options = options || extend({}, self.peerOptions);
+        peer = TChannelPeer(self.channel, hostPort, options);
+        self.allocPeerEvent.emit(self, peer);
+    }
+
+    self._map[hostPort] = peer;
+    self._keys.push(hostPort);
+
     return peer;
 };
 

--- a/node/peers.js
+++ b/node/peers.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var assert = require('assert');
 var inherits = require('util').inherits;
 var extend = require('xtend');
 var EventEmitter = require('./lib/event_emitter');
@@ -192,16 +191,6 @@ TChannelPeers.prototype.delete = function del(hostPort) {
     self._keys.splice(index, 1);
 
     return peer;
-};
-
-TChannelPeers.prototype.waitForIdentified =
-function waitForIdentified(options, callback) {
-    var self = this;
-
-    assert(typeof options.host === 'string', 'options.host is required');
-
-    var peer = self.add(options.host);
-    peer.waitForIdentified(callback);
 };
 
 TChannelPeers.prototype.choosePeer =

--- a/node/peers.js
+++ b/node/peers.js
@@ -160,8 +160,7 @@ TChannelPeers.prototype.entries = function entries() {
 
 TChannelPeers.prototype.clear = function clear() {
     var self = this;
-    var keys = self.keys();
-    var vals = new Array(keys.length);
+
     if (self.channel.subChannels) {
         var names = Object.keys(self.channel.subChannels);
         for (var i = 0; i < names.length; i++) {
@@ -172,7 +171,6 @@ TChannelPeers.prototype.clear = function clear() {
     }
     self._map = Object.create(null);
     self._keys = [];
-    return vals;
 };
 
 TChannelPeers.prototype.delete = function del(hostPort) {

--- a/node/peers.js
+++ b/node/peers.js
@@ -200,6 +200,10 @@ function choosePeer(req) {
     /*eslint complexity: [2, 15]*/
     var self = this;
 
+    if (!self.channel.topChannel) {
+        return null;
+    }
+
     var hosts = self._keys;
     if (!hosts || !hosts.length) {
         return null;

--- a/node/test/lib/relay_network.js
+++ b/node/test/lib/relay_network.js
@@ -220,11 +220,9 @@ RelayNetwork.prototype.setCluster = function setCluster(cluster) {
                         cn: serviceName
                     },
                     hasNoParent: true
-                }
+                },
+                peers: self.topology[serviceName]
             });
-            // The subchannel's peers are linked to the peer list as managed by
-            // incoming connections from the relays.
-            subChannel.peers = channel.peers;
 
             // Set up server
             var endpointHandler = new EndpointHandler(serviceName);


### PR DESCRIPTION
- drop dubious `#waitForIdentified`
- drop broken return from `#clear`
- flatten flow of `#add` so it's clearer to break up going forward
- always return null from `#choosePeer` on the top channel

r @Raynos @kriskowal 