### PR TITLE
go: error handling for bad init parameters + fix errorMessage

### DIFF
--- a/golang/connection.go
+++ b/golang/connection.go
@@ -342,9 +342,17 @@ func (c *Connection) handleInitReq(frame *Frame) {
 		return
 	}
 
-	c.remotePeerInfo.HostPort = req.initParams[InitParamHostPort]
-	c.remotePeerInfo.ProcessName = req.initParams[InitParamProcessName]
+	var ok bool
+	if c.remotePeerInfo.HostPort, ok = req.initParams[InitParamHostPort]; !ok {
+		c.protocolError(fmt.Errorf("Header %v is required", InitParamHostPort))
+		return
+	}
+	if c.remotePeerInfo.ProcessName, ok = req.initParams[InitParamProcessName]; !ok {
+		c.protocolError(fmt.Errorf("Header %v is required", InitParamProcessName))
+		return
+	}
 	if c.remotePeerInfo.IsEphemeral() {
+		// TODO(prashant): Add an IsEphemeral bool to the peer info.
 		c.remotePeerInfo.HostPort = c.conn.RemoteAddr().String()
 	}
 

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -238,7 +238,6 @@ func (response *InboundCallResponse) SendSystemError(err error) error {
 	frame := response.conn.framePool.Get()
 	if err := frame.write(&errorMessage{
 		id:      response.mex.msgID,
-		tracing: response.span,
 		errCode: GetSystemErrorCode(err),
 		message: err.Error()}); err != nil {
 		// Nothing we can do here

--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -1,0 +1,49 @@
+package tchannel
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeMessage(w io.Writer, msg message) error {
+	f := NewFrame(MaxFramePayloadSize)
+	if err := f.write(msg); err != nil {
+		return err
+	}
+	return f.WriteTo(w)
+}
+
+func readFrame(r io.Reader) (*Frame, error) {
+	f := NewFrame(MaxFramePayloadSize)
+	return f, f.ReadFrom(r)
+}
+
+func TestUnexpectedInitReq(t *testing.T) {
+	ch, err := NewChannel("test", nil)
+	require.NoError(t, err)
+	require.NoError(t, ch.ListenAndServe(":0"))
+	hostPort := ch.PeerInfo().HostPort
+
+	conn, err := net.Dial("tcp", hostPort)
+	require.NoError(t, err)
+	conn.SetReadDeadline(time.Now().Add(time.Second))
+
+	msg := &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
+		InitParamHostPort:    "0.0.0.0:0",
+		InitParamProcessName: "test",
+	}}}
+	require.NoError(t, writeMessage(conn, msg))
+
+	f, err := readFrame(conn)
+	require.NoError(t, err)
+	assert.Equal(t, messageTypeError, f.Header.messageType)
+	var errMsg errorMessage
+	require.NoError(t, f.read(&errMsg))
+	assert.Equal(t, invalidMessageID, errMsg.ID())
+	assert.Equal(t, ErrCodeProtocol, errMsg.errCode)
+}

--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -24,26 +24,63 @@ func readFrame(r io.Reader) (*Frame, error) {
 }
 
 func TestUnexpectedInitReq(t *testing.T) {
-	ch, err := NewChannel("test", nil)
-	require.NoError(t, err)
-	require.NoError(t, ch.ListenAndServe(":0"))
-	hostPort := ch.PeerInfo().HostPort
+	tests := []struct {
+		name          string
+		initMsg       message
+		expectedError errorMessage
+	}{
+		{
+			name: "bad version",
+			initMsg: &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
+				InitParamHostPort:    "0.0.0.0:0",
+				InitParamProcessName: "test",
+			}}},
+			expectedError: errorMessage{
+				id:      invalidMessageID,
+				errCode: ErrCodeProtocol,
+			},
+		},
+		{
+			name: "missing InitParamHostPort",
+			initMsg: &initReq{initMessage{id: 1, Version: CurrentProtocolVersion, initParams: initParams{
+				InitParamProcessName: "test",
+			}}},
+			expectedError: errorMessage{
+				id:      invalidMessageID,
+				errCode: ErrCodeProtocol,
+			},
+		},
+		{
+			name: "missing InitParamProcessName",
+			initMsg: &initReq{initMessage{id: 1, Version: CurrentProtocolVersion, initParams: initParams{
+				InitParamHostPort: "0.0.0.0:0",
+			}}},
+			expectedError: errorMessage{
+				id:      invalidMessageID,
+				errCode: ErrCodeProtocol,
+			},
+		},
+	}
 
-	conn, err := net.Dial("tcp", hostPort)
-	require.NoError(t, err)
-	conn.SetReadDeadline(time.Now().Add(time.Second))
+	for _, tt := range tests {
+		ch, err := NewChannel("test", nil)
+		require.NoError(t, err)
+		defer ch.Close()
+		require.NoError(t, ch.ListenAndServe(":0"))
+		hostPort := ch.PeerInfo().HostPort
 
-	msg := &initReq{initMessage{id: 1, Version: 0x1, initParams: initParams{
-		InitParamHostPort:    "0.0.0.0:0",
-		InitParamProcessName: "test",
-	}}}
-	require.NoError(t, writeMessage(conn, msg))
+		conn, err := net.Dial("tcp", hostPort)
+		require.NoError(t, err)
+		conn.SetReadDeadline(time.Now().Add(time.Second))
 
-	f, err := readFrame(conn)
-	require.NoError(t, err)
-	assert.Equal(t, messageTypeError, f.Header.messageType)
-	var errMsg errorMessage
-	require.NoError(t, f.read(&errMsg))
-	assert.Equal(t, invalidMessageID, errMsg.ID())
-	assert.Equal(t, ErrCodeProtocol, errMsg.errCode)
+		require.NoError(t, writeMessage(conn, tt.initMsg))
+
+		f, err := readFrame(conn)
+		require.NoError(t, err)
+		assert.Equal(t, messageTypeError, f.Header.messageType)
+		var errMsg errorMessage
+		require.NoError(t, f.read(&errMsg))
+		assert.Equal(t, tt.expectedError.ID(), errMsg.ID(), "test %v got bad ID", tt.name)
+		assert.Equal(t, tt.expectedError.errCode, errMsg.errCode, "test %v got bad code", tt.name)
+	}
 }

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -264,7 +264,6 @@ func (c *callResContinue) write(w *typed.WriteBuffer) error { return nil }
 type errorMessage struct {
 	id      uint32
 	errCode SystemErrCode
-	tracing Span
 	message string
 }
 
@@ -272,14 +271,14 @@ func (m *errorMessage) ID() uint32               { return m.id }
 func (m *errorMessage) messageType() messageType { return messageTypeError }
 func (m *errorMessage) read(r *typed.ReadBuffer) error {
 	m.errCode = SystemErrCode(r.ReadByte())
-	m.tracing.read(r)
+	m.id = r.ReadUint32()
 	m.message = r.ReadLen16String()
 	return r.Err()
 }
 
 func (m *errorMessage) write(w *typed.WriteBuffer) error {
 	w.WriteByte(byte(m.errCode))
-	m.tracing.write(w)
+	w.WriteUint32(m.id)
 	w.WriteLen16String(m.message)
 	return w.Err()
 }


### PR DESCRIPTION
adds some init error handling scenarios from #279 
r @mmihic 