### PR TITLE
Move connection error vs close handling more towards correct

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -463,7 +463,6 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
     self.closing = true;
     self.closeError = err;
     self.socket.destroy();
-    self.closeEvent.emit(self, err);
 
     var requests = self.ops.getRequests();
     var pending = self.ops.getPending();
@@ -514,22 +513,6 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
         outPending: pending.out
     };
 
-    var errorCodeName = errors.classify(err);
-
-    if (errorCodeName !== 'NetworkError' &&
-        errorCodeName !== 'ProtocolError'
-    ) {
-        self.logger.warn('resetting connection', logInfo);
-        self.errorEvent.emit(self, err);
-    } else if (
-        err.type !== 'tchannel.socket-closed' &&
-        err.type !== 'tchannel.socket-local-closed'
-    ) {
-        logInfo.error = extend(err);
-        logInfo.error.message = err.message;
-        self.logger.info('resetting connection', logInfo);
-    }
-
     // requests that we've received we can delete, but these reqs may have started their
     //   own outgoing work, which is hard to cancel. By setting this.closing, we make sure
     //   that once they do finish that their callback will swallow the response.
@@ -566,6 +549,23 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
     });
 
     self.ops.clear();
+
+    var errorCodeName = errors.classify(err);
+    if (errorCodeName !== 'NetworkError' &&
+        errorCodeName !== 'ProtocolError'
+    ) {
+        self.logger.warn('resetting connection', logInfo);
+        self.errorEvent.emit(self, err);
+    } else if (
+        err.type !== 'tchannel.socket-closed' &&
+        err.type !== 'tchannel.socket-local-closed'
+    ) {
+        logInfo.error = extend(err);
+        logInfo.error.message = err.message;
+        self.logger.info('resetting connection', logInfo);
+    }
+
+    self.closeEvent.emit(self, err);
 };
 
 function InitOperation(connection, time, timeout) {

--- a/node/connection.js
+++ b/node/connection.js
@@ -554,13 +554,15 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
             serviceName: req.serviceName,
             outArg1: String(req.arg1)
         };
-        if (err.type === 'tchannel.socket-local-closed') {
-            err = errors.TChannelLocalResetError(err, info);
+
+        var reqErr = err;
+        if (reqErr.type === 'tchannel.socket-local-closed') {
+            reqErr = errors.TChannelLocalResetError(reqErr, info);
         } else {
-            err = errors.TChannelConnectionResetError(err, info);
+            reqErr = errors.TChannelConnectionResetError(reqErr, info);
         }
 
-        req.emitError(err);
+        req.emitError(reqErr);
     });
 
     self.ops.clear();

--- a/node/peer.js
+++ b/node/peer.js
@@ -260,25 +260,30 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
     return conn;
 
     function onConnectionError(err) {
-        var codeName = errors.classify(err);
-
-        var loggerInfo = {
-            error: err,
-            direction: conn.direction,
-            remoteName: conn.remoteName,
-            socketRemoteAddr: conn.socketRemoteAddr
-        };
-
-        if (codeName === 'Timeout') {
-            self.logger.warn('Got a connection error', loggerInfo);
-        } else {
-            self.logger.error('Got an unexpected connection error', loggerInfo);
-        }
-
-        self.removeConnection(conn);
+        removeConnection(err);
     }
 
     function onConnectionClose() {
+        removeConnection(null);
+    }
+
+    function removeConnection(err) {
+        if (err) {
+            var loggerInfo = {
+                error: err,
+                direction: conn.direction,
+                remoteName: conn.remoteName,
+                socketRemoteAddr: conn.socketRemoteAddr
+            };
+
+            var codeName = errors.classify(err);
+            if (codeName === 'Timeout') {
+                self.logger.warn('Got a connection error', loggerInfo);
+            } else {
+                self.logger.error('Got an unexpected connection error', loggerInfo);
+            }
+        }
+
         self.removeConnection(conn);
     }
 };

