### PR TITLE
Timed periodic

### DIFF
--- a/node/circuits.js
+++ b/node/circuits.js
@@ -117,6 +117,7 @@ function Circuits(options) {
     self.config = options.config || {};
 
     self.stateOptions = new states.StateOptions(null, {
+        timeHeap: options.timeHeap,
         timers: options.timers,
         random: options.random,
         nextHandler: alwaysShouldRequestHandler,

--- a/node/hyperbahn/service_proxy.js
+++ b/node/hyperbahn/service_proxy.js
@@ -53,6 +53,7 @@ function ServiceDispatchHandler(options) {
     self.serviceReqDefaults = options.serviceReqDefaults || {};
 
     self.circuits = options.circuitsConfig && options.circuitsConfig.enabled ? new Circuits({
+        timeHeap: self.channel.timeHeap,
         timers: self.channel.timers,
         random: self.random,
         egressNodes: self.egressNodes,

--- a/node/peer.js
+++ b/node/peer.js
@@ -55,6 +55,7 @@ function TChannelPeer(channel, hostPort, options) {
     self.connections = [];
 
     self.stateOptions = new states.StateOptions(self, {
+        timeHeap: self.channel.timeHeap,
         timers: self.timers,
         random: self.random,
         period: self.options.period,

--- a/node/state_machine.js
+++ b/node/state_machine.js
@@ -39,16 +39,17 @@ StateMachine.prototype.setState = function setState(StateType) {
     if (currentType &&
         StateType.prototype.type &&
         StateType.prototype.type === currentType) {
-        return;
+        return null;
     }
 
     assert(self.stateOptions, 'state machine must have stateOptions');
     var state = new StateType(self.stateOptions);
     if (state && state.type === currentType) {
-        return;
+        return null;
     }
 
     var oldState = self.state;
     self.state = state;
     self.stateChangedEvent.emit(self, [oldState, state]);
+    return state;
 };

--- a/node/state_machine.js
+++ b/node/state_machine.js
@@ -50,6 +50,9 @@ StateMachine.prototype.setState = function setState(StateType) {
 
     var oldState = self.state;
     self.state = state;
+    if (oldState) {
+        oldState.onDeactivate();
+    }
     self.stateChangedEvent.emit(self, [oldState, state]);
     return state;
 };

--- a/node/state_machine.js
+++ b/node/state_machine.js
@@ -34,17 +34,20 @@ function StateMachine() {
 
 StateMachine.prototype.setState = function setState(StateType) {
     var self = this;
+
     var currentType = self.state && self.state.type;
     if (currentType &&
         StateType.prototype.type &&
         StateType.prototype.type === currentType) {
         return;
     }
+
     assert(self.stateOptions, 'state machine must have stateOptions');
     var state = new StateType(self.stateOptions);
     if (state && state.type === currentType) {
         return;
     }
+
     var oldState = self.state;
     self.state = state;
     self.stateChangedEvent.emit(self, [oldState, state]);

--- a/node/states.js
+++ b/node/states.js
@@ -243,6 +243,7 @@ HealthyState.prototype.onRequestUnhealthy = function onRequestUnhealthy() {
     var self = this;
     self.totalRequests++;
     self.unhealthyCount++;
+    self.checkPeriod(false, self.timers.now());
 };
 
 HealthyState.prototype.onRequestError = function onRequestError(err) {
@@ -255,6 +256,7 @@ HealthyState.prototype.onRequestError = function onRequestError(err) {
     } else {
         self.healthyCount++;
     }
+    self.checkPeriod(false, self.timers.now());
 };
 
 function UnhealthyState(options) {
@@ -301,6 +303,7 @@ UnhealthyState.prototype.onRequest = function onRequest(/* req */) {
     var self = this;
 
     self.triedThisPeriod = true;
+    self.checkPeriod(false, self.timers.now());
 };
 
 UnhealthyState.prototype.onRequestHealthy = function onRequestHealthy() {

--- a/node/states.js
+++ b/node/states.js
@@ -76,6 +76,9 @@ function State(options) {
     self.random = options.random;
 }
 
+State.prototype.onDeactivate = function onDeactivate() {
+};
+
 State.prototype.onRequest = function onRequest(/* req */) {
 };
 


### PR DESCRIPTION
Final work so that peer states can maintain functionality beyond being short-polled by request scoring:
- add state deactivation hook
- pass channel time heap to states
- implement and use the heaped timeout api in PeriodicState
- pump period checking from other event trigger paths to maintain expected fast edge triggering (e.g. the probe back to healthy case)