### PR TITLE
No checksumming for out relay request.

### DIFF
--- a/node/benchmarks/Makefile
+++ b/node/benchmarks/Makefile
@@ -36,7 +36,7 @@ take:
 
 take_relay:
 	node index.js --relay -o relay-$$(git rev-parse --short HEAD).json \
-		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
+		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000,20000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 
 take_trace:

--- a/node/channel.js
+++ b/node/channel.js
@@ -685,6 +685,7 @@ function RequestOptions(channel, opts) {
     self.tracing = opts.tracing || null;
     self.peer = opts.peer || null;
     self.timeoutPerAttempt = opts.timeoutPerAttempt || 0;
+    self.checksum = opts.checksum || null;
 
     // TODO optimize?
     self.headers = opts.headers || new RequestHeaders();
@@ -694,7 +695,6 @@ function RequestOptions(channel, opts) {
     self.peerState = null;
     self.remoteAddr = null;
     self.hostPort = null;
-    self.checksum = null;
 }
 
 function RequestHeaders() {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -886,7 +886,9 @@ TChannelV2Handler.prototype.buildOutResponse = function buildOutResponse(req, op
     options.tracing = req.tracing;
     options.span = req.span;
     options.checksumType = req.checksum.type;
-    options.checksum = new v2.Checksum(req.checksum.type);
+    if (!options.checksum) {
+        options.checksum = new v2.Checksum(req.checksum.type);
+    }
     if (options.streamed) {
         return new StreamingOutResponse(self, req.id, options);
     } else {


### PR DESCRIPTION
This removes the CRC32 calls in the outrequest and
outresponse path for the relay.

```
GET 16KiB, 1000/0  rate: hi-diff:     65.78 (  3.2%)
GET 16KiB, 10000/0 rate: hi-diff:    -35.42 ( -2.0%)
GET 16KiB, 20000/0 rate: hi-diff:    -45.27 ( -3.0%)
GET 4KiB, 1000/0   rate: hi-diff:    102.29 (  4.2%)
GET 4KiB, 10000/0  rate: hi-diff:    165.04 (  7.8%)
GET 4KiB, 20000/0  rate: hi-diff:    -66.58 ( -3.4%)
SET 16KiB, 1000/0  rate: hi-diff:   -327.10 (-17.6%)
SET 16KiB, 10000/0 rate: hi-diff:     43.05 (  2.7%)
SET 16KiB, 20000/0 rate: hi-diff:     44.40 (  3.2%)
SET 4KiB, 1000/0   rate: hi-diff:    -66.24 ( -2.7%)
SET 4KiB, 10000/0  rate: hi-diff:     74.71 (  3.6%)
SET 4KiB, 20000/0  rate: hi-diff:    120.23 (  7.6%)
```

Benchmarking numbers are spotty but I'm removing
weight from the flamegraphs.

r: @kriskowal @shannili @jcorbin