### PR TITLE
Peers: breakup

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -161,9 +161,8 @@ function TChannel(options) {
         delete self.options.serviceName;
     }
 
-    // populated by makeSubChannel
     self.topChannel = self.options.topChannel || null;
-    self.subChannels = self.serviceName ? null : {};
+    self.subChannels = self.topChannel ? null : {};
 
     // for processing operation timeouts
     self.timeHeap = self.options.timeHeap || new TimeHeap({

--- a/node/channel.js
+++ b/node/channel.js
@@ -44,7 +44,8 @@ var Stat = require('./lib/stat.js');
 var TChannelAsThrift = require('./as/thrift');
 var TChannelAsJSON = require('./as/json');
 var TChannelConnection = require('./connection');
-var TChannelPeers = require('./peers');
+var TChannelRootPeers = require('./root_peers');
+var TChannelSubPeers = require('./sub_peers');
 var TChannelServices = require('./services');
 var TChannelStatsd = require('./lib/statsd');
 var RetryFlags = require('./retry-flags.js');
@@ -197,7 +198,12 @@ function TChannel(options) {
     // populated by:
     // - manually api (.peers.add etc)
     // - incoming connections on any listening socket
-    self.peers = TChannelPeers(self, self.options);
+
+    if (!self.topChannel) {
+        self.peers = TChannelRootPeers(self, self.options);
+    } else {
+        self.peers = TChannelSubPeers(self, self.options);
+    }
 
     // For tracking the number of pending requests to any service
     self.services = new TChannelServices();

--- a/node/peers_base.js
+++ b/node/peers_base.js
@@ -1,0 +1,122 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var inherits = require('util').inherits;
+var EventEmitter = require('./lib/event_emitter');
+
+function TChannelPeersBase(channel, options) {
+    var self = this;
+    EventEmitter.call(self);
+
+    self.channel = channel;
+    self.logger = self.channel.logger;
+    self.options = options || {};
+    self._map = Object.create(null);
+    self._keys = [];
+}
+
+inherits(TChannelPeersBase, EventEmitter);
+
+TChannelPeersBase.prototype.close = function close(peers, callback) {
+    var self = this;
+
+    var counter = peers.length + 1;
+    peers.forEach(function eachPeer(peer) {
+        peer.close(onClose);
+    });
+    self.clear();
+    onClose();
+
+    function onClose() {
+        if (--counter <= 0) {
+            if (counter < 0) {
+                self.logger.error('closed more peers than expected', {
+                    counter: counter
+                });
+            }
+            callback();
+        }
+    }
+};
+
+TChannelPeersBase.prototype.sanitySweep = function sanitySweep() {
+    var self = this;
+
+    var peers = self.values();
+    for (var i = 0; i < peers.length; i++) {
+        var peer = peers[i];
+        for (var j = 0; j < peer.connections.length; j++) {
+            var conn = peer.connections[j];
+            conn.ops.sanitySweep();
+        }
+    }
+};
+
+TChannelPeersBase.prototype.get = function get(hostPort) {
+    var self = this;
+
+    return self._map[hostPort] || null;
+};
+
+TChannelPeersBase.prototype.keys = function keys() {
+    var self = this;
+
+    return self._keys.slice();
+};
+
+TChannelPeersBase.prototype.values = function values() {
+    var self = this;
+
+    var keys = self._keys;
+    var ret = new Array(keys.length);
+    for (var i = 0; i < keys.length; i++) {
+        ret[i] = self._map[keys[i]];
+    }
+
+    return ret;
+};
+
+TChannelPeersBase.prototype.entries = function entries() {
+    var self = this;
+
+    var keys = self._keys;
+    var ret = new Array(keys.length);
+    for (var i = 0; i < keys.length; i++) {
+        ret[i] = [keys[i], self._map[keys[i]]];
+    }
+    return ret;
+};
+
+TChannelPeersBase.prototype.delete = function del(hostPort) {
+    var self = this;
+    var peer = self._map[hostPort];
+
+    if (!peer) {
+        return;
+    }
+
+    self._delete(peer);
+
+    return peer;
+};
+
+module.exports = TChannelPeersBase;

--- a/node/root_peers.js
+++ b/node/root_peers.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var inherits = require('util').inherits;
+var extend = require('xtend');
+
+var TChannelPeersBase = require('./peers_base.js');
+var TChannelPeer = require('./peer');
+var TChannelSelfPeer = require('./self_peer');
+
+function TChannelRootPeers(channel, options) {
+    if (!(this instanceof TChannelRootPeers)) {
+        return new TChannelRootPeers(channel, options);
+    }
+
+    var self = this;
+    TChannelPeersBase.call(self, channel, options);
+
+    self.allocPeerEvent = self.defineEvent('allocPeer');
+    self.peerOptions = self.options.peerOptions || {};
+    self.selfPeer = null;
+}
+
+inherits(TChannelRootPeers, TChannelPeersBase);
+
+TChannelRootPeers.prototype.close = function close(callback) {
+    var self = this;
+
+    var peers = self.values();
+    if (self.selfPeer) {
+        peers.push(self.selfPeer);
+    }
+    TChannelPeersBase.prototype.close.call(self, peers, callback);
+};
+
+TChannelRootPeers.prototype.sanitySweep = function sanitySweep() {
+    var self = this;
+
+    if (self.selfPeer) {
+        for (var i = 0; i < self.selfPeer.connections.length; i++) {
+            var conn = self.selfPeer.connections[i];
+            conn.ops.sanitySweep();
+        }
+    }
+    TChannelPeersBase.prototype.sanitySweep.call(self);
+};
+
+TChannelRootPeers.prototype.getSelfPeer = function getSelfPeer() {
+    var self = this;
+
+    if (!self.selfPeer) {
+        self.selfPeer = TChannelSelfPeer(self.channel);
+    }
+    return self.selfPeer;
+};
+
+TChannelRootPeers.prototype.add = function add(hostPort, options) {
+    /*eslint max-statements: [2, 25]*/
+    var self = this;
+
+    var peer = self._map[hostPort];
+    if (peer) {
+        return peer;
+    }
+
+    if (hostPort === self.channel.hostPort) {
+        return self.getSelfPeer();
+    }
+
+    options = options || extend({}, self.peerOptions);
+    peer = TChannelPeer(self.channel, hostPort, options);
+    self.allocPeerEvent.emit(self, peer);
+
+    self._map[hostPort] = peer;
+    self._keys.push(hostPort);
+
+    return peer;
+};
+
+TChannelRootPeers.prototype.clear = function clear() {
+    var self = this;
+
+    var names = Object.keys(self.channel.subChannels);
+    for (var i = 0; i < names.length; i++) {
+        var subChannel = self.channel.subChannels[names[i]];
+        subChannel.peers._map = Object.create(null);
+        subChannel.peers._keys = [];
+    }
+
+    self._map = Object.create(null);
+    self._keys = [];
+};
+
+TChannelRootPeers.prototype._delete = function _del(peer) {
+    var self = this;
+
+    var names = Object.keys(self.channel.subChannels);
+    for (var i = 0; i < names.length; i++) {
+        var subChannel = self.channel.subChannels[names[i]];
+        subChannel.peers._delete(peer);
+    }
+
+    delete self._map[peer.hostPort];
+    var index = self._keys.indexOf(peer.hostPort);
+    self._keys.splice(index, 1); // TODO: such splice
+};
+
+TChannelRootPeers.prototype.choosePeer = function choosePeer(req) {
+    return null;
+};
+
+module.exports = TChannelRootPeers;

--- a/node/root_peers.js
+++ b/node/root_peers.js
@@ -121,11 +121,25 @@ TChannelRootPeers.prototype._delete = function _del(peer) {
 
     delete self._map[peer.hostPort];
     var index = self._keys.indexOf(peer.hostPort);
-    self._keys.splice(index, 1); // TODO: such splice
+    popout(self._keys, index);
 };
 
 TChannelRootPeers.prototype.choosePeer = function choosePeer(req) {
     return null;
 };
+
+function popout(array, i) {
+    if (!array.length) {
+        return;
+    }
+
+    var j = array.length - 1;
+    if (i !== j) {
+        var tmp = array[i];
+        array[i] = array[j];
+        array[j] = tmp;
+    }
+    array.pop();
+}
 
 module.exports = TChannelRootPeers;

--- a/node/sub_peers.js
+++ b/node/sub_peers.js
@@ -78,7 +78,7 @@ TChannelSubPeers.prototype._delete = function _del(peer) {
 
     delete self._map[peer.hostPort];
     var index = self._keys.indexOf(peer.hostPort);
-    self._keys.splice(index, 1); // TODO: such splice
+    popout(self._keys, index);
 };
 
 TChannelSubPeers.prototype.choosePeer = function choosePeer(req) {
@@ -109,5 +109,19 @@ TChannelSubPeers.prototype.choosePeer = function choosePeer(req) {
     }
     return selectedPeer;
 };
+
+function popout(array, i) {
+    if (!array.length) {
+        return;
+    }
+
+    var j = array.length - 1;
+    if (i !== j) {
+        var tmp = array[i];
+        array[i] = array[j];
+        array[j] = tmp;
+    }
+    array.pop();
+}
 
 module.exports = TChannelSubPeers;


### PR DESCRIPTION
The existing TChannelPeers class already had extensive branching for root vs sub channel use case.

This PR breaks those out explicitly into two subclases of a new shared base class.

Plus I killed use of array splice for fun.

r @kriskowal @Raynos 