### PR TITLE
WIP: Use a branch of stats that goes faster

### DIFF
--- a/node/benchmarks/relay_server.js
+++ b/node/benchmarks/relay_server.js
@@ -72,6 +72,7 @@ function RelayServer(opts) {
         trace: false,
         statsd: new Statsd({
             host: '127.0.0.1',
+            unsafeIPOnly: true,
             port: 7036
         })
     });

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "sse4_crc32": "^3.1.0",
     "tape-cluster": "2.1.0",
     "thriftify": "1.0.0-alpha14",
-    "uber-statsd-client": "1.3.2",
+    "uber-statsd-client": "git://github.com/uber/node-statsd-client.git#go-fast",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
```
GET 16KiB, 1000/0  rate: hi-diff:     30.24 (  1.5%)
GET 16KiB, 10000/0 rate: hi-diff:    -88.32 ( -4.9%)
GET 16KiB, 20000/0 rate: hi-diff:     -7.21 ( -0.5%)
GET 4KiB, 1000/0   rate: hi-diff:     19.68 (  0.8%)
GET 4KiB, 10000/0  rate: hi-diff:    121.40 (  5.8%)
GET 4KiB, 20000/0  rate: hi-diff:     54.19 (  2.7%)
SET 16KiB, 1000/0  rate: hi-diff:     41.02 (  2.2%)
SET 16KiB, 10000/0 rate: hi-diff:     12.75 (  0.8%)
SET 16KiB, 20000/0 rate: hi-diff:     54.18 (  3.9%)
SET 4KiB, 1000/0   rate: hi-diff:     62.25 (  2.6%)
SET 4KiB, 10000/0  rate: hi-diff:    -37.49 ( -1.8%)
SET 4KiB, 20000/0  rate: hi-diff:    174.15 ( 11.0%)
```

This relies on the #go-fast branch of uber-statsd-client
- Move Tag constructors into file.
- Remove a tchannel string concat
- Move string building out of switch and into method
- Turn on unsafeIPOnly feature to avoid buffer copies

r: @jcorbin @kriskowal @shannili
