### PR TITLE
go: Use a list instead of map for the logger interface.

### DIFF
--- a/golang/connection.go
+++ b/golang/connection.go
@@ -198,9 +198,9 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, on
 
 	connID := atomic.AddUint32(&nextConnID, 1)
 	log := ch.log.WithFields(LogFields{
-		"connID":     connID,
-		"localPeer":  conn.LocalAddr(),
-		"remotePeer": conn.RemoteAddr(),
+		{"connID", connID},
+		{"localPeer", conn.LocalAddr()},
+		{"remotePeer", conn.RemoteAddr()},
 	})
 	peerInfo := ch.PeerInfo()
 	log.Debugf("created for %v (%v) local: %v remote: %v",

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -63,7 +63,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.contents = newFragmentingWriter(response, initialFragment.checksumType.New())
 	response.cancel = cancel
 	response.span = callReq.Tracing
-	response.log = c.log.WithFields(LogFields{"In-Response": callReq.ID()})
+	response.log = c.log.WithField(LogField{"In-Response", callReq.ID()})
 	response.headers = callHeaders{}
 	response.messageForFragment = func(initial bool) message {
 		if initial {
@@ -85,7 +85,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	call.headers = callReq.Headers
 	call.span = callReq.Tracing
 	call.response = response
-	call.log = c.log.WithFields(LogFields{"In-Call": callReq.ID()})
+	call.log = c.log.WithField(LogField{"In-Call", callReq.ID()})
 	call.messageForFragment = func(initial bool) message { return new(callReqContinue) }
 	call.contents = newFragmentingReader(call)
 	call.statsReporter = c.statsReporter

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -77,7 +77,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	}
 	call.statsReporter = c.statsReporter
 	call.createStatsTags(c.commonStatsTags)
-	call.log = c.log.WithFields(LogFields{"Out-Call": requestID})
+	call.log = c.log.WithFields(LogFields{{"Out-Call", requestID}})
 
 	// TODO(mmihic): It'd be nice to do this without an fptr
 	call.messageForFragment = func(initial bool) message {
@@ -100,7 +100,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 	response := new(OutboundCallResponse)
 	response.startedAt = timeNow()
 	response.mex = mex
-	response.log = c.log.WithFields(LogFields{"Out-Response": requestID})
+	response.log = c.log.WithFields(LogFields{{"Out-Response", requestID}})
 	response.messageForFragment = func(initial bool) message {
 		if initial {
 			return &response.callRes


### PR DESCRIPTION
The order of LogFields is important for us when reading output.