### PR TITLE
PreferOutgoingHandler: unify "not fully ready" tiers

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -462,7 +462,9 @@ PreferOutgoingHandler.prototype.shouldRequest = function shouldRequest() {
         case QOS_UNCONNECTED:
             return 0.1 + random * 0.1;
         case QOS_ONLY_INCOMING:
-            self.peer.connect();
+            if (!self.peer.channel.destroyed) {
+                self.peer.connect();
+            }
             return 0.2 + random * 0.1;
         case QOS_FRESH_OUTGOING:
             return 0.3 + random * 0.1;

--- a/node/peer.js
+++ b/node/peer.js
@@ -449,9 +449,7 @@ PreferOutgoingHandler.prototype.shouldRequest = function shouldRequest() {
     var self = this;
 
     // space:
-    //   [0.1, 0.2)  unconnected peers
-    //   [0.2, 0.3)  incoming connections
-    //   [0.3, 0.4)  new outgoing connections
+    //   [0.1, 0.4)  peers with no identified outgoing connection
     //   [0.4, 1.0)  identified outgoing connections
     var random = self.peer.outPendingWeightedRandom();
     var qos = self.getQOS();
@@ -459,15 +457,15 @@ PreferOutgoingHandler.prototype.shouldRequest = function shouldRequest() {
         self.lastQOS = qos;
     }
     switch (qos) {
-        case QOS_UNCONNECTED:
-            return 0.1 + random * 0.1;
         case QOS_ONLY_INCOMING:
             if (!self.peer.channel.destroyed) {
                 self.peer.connect();
             }
-            return 0.2 + random * 0.1;
+            /* falls through */
+        case QOS_UNCONNECTED:
+            /* falls through */
         case QOS_FRESH_OUTGOING:
-            return 0.3 + random * 0.1;
+            return 0.1 + random * 0.3;
         case QOS_READY_OUTGOING:
             return 0.4 + random * 0.6;
     }

--- a/node/test/peer_states.js
+++ b/node/test/peer_states.js
@@ -52,7 +52,7 @@ allocCluster.test('healthy state stays healthy', {
     var peer = one.peers.add(cluster.hosts[1]);
 
     assert.equals(peer.state.type, 'tchannel.healthy', 'initially healthy');
-    assert.equals(peer.state.shouldRequest(), 0.2, 'got not connected score');
+    assert.equals(peer.state.shouldRequest(), 0.4, 'got not connected score');
     assert.equals(peer.state.type, 'tchannel.healthy', 'still healthy');
 
     var conn = peer.connect();


### PR DESCRIPTION
Fixes an edge case in early peer balancing: when a client library has a batch of requests to kick off with no existing connections, they all get allocated to the first peer to win random selection, since:
- the first score picks a randomized unconnected peer...
- ...and connects to it, changing its tier...
- ...so that any pending counts become irrelevant, preferring the still-connecting peer

Separating these 3 cases as separate tiers really didn't give us anything, since until we've exchanged a first init req/res with a peer we really can't say if it'll be any better than the others.

Clients wishing to control or bound to a set of connecting peers will need to implement such logic manually at present, as the hyperbahn client currently does.  We could choose in the future to instead place a cap on the number of pending new connections, and at that point prefer to select a still-connecting peer in preference to an unconnected one.

r @Raynos @kriskowal 

cc @abhinav @prashantv 