### PR TITLE
channel: do not traceSample if no trace

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -640,17 +640,16 @@ TChannel.prototype.request = function channelRequest(options) {
 
     options = options || {};
 
-    if (options.hasNoParent) {
+    var opts = new RequestOptions(self, options);
+    self.fastRequestDefaults(opts);
+
+    if (opts.trace && opts.hasNoParent) {
         if (Math.random() < self.traceSample) {
-            options.trace = true;
+            opts.trace = true;
         } else {
-            options.trace = false;
+            opts.trace = false;
         }
     }
-
-    var opts = new RequestOptions(self, options);
-
-    self.fastRequestDefaults(opts);
 
     return self._request(opts);
 };

--- a/node/examples/example1.js
+++ b/node/examples/example1.js
@@ -67,7 +67,7 @@ server.listen(4040, '127.0.0.1', function onListen() {
 
     clientChan.request({
         serviceName: 'server',
-        timeout: 1000
+        timeout: 1500
     }).send('func1', 'arg 1', 'arg 2', function onResp(err, res, arg2, arg3) {
         if (err) {
             finish(err);


### PR DESCRIPTION
We must not mutate trace=false -> trace=true due
to the hasNoParent stuff.

r: @rf @shannili @kriskowal