### PR TITLE
document Shard key

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -623,6 +623,7 @@ name  | req | res | description
 `re`  | Y   | N   | Retry Flags
 `se`  | Y   | N   | Speculative Execution
 `fd`  | Y   | Y   | Failure Domain
+`sk`  | Y   | N   | Shard key
 
 ### Transport Header `as` -- Arg Scheme
 
@@ -700,6 +701,19 @@ likely to fail in the same way if they were to fail.
 For example some requests might have a downstream dependency on another
 service, while others might be handled entirely within the requested service.
 This is used to implement Hystrix-like "circuit breaker" behavior.
+
+### Transport Header `sk` -- Shard Key
+
+The shard key determines where this call request belongs. If you want to have
+a ring of tchannels where requests go to a particular node you can set a shard
+key header.
+
+This `sk` header is used by `ringpop` to deliver the call request to a specific
+tchannel instance.
+
+For example you may want to keep some in memory state, i.e. cache, aggregation.
+You can use read the `sk` and forward the call request to a specific process
+that has ownership for the shard key.
 
 ### A note on `host:port` header values
 


### PR DESCRIPTION
We currently have a tchannel+ringpop service that implements a ringpop forwarding handler.

This ringpop forwarding handler reads the sharding key out of the transport headers to determine where to forward the request.

I would like to add the shard key to the transport headers to enable efficient forwarding without having to read arg{1..3}.

cc @jcorbin @jwolski @mranney @blampe 