### PR TITLE
Now all code paths in forwardToTChannel are calling callback function

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -188,6 +188,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
         if (err) {
             hres.writeHead(500, 'Connection failure');
             hres.end();
+            callback(err);
             return null;
         }
 


### PR DESCRIPTION
Found this during testing my service (xlate) using TChannel on local box. Was not getting TChannel error propagted back to my service