--- a/node/peer.js
+++ b/node/peer.js
@@ -214,21 +214,27 @@ function waitForIdentified(callback) {
 
 TChannelPeer.prototype._waitForIdentified =
 function _waitForIdentified(conn, callback) {
+    conn.errorEvent.on(onConnectionError);
     conn.closeEvent.on(onConnectionClose);
     conn.identifiedEvent.on(onIdentified);
 
-    function onConnectionClose(err) {
-        conn.closeEvent.removeListener(onConnectionClose);
-        conn.identifiedEvent.removeListener(onIdentified);
+    function onConnectionError(err) {
+        finish(err);
+    }
 
-        callback(err);
+    function onConnectionClose(err) {
+        finish(err);
     }
 
     function onIdentified() {
+        finish(null);
+    }
+
+    function finish(err) {
+        conn.errorEvent.removeListener(onConnectionError);
         conn.closeEvent.removeListener(onConnectionClose);
         conn.identifiedEvent.removeListener(onIdentified);
-
-        callback(null);
+        callback(err);
     }
 };
 

--- a/node/peer.js
+++ b/node/peer.js
@@ -268,6 +268,8 @@ TChannelPeer.prototype.addConnection = function addConnection(conn) {
     }
 
     function removeConnection(err) {
+        conn.closeEvent.removeListener(onConnectionClose);
+        conn.errorEvent.removeListener(onConnectionError);
         if (err) {
             var loggerInfo = {
                 error: err,

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -110,9 +110,9 @@ allocCluster.test('request() with zero timeout', {
             tracer: conn.tracer,
             serviceName: 'server',
             host: one.hostPort,
+            hasNoParent: true,
             checksumType: null,
             timers: conn.channel.timers,
-            hasNoParent: true,
             headers: {
                 'as': 'raw',
                 'cn': 'wat'

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -82,8 +82,6 @@ allocCluster.test('request() with zero timeout', {
     }
 });
 
-var allocCluster = require('./lib/alloc-cluster.js');
-
 allocCluster.test('request() with zero timeout', {
     numPeers: 2
 }, function t(cluster, assert) {

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -79,8 +79,8 @@ allocCluster.test('request() with zero timeout', {
     function checkLog() {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
-        assert.equal(logLine.levelName, 'info');
-        assert.equal(logLine.meta.error.type, 'tchannel.protocol.write-failed');
+        assert.equal(logLine && logLine.levelName, 'info');
+        assert.equal(logLine && logLine.meta.error.type, 'tchannel.protocol.write-failed');
 
         assert.end();
     }
@@ -142,8 +142,8 @@ allocCluster.test('request() with zero timeout', {
     function checkLog() {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
-        assert.equal(logLine.levelName, 'info');
-        assert.equal(logLine.meta.error.type, 'tchannel.protocol.write-failed');
+        assert.equal(logLine && logLine.levelName, 'info');
+        assert.equal(logLine && logLine.meta.error.type, 'tchannel.protocol.write-failed');
 
         assert.end();
     }

--- a/node/test/non-zero-ttl.js
+++ b/node/test/non-zero-ttl.js
@@ -73,6 +73,10 @@ allocCluster.test('request() with zero timeout', {
 
         assert.equal(resp, null);
 
+        process.nextTick(checkLog);
+    }
+
+    function checkLog() {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
         assert.equal(logLine.levelName, 'info');
@@ -132,6 +136,10 @@ allocCluster.test('request() with zero timeout', {
 
         assert.equal(resp, null);
 
+        process.nextTick(checkLog);
+    }
+
+    function checkLog() {
         assert.equal(cluster.logger.items().length, 1);
         var logLine = cluster.logger.items()[0];
         assert.equal(logLine.levelName, 'info');


### PR DESCRIPTION
Had to back off from making close event node-idiomatic (take only a "was it a clean close" boolean) due to how coupled we are currently to getting the error through close.

r @raynos @kriskowal 