### PR TITLE
Sort out relay request log shenanigans

### DIFF
--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -269,6 +269,9 @@ function errorLogLevel(err, codeName) {
         case 'BadRequest':
         case 'Timeout':
             return 'info';
+
+        default:
+            return 'error';
     }
 }
 

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -246,14 +246,12 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
         } else if (level === 'info') {
             logger.info('forwarding expected error frame', logOptions);
         }
-    } else {
-        if (level === 'error') {
-            logger.error('unexpected error while forwarding', logOptions);
-        } else if (level === 'warn') {
-            logger.warn('error while forwarding', logOptions);
-        } else if (level === 'info') {
-            logger.info('expected error while forwarding', logOptions);
-        }
+    } else if (level === 'error') {
+        logger.error('unexpected error while forwarding', logOptions);
+    } else if (level === 'warn') {
+        logger.warn('error while forwarding', logOptions);
+    } else if (level === 'info') {
+        logger.info('expected error while forwarding', logOptions);
     }
 };
 

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -26,6 +26,7 @@ function RelayRequest(channel, inreq, buildRes) {
     var self = this;
 
     self.channel = channel;
+    self.logger = self.channel.logger;
     self.inreq = inreq;
     self.inres = null;
     self.outres = null;
@@ -40,7 +41,7 @@ RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
     var self = this;
 
     if (self.outreq) {
-        self.channel.logger.warn('relay request already started', {
+        self.logger.warn('relay request already started', {
             // TODO: better context
             remoteAddr: self.inreq.remoteAddr,
             id: self.inreq.id
@@ -149,7 +150,7 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
 RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     var self = this;
     if (self.outres) {
-        self.channel.logger.warn('relay request already responded', {
+        self.logger.warn('relay request already responded', {
             // TODO: better context
             remoteAddr: self.inreq.remoteAddr,
             id: self.inreq.id,
@@ -163,7 +164,7 @@ RelayRequest.prototype.createOutResponse = function createOutResponse(options) {
     // It is also possible that the out request gets repead with a timeout
     // Both the in & out req try to create an outgoing response
     if (self.inreq.res && self.inreq.res.codeString === 'Timeout') {
-        self.channel.logger.debug('relay: in request already timed out', {
+        self.logger.debug('relay: in request already timed out', {
             codeString: self.inreq.res.codeString,
             responseMessage: self.inreq.res.message,
             serviceName: self.outreq && self.outreq.serviceName,
@@ -184,7 +185,7 @@ RelayRequest.prototype.onResponse = function onResponse(res) {
     var self = this;
 
     if (self.inres) {
-        self.channel.logger.warn('relay request got more than one response callback', {
+        self.logger.warn('relay request got more than one response callback', {
             // TODO: better context
             remoteAddr: res.remoteAddr,
             id: res.id
@@ -226,7 +227,6 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
 
     var level = errorLogLevel(err, codeName);
 
-    var logger = self.channel.logger;
     var logOptions = {
         error: err,
         isErrorFrame: err.isErrorFrame,
@@ -238,16 +238,16 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
 
     if (err.isErrorFrame) {
         if (level === 'warn') {
-            logger.warn('forwarding error frame', logOptions);
+            self.logger.warn('forwarding error frame', logOptions);
         } else if (level === 'info') {
-            logger.info('forwarding expected error frame', logOptions);
+            self.logger.info('forwarding expected error frame', logOptions);
         }
     } else if (level === 'error') {
-        logger.error('unexpected error while forwarding', logOptions);
+        self.logger.error('unexpected error while forwarding', logOptions);
     } else if (level === 'warn') {
-        logger.warn('error while forwarding', logOptions);
+        self.logger.warn('error while forwarding', logOptions);
     } else if (level === 'info') {
-        logger.info('expected error while forwarding', logOptions);
+        self.logger.info('expected error while forwarding', logOptions);
     }
 };
 

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -224,26 +224,7 @@ RelayRequest.prototype.onError = function onError(err) {
 RelayRequest.prototype.logError = function logError(err, codeName) {
     var self = this;
 
-    var level;
-    switch (codeName) {
-        case 'ProtocolError':
-        case 'UnexpectedError':
-            level = 'error';
-            break;
-
-        case 'NetworkError':
-        case 'Cancelled':
-        case 'Declined':
-        case 'Busy':
-            level = 'warn';
-            break;
-
-        case 'BadRequest':
-        case 'Timeout':
-            level = 'info';
-            break;
-
-    }
+    var level = errorLogLevel(err, codeName);
 
     if (level === 'error' && err.isErrorFrame) {
         level = 'warn';
@@ -276,5 +257,22 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
     }
 };
 
-module.exports = RelayRequest;
+function errorLogLevel(err, codeName) {
+    switch (codeName) {
+        case 'ProtocolError':
+        case 'UnexpectedError':
+            return 'error';
 
+        case 'NetworkError':
+        case 'Cancelled':
+        case 'Declined':
+        case 'Busy':
+            return 'warn';
+
+        case 'BadRequest':
+        case 'Timeout':
+            return 'info';
+    }
+}
+
+module.exports = RelayRequest;

--- a/node/relay_request.js
+++ b/node/relay_request.js
@@ -226,10 +226,6 @@ RelayRequest.prototype.logError = function logError(err, codeName) {
 
     var level = errorLogLevel(err, codeName);
 
-    if (level === 'error' && err.isErrorFrame) {
-        level = 'warn';
-    }
-
     var logger = self.channel.logger;
     var logOptions = {
         error: err,
@@ -259,6 +255,9 @@ function errorLogLevel(err, codeName) {
     switch (codeName) {
         case 'ProtocolError':
         case 'UnexpectedError':
+            if (err.isErrorFrame) {
+                return 'warn';
+            }
             return 'error';
 
         case 'NetworkError':


### PR DESCRIPTION
Whilst doing other work, I managed to provoke a "cannot call method error of undefined" wrt self.logger in RelayRequest from our test suite.

This fixes that, plus:
- factors out the error/code classification as a forward pass to other lazy relay request refactoring work
- adds a defense-in-depth default error log level; the old behavior would have been silent failure
- gets rid of a needless comparison by doing it in its predicated case branch

r @kriskowal @Raynos 