### PR TITLE
Unbreak the tchannel relay for streaming

### DIFF
--- a/node/argstream.js
+++ b/node/argstream.js
@@ -227,6 +227,7 @@ function StreamArg(options) {
     PassThrough.call(self, options);
     self.started = false;
     self.onValueReady = self.onValueReady.bind(self);
+    self.buf = null;
 }
 inherits(StreamArg, PassThrough);
 
@@ -259,6 +260,7 @@ function bufferStreamData(stream, callback) {
         stream.removeListener('error', finish);
         stream.removeListener('end', finish);
         var buf = Buffer.concat(parts);
+        stream.buf = buf;
         if (err === undefined) err = null;
         callback(err, buf);
     }

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -124,9 +124,15 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
 
     if (self.outreq.streamed) {
         // TODO: frame-at-a-time rather than re-streaming?
-        self.inreq.arg1.pipe(self.outreq.arg1);
-        self.inreq.arg2.pipe(self.outreq.arg2);
-        self.inreq.arg3.pipe(self.outreq.arg3);
+
+        var arg1 = self.inreq.arg1;
+        if (arg1.buf) {
+            arg1 = arg1.buf;
+        }
+
+        self.outreq.sendStreams(
+            arg1, self.inreq.arg2, self.inreq.arg3
+        );
     } else {
         self.outreq.send(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
     }

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -32,6 +32,8 @@ function RelayRequest(channel, inreq, buildRes) {
     self.outreq = null;
     self.buildRes = buildRes;
     self.peer = null;
+
+    self.error = null;
 }
 
 RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
@@ -144,7 +146,9 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
         self.channel.logger.warn('relay request already responded', {
             // TODO: better context
             remoteAddr: self.inreq.remoteAddr,
-            id: self.inreq.id
+            id: self.inreq.id,
+            options: options,
+            error: self.error
         });
         return null;
     }
@@ -200,6 +204,9 @@ RelayRequest.prototype.onResponse = function onResponse(res) {
 
 RelayRequest.prototype.onError = function onError(err) {
     var self = this;
+
+    self.error = err;
+
     if (!self.createOutResponse()) return;
     var codeName = errors.classify(err) || 'UnexpectedError';
 

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -23,7 +23,7 @@
 var bufrw = require('bufrw');
 var Checksum = require('./checksum');
 var ArgsRW = require('./args');
-var argsrw = ArgsRW(bufrw.buf2);
+var argsrw = ArgsRW();
 
 // flags:1 csumtype:1 (csum:4){0,1} (arg~2)+
 function CallRequestCont(flags, csum, args) {


### PR DESCRIPTION
When circuits is turned on then the circuit breaker will
drain arg1.

To avoid dropping arg1 in the relay we have to favor
the cached buffer if available.

**Note:** We really need to fix the code debt where
arg1 is a stream instead of a buffer. It should always
be a buffer.

r: @kriskowal @jcorbin