### PR TITLE
Fix peer balancing regression

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -243,6 +243,7 @@ function _waitForIdentified(conn, callback) {
     conn.errorEvent.on(onConnectionError);
     conn.closeEvent.on(onConnectionClose);
     conn.identifiedEvent.on(onIdentified);
+    self.invalidateScore();
 
     function onConnectionError(err) {
         finish(err);
@@ -261,6 +262,7 @@ function _waitForIdentified(conn, callback) {
         conn.errorEvent.removeListener(onConnectionError);
         conn.closeEvent.removeListener(onConnectionClose);
         conn.identifiedEvent.removeListener(onIdentified);
+        self.invalidateScore();
         callback(err);
     }
 };

--- a/node/peer_heap.js
+++ b/node/peer_heap.js
@@ -51,17 +51,6 @@ PeerHeap.prototype.choose = function choose(threshold, filter) {
         return null;
     }
 
-    // TODO: rescore could be deferred:
-    // - store a pendingRescore bit
-    // - set a next tick to rescore and clear bit
-    // - if asked to choose a peer while pendingRescore is still set, take the
-    //   hit and rescore then (do not clear bit)
-    //
-    // However such cleverness might just slow down the throughput of a very
-    // busy server rather than help.
-    el.score = el.peer.state.shouldRequest();
-    self.siftdown(0);
-
     return el.peer;
 
 };

--- a/node/states.js
+++ b/node/states.js
@@ -300,6 +300,11 @@ UnhealthyState.prototype.locked = false;
 UnhealthyState.prototype.onNewPeriod = function onNewPeriod(now) {
     var self = this;
 
+    if (self.healthyCount >= self.minResponseCount) {
+        self.stateMachine.setState(HealthyState);
+        return;
+    }
+
     var triedLastPeriod = self.triedThisPeriod;
     self.triedThisPeriod = false;
 

--- a/node/states.js
+++ b/node/states.js
@@ -111,6 +111,8 @@ State.prototype.shouldRequest = function shouldRequest(req, options) {
     var now = self.timers.now();
     if (self.willCallNextHandler(now)) {
         return self.nextHandler.shouldRequest(req, options);
+    } else if (self.stateMachine.state !== self) {
+        return self.stateMachine.state.shouldRequest(req, options);
     } else {
         return 0;
     }

--- a/node/states.js
+++ b/node/states.js
@@ -243,17 +243,26 @@ HealthyState.prototype.onNewPeriod = function onNewPeriod(now) {
     }
 };
 
+HealthyState.prototype.onRequest = function onRequest(/* req */) {
+    var self = this;
+
+    self.invalidate();
+};
+
 HealthyState.prototype.onRequestHealthy = function onRequestHealthy() {
     var self = this;
     self.healthyCount++;
     self.totalRequests++;
+    self.invalidate();
 };
 
 HealthyState.prototype.onRequestUnhealthy = function onRequestUnhealthy() {
     var self = this;
     self.totalRequests++;
     self.unhealthyCount++;
-    self.checkPeriod(false, self.timers.now());
+    if (!self.checkPeriod(false, self.timers.now())) {
+        self.invalidate();
+    }
 };
 
 HealthyState.prototype.onRequestError = function onRequestError(err) {
@@ -266,7 +275,9 @@ HealthyState.prototype.onRequestError = function onRequestError(err) {
     } else {
         self.healthyCount++;
     }
-    self.checkPeriod(false, self.timers.now());
+    if (!self.checkPeriod(false, self.timers.now())) {
+        self.invalidate();
+    }
 };
 
 function UnhealthyState(options) {
@@ -320,7 +331,9 @@ UnhealthyState.prototype.onRequest = function onRequest(/* req */) {
     var self = this;
 
     self.triedThisPeriod = true;
-    self.checkPeriod(false, self.timers.now());
+    if (!self.checkPeriod(false, self.timers.now())) {
+        self.invalidate();
+    }
 };
 
 UnhealthyState.prototype.onRequestHealthy = function onRequestHealthy() {
@@ -329,6 +342,8 @@ UnhealthyState.prototype.onRequestHealthy = function onRequestHealthy() {
     self.healthyCount++;
     if (self.healthyCount > self.minResponseCount) {
         self.stateMachine.setState(HealthyState);
+    } else {
+        self.invalidate();
     }
 };
 

--- a/node/states.js
+++ b/node/states.js
@@ -172,9 +172,11 @@ PeriodicState.prototype.checkPeriod = function checkPeriod(inTimeout, now) {
     var remain = self.period - elapsed;
     if (remain <= 0) {
         self.startNewPeriod(now);
+        return true;
     } else if (inTimeout) {
         self.setPeriodTimer(remain, now);
     }
+    return false;
 };
 
 PeriodicState.prototype.willCallNextHandler = function willCallNextHandler(now) {

--- a/node/test/lib/peer_score_random.js
+++ b/node/test/lib/peer_score_random.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var format = require('util').format;
+
 module.exports.debugShouldRequestStack = debugShouldRequestStack;
 module.exports.randSeq = randSeq;
 
@@ -44,6 +46,10 @@ function debugShouldRequestStack() {
             return match[1];
         })
         ;
+
+    elide('.shouldRequest(%s)', /\.shouldRequest$/, stackLines);
+    elide('.add(%s)', /\.add/, stackLines);
+
     return stackLines.join(' < ');
 }
 
@@ -58,4 +64,24 @@ function randSeq(seq, debug) {
         i = (i + 1) % seq.length;
         return r;
     };
+}
+
+function elide(fmt, pattern, array) {
+    for (var i = 0; i < array.length; i++) {
+        if (!pattern.test(array[i])) {
+            continue;
+        }
+        for (var j = i + 1; j < array.length; j++) {
+            if (!pattern.test(array[j])) {
+                break;
+            }
+        }
+        var gone = array.splice(i, j - i);
+        var rep = format(fmt, gone.map(replace).join(' < '));
+        array.splice(i, 0, [rep]);
+    }
+
+    function replace(str) {
+        return str.replace(pattern, '');
+    }
 }

--- a/node/test/send.js
+++ b/node/test/send.js
@@ -319,6 +319,123 @@ allocCluster.test('request().send() to a pool of servers', 4, function t(cluster
     }
 });
 
+allocCluster.test('request().send() balances', 4, function t(cluster, assert) {
+    var client = TChannel({
+        timeoutFuzz: 0,
+        random: function indifferent() {
+            return 0.5;
+        }
+    });
+
+    var clientChan = client.makeSubChannel({
+        serviceName: 'lol'
+    });
+
+    cluster.channels.forEach(function each(chan, i) {
+        var chanNum = i + 1;
+        chan.handler = EndpointHandler();
+        chan.handler.register('foo', function foo(req, res, arg2, arg3) {
+            res.headers.as = 'raw';
+            res.sendOk(arg2, arg3 + ' served by ' + chanNum);
+        });
+
+        clientChan.peers.add(chan.hostPort);
+    });
+
+    var round = 0;
+    runBalanceTest(round, cluster, clientChan, assert, onRoundDone);
+
+    function onRoundDone(err) {
+        if (err) {
+            onResults(err);
+            return;
+        }
+
+        if (++round > 3) {
+            onResults();
+            return;
+        }
+
+        runBalanceTest(round, cluster, clientChan, assert, onRoundDone);
+    }
+
+    function onResults(err) {
+        assert.ifError(err, 'no errors from sending');
+        cluster.assertCleanState(assert, {
+            channels: cluster.channels.map(function each() {
+                return {
+                    peers: [{
+                        connections: [
+                            {direction: 'in', inReqs: 0, outReqs: 0}
+                        ]
+                    }]
+                };
+            })
+        });
+        client.close();
+        assert.end();
+    }
+});
+
+function balancedChecker(assert) {
+    var seen = {};
+
+    return checkBalancedServe;
+
+    function checkBalancedServe(testCase, err, res, arg2, arg3) {
+        assert.ifError(err, testCase.name + ': no result error');
+        if (!err) {
+            return;
+        }
+
+        var head = arg2 ? String(arg2) : arg2;
+        var body = arg3 ? String(arg3) : arg3;
+        assert.equal(head, '', testCase.name + ': expected head content');
+
+        var match = /served by (\d+)$/.exec(body);
+        if (!match) {
+            assert.fail(testCase.name + ': expected a matching body');
+            return;
+        }
+
+        var maxPrior = getMaxSeenCount();
+
+        var servedBy = match[1];
+        if (!seen[servedBy]) {
+            seen[servedBy] = 0;
+        }
+        var count = ++seen[servedBy];
+        var delta = count - maxPrior;
+        assert.equal(delta, 1, testCase.resBody, testCase.name + ': expected served balance');
+    }
+
+    function getMaxSeenCount() {
+        return Object.keys(seen).reduce(function max(count, key) {
+            return seen[key] > count ? seen[key] : count;
+        }, 0);
+    }
+}
+
+function runBalanceTest(roundNo, cluster, channel, assert, callback) {
+    var checkBalancedServe = balancedChecker(assert);
+    var testCases = [];
+
+    var n = 2 * cluster.channels.length;
+    for (var m = 1; m <= n; m++) {
+        var msgNum = n * roundNo + m;
+        testCases.push({
+            logger: cluster.logger,
+            name: 'msg' + msgNum,
+            op: 'foo',
+            reqHead: '',
+            reqBody: 'msg' + msgNum,
+            check: checkBalancedServe
+        });
+    }
+
+    parallelSendTest(channel, testCases, assert, callback);
+}
+
 allocCluster.test('request().send() to self', 1, function t(cluster, assert) {
     var one = cluster.channels[0];
 
@@ -598,23 +715,31 @@ function sendTest(channel, testCase, assert) {
         channel
             .request(testCase.opts)
             .send(testCase.op, testCase.reqHead, testCase.reqBody, onResult);
+
         function onResult(err, res, arg2, arg3) {
-            var head = arg2;
-            var body = arg3;
-            assert.ifError(err, testCase.name + ': no result error');
-            if (!err) {
-                assert.ok(typeof head === 'string' || Buffer.isBuffer(head), testCase.name + ': got head buffer or string');
-                assert.ok(typeof body === 'string' || Buffer.isBuffer(body), testCase.name + ': got body buffer or string');
-                assert.equal(head ? String(head) : head, testCase.resHead, testCase.name + ': expected head content');
-                assert.equal(body ? String(body) : body, testCase.resBody, testCase.name + ': expected body content');
+            if (testCase.check) {
+                testCase.check(testCase, err, res, arg2, arg3);
+            } else {
+                check(err, res, arg2, arg3);
             }
-
-            if ('resOk' in testCase) {
-                assert.equal(res.ok, testCase.resOk,
-                    testCase.name + ': expected res ok');
-            }
-
             callback();
         }
     };
+
+    function check(err, res, arg2, arg3) {
+        var head = arg2;
+        var body = arg3;
+        assert.ifError(err, testCase.name + ': no result error');
+        if (!err) {
+            assert.ok(typeof head === 'string' || Buffer.isBuffer(head), testCase.name + ': got head buffer or string');
+            assert.ok(typeof body === 'string' || Buffer.isBuffer(body), testCase.name + ': got body buffer or string');
+            assert.equal(head ? String(head) : head, testCase.resHead, testCase.name + ': expected head content');
+            assert.equal(body ? String(body) : body, testCase.resBody, testCase.name + ': expected body content');
+        }
+
+        if ('resOk' in testCase) {
+            assert.equal(res.ok, testCase.resOk,
+                testCase.name + ': expected res ok');
+        }
+    }
 }


### PR DESCRIPTION
The heaped score work in v2.4.0 broke peer balance:
- peers only got rescored once in PeerHeap#choose
- this happens before request allocation (pending count mutation)
- scores weren't being recomputed by the "started a request" path anymore

This PR fixes those issues.

We should add a test for peer balancing so that we don't break this again, and to check this fix.