### PR TITLE
go: Add Flush to ArgXWriter so partial frames can be flushed (for streaming)

### DIFF
--- a/golang/arguments.go
+++ b/golang/arguments.go
@@ -27,19 +27,19 @@ import (
 	"io/ioutil"
 )
 
-// ArgReader providers a simpler interface to reading arguments.
-type ArgReader struct {
+// ArgReadHelper providers a simpler interface to reading arguments.
+type ArgReadHelper struct {
 	reader io.ReadCloser
 	err    error
 }
 
 // NewArgReader wraps the result of calling ArgXReader to provide a simpler
 // interface for reading arguments.
-func NewArgReader(reader io.ReadCloser, err error) ArgReader {
-	return ArgReader{reader, err}
+func NewArgReader(reader io.ReadCloser, err error) ArgReadHelper {
+	return ArgReadHelper{reader, err}
 }
 
-func (r ArgReader) read(f func() error) error {
+func (r ArgReadHelper) read(f func() error) error {
 	if r.err != nil {
 		return r.err
 	}
@@ -50,7 +50,7 @@ func (r ArgReader) read(f func() error) error {
 }
 
 // Read reads from the reader into the byte slice.
-func (r ArgReader) Read(bs *[]byte) error {
+func (r ArgReadHelper) Read(bs *[]byte) error {
 	return r.read(func() error {
 		var err error
 		*bs, err = ioutil.ReadAll(r.reader)
@@ -59,7 +59,7 @@ func (r ArgReader) Read(bs *[]byte) error {
 }
 
 // ReadJSON deserializes JSON from the underlying reader into data.
-func (r ArgReader) ReadJSON(data interface{}) error {
+func (r ArgReadHelper) ReadJSON(data interface{}) error {
 	return r.read(func() error {
 		// TChannel allows for 0 length values (not valid JSON), so we use a bufio.Reader
 		// to check whether data is of 0 length.
@@ -76,19 +76,19 @@ func (r ArgReader) ReadJSON(data interface{}) error {
 	})
 }
 
-// ArgWriter providers a simpler interface to writing arguments.
-type ArgWriter struct {
+// ArgWriteHelper providers a simpler interface to writing arguments.
+type ArgWriteHelper struct {
 	writer io.WriteCloser
 	err    error
 }
 
 // NewArgWriter wraps the result of calling ArgXWriter to provider a simpler
 // interface for writing arguments.
-func NewArgWriter(writer io.WriteCloser, err error) ArgWriter {
-	return ArgWriter{writer, err}
+func NewArgWriter(writer io.WriteCloser, err error) ArgWriteHelper {
+	return ArgWriteHelper{writer, err}
 }
 
-func (w ArgWriter) write(f func() error) error {
+func (w ArgWriteHelper) write(f func() error) error {
 	if w.err != nil {
 		return w.err
 	}
@@ -101,7 +101,7 @@ func (w ArgWriter) write(f func() error) error {
 }
 
 // Write writes the given bytes to the underlying writer.
-func (w ArgWriter) Write(bs []byte) error {
+func (w ArgWriteHelper) Write(bs []byte) error {
 	return w.write(func() error {
 		_, err := w.writer.Write(bs)
 		return err
@@ -109,7 +109,7 @@ func (w ArgWriter) Write(bs []byte) error {
 }
 
 // WriteJSON writes the given object as JSON.
-func (w ArgWriter) WriteJSON(data interface{}) error {
+func (w ArgWriteHelper) WriteJSON(data interface{}) error {
 	return w.write(func() error {
 		e := json.NewEncoder(w.writer)
 		return e.Encode(data)

--- a/golang/fragmentation_test.go
+++ b/golang/fragmentation_test.go
@@ -164,8 +164,8 @@ func TestFragmentationWriterErrors(t *testing.T) {
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
-		// EndArgument without beginning argument
-		assert.Error(t, w.EndArgument())
+		// Close without beginning argument
+		assert.Error(t, w.Close())
 	})
 }
 
@@ -178,8 +178,8 @@ func TestFragmentationReaderErrors(t *testing.T) {
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
-		// EndArgument without beginning argument
-		assert.Error(t, r.EndArgument())
+		// Close without beginning argument
+		assert.Error(t, r.Close())
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
@@ -211,7 +211,7 @@ func TestFragmentationReaderErrors(t *testing.T) {
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
-		// EndArgument without receiving all data in chunk
+		// Close without receiving all data in chunk
 		writer, err := w.ArgWriter(true /* last */)
 		assert.NoError(t, err)
 		assert.NoError(t, NewArgWriter(writer, nil).Write([]byte("hello")))
@@ -221,11 +221,11 @@ func TestFragmentationReaderErrors(t *testing.T) {
 		_, err = r.Read(b)
 		assert.NoError(t, err)
 		assert.Equal(t, "hel", string(b))
-		assert.Error(t, r.EndArgument())
+		assert.Error(t, r.Close())
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {
-		// EndArgument without receiving all fragments
+		// Close without receiving all fragments
 		writer, err := w.ArgWriter(true /* last */)
 		assert.NoError(t, err)
 		assert.NoError(t, NewArgWriter(writer, nil).Write([]byte("hello world what's up")))
@@ -235,7 +235,7 @@ func TestFragmentationReaderErrors(t *testing.T) {
 		_, err = r.Read(b)
 		assert.NoError(t, err)
 		assert.Equal(t, "hello wo", string(b))
-		assert.Error(t, r.EndArgument())
+		assert.Error(t, r.Close())
 	})
 
 	runFragmentationErrorTest(func(w *fragmentingWriter, r *fragmentingReader) {

--- a/golang/fragmenting_reader.go
+++ b/golang/fragmenting_reader.go
@@ -113,7 +113,7 @@ func (r *fragmentingReader) BeginArgument(last bool) error {
 
 	// We're guaranteed that either this is the first argument (in which
 	// case we need to get the first fragment and chunk) or that we have a
-	// valid curChunk (populated via EndArgument)
+	// valid curChunk (populated via Close)
 	if r.state == fragmentingReadStart {
 		if r.err = r.recvAndParseNextFragment(true); r.err != nil {
 			return r.err
@@ -173,10 +173,6 @@ func (r *fragmentingReader) Read(b []byte) (int, error) {
 }
 
 func (r *fragmentingReader) Close() error {
-	return r.EndArgument()
-}
-
-func (r *fragmentingReader) EndArgument() error {
 	last := r.state == fragmentingReadInLastArgument
 	if r.err != nil {
 		return r.err

--- a/golang/fragmenting_writer.go
+++ b/golang/fragmenting_writer.go
@@ -247,12 +247,8 @@ func (w *fragmentingWriter) Flush() error {
 	return nil
 }
 
+// Close ends the current argument.
 func (w *fragmentingWriter) Close() error {
-	return w.EndArgument()
-}
-
-// EndArgument ends the current argument.
-func (w *fragmentingWriter) EndArgument() error {
 	last := w.state == fragmentingWriteInLastArgument
 	if w.err != nil {
 		return w.err

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -271,7 +271,7 @@ func (response *InboundCallResponse) SetApplicationError() error {
 
 // Arg2Writer returns a WriteCloser that can be used to write the second argument.
 // The returned writer must be closed once the write is complete.
-func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
+func (response *InboundCallResponse) Arg2Writer() (ArgWriter, error) {
 	if err := NewArgWriter(response.arg1Writer()).Write(nil); err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (response *InboundCallResponse) Arg2Writer() (io.WriteCloser, error) {
 
 // Arg3Writer returns a WriteCloser that can be used to write the last argument.
 // The returned writer must be closed once the write is complete.
-func (response *InboundCallResponse) Arg3Writer() (io.WriteCloser, error) {
+func (response *InboundCallResponse) Arg3Writer() (ArgWriter, error) {
 	return response.arg3Writer()
 }
 

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -177,13 +177,13 @@ func (call *OutboundCall) writeOperation(operation []byte) error {
 
 // Arg2Writer returns a WriteCloser that can be used to write the second argument.
 // The returned writer must be closed once the write is complete.
-func (call *OutboundCall) Arg2Writer() (io.WriteCloser, error) {
+func (call *OutboundCall) Arg2Writer() (ArgWriter, error) {
 	return call.arg2Writer()
 }
 
 // Arg3Writer returns a WriteCloser that can be used to write the last argument.
 // The returned writer must be closed once the write is complete.
-func (call *OutboundCall) Arg3Writer() (io.WriteCloser, error) {
+func (call *OutboundCall) Arg3Writer() (ArgWriter, error) {
 	return call.arg3Writer()
 }
 

--- a/golang/reqres.go
+++ b/golang/reqres.go
@@ -78,7 +78,7 @@ type reqResWriter struct {
 
 //go:generate stringer -type=reqResReaderState
 
-func (w *reqResWriter) argWriter(last bool, inState reqResWriterState, outState reqResWriterState) (io.WriteCloser, error) {
+func (w *reqResWriter) argWriter(last bool, inState reqResWriterState, outState reqResWriterState) (ArgWriter, error) {
 	if w.err != nil {
 		return nil, w.err
 	}
@@ -96,15 +96,15 @@ func (w *reqResWriter) argWriter(last bool, inState reqResWriterState, outState 
 	return argWriter, nil
 }
 
-func (w *reqResWriter) arg1Writer() (io.WriteCloser, error) {
+func (w *reqResWriter) arg1Writer() (ArgWriter, error) {
 	return w.argWriter(false /* last */, reqResWriterPreArg1, reqResWriterPreArg2)
 }
 
-func (w *reqResWriter) arg2Writer() (io.WriteCloser, error) {
+func (w *reqResWriter) arg2Writer() (ArgWriter, error) {
 	return w.argWriter(false /* last */, reqResWriterPreArg2, reqResWriterPreArg3)
 }
 
-func (w *reqResWriter) arg3Writer() (io.WriteCloser, error) {
+func (w *reqResWriter) arg3Writer() (ArgWriter, error) {
 	return w.argWriter(true /* last */, reqResWriterPreArg3, reqResWriterComplete)
 }
 

--- a/golang/stream_test.go
+++ b/golang/stream_test.go
@@ -1,0 +1,164 @@
+package tchannel_test
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	. "github.com/uber/tchannel/golang"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang/testutils"
+	"golang.org/x/net/context"
+)
+
+// streamPartialHandler returns a streaming handler that has the following contract:
+// read a byte, write N bytes where N = the byte that was read.
+// The results are be written as soon as the byte is read.
+func streamPartialHandler(t *testing.T) HandlerFunc {
+	return func(ctx context.Context, call *InboundCall) {
+		response := call.Response()
+		onError := func(err error) {
+			t.Errorf("Handler error: %v", err)
+			response.SendSystemError(fmt.Errorf("failed to read arg2"))
+		}
+
+		var arg2 []byte
+		if err := NewArgReader(call.Arg2Reader()).Read(&arg2); err != nil {
+			onError(fmt.Errorf("failed to read arg2"))
+			return
+		}
+
+		if err := NewArgWriter(response.Arg2Writer()).Write(nil); err != nil {
+			onError(fmt.Errorf(""))
+			return
+		}
+
+		argReader, err := call.Arg3Reader()
+		if err != nil {
+			onError(fmt.Errorf("failed to read arg3"))
+			return
+		}
+
+		argWriter, err := response.Arg3Writer()
+		if err != nil {
+			onError(fmt.Errorf("arg3 writer failed"))
+			return
+		}
+
+		arg3 := make([]byte, 1)
+		for {
+			n, err := argReader.Read(arg3)
+			if err == io.EOF {
+				break
+			}
+			if n == 0 && err == nil {
+				err = fmt.Errorf("read 0 bytes")
+			}
+			if err != nil {
+				onError(fmt.Errorf("arg3 Read failed: %v", err))
+				return
+			}
+
+			// Write the number of bytes as specified by arg3[0]
+			for i := byte(0); i < arg3[0]; i++ {
+				if _, err := argWriter.Write(arg3); err != nil {
+					onError(fmt.Errorf("argWriter Write failed: %v", err))
+					return
+				}
+			}
+			if err := argWriter.Flush(); err != nil {
+				onError(fmt.Errorf("argWriter flush failed: %v", err))
+				return
+			}
+		}
+
+		if err := argReader.Close(); err != nil {
+			onError(fmt.Errorf("argReader Close failed: %v", err))
+			return
+		}
+
+		if err := argWriter.Close(); err != nil {
+			onError(fmt.Errorf("arg3writer Close failed: %v", err))
+			return
+		}
+	}
+}
+
+func TestStreamPartialArg(t *testing.T) {
+	defer testutils.SetTimeout(t, 2*time.Second)()
+	ctx, cancel := NewContext(time.Second)
+	defer cancel()
+
+	require.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+		ch.Register(streamPartialHandler(t), "echoStream")
+
+		call, err := ch.BeginCall(ctx, hostPort, ch.PeerInfo().ServiceName, "echoStream", nil)
+		require.NoError(t, err, "BeginCall failed")
+		require.Nil(t, NewArgWriter(call.Arg2Writer()).Write(nil))
+
+		argWriter, err := call.Arg3Writer()
+		require.NoError(t, err, "Arg3Writer failed")
+
+		// Write out to the stream, and expect to get data
+		response := call.Response()
+
+		var arg2 []byte
+		require.NoError(t, NewArgReader(response.Arg2Reader()).Read(&arg2), "Arg2Reader failed")
+		require.False(t, response.ApplicationError(), "call failed")
+
+		argReader, err := response.Arg3Reader()
+		require.NoError(t, err, "Arg3Reader failed")
+
+		verifyBytes := func(n byte) {
+			_, err := argWriter.Write([]byte{n})
+			require.NoError(t, err, "arg3 write failed")
+			require.NoError(t, argWriter.Flush(), "arg3 flush failed")
+
+			arg3 := make([]byte, int(n))
+			_, err = io.ReadFull(argReader, arg3)
+			require.NoError(t, err, "arg3 read failed")
+
+			expected := make([]byte, int(n))
+			for i := byte(0); i < n; i++ {
+				expected[i] = i
+			}
+			assert.Equal(t, expected, arg3, "arg3 result mismatch")
+		}
+
+		verifyBytes(0)
+		verifyBytes(5)
+		verifyBytes(100)
+		verifyBytes(1)
+
+		require.NoError(t, argWriter.Close(), "arg3 close failed")
+
+		// Once closed, we expect the reader to return EOF
+		n, err := io.Copy(ioutil.Discard, argReader)
+		assert.Equal(t, 0, n, "arg2 reader expected to EOF after arg3 writer is closed")
+		assert.Equal(t, io.EOF, err, "arg2 reader expected to EOF after arg3 writer is closed")
+	}))
+}


### PR DESCRIPTION
This allows callers to Flush written bytes without waiting for the frame to be filled. This is especially useful in the streaming use-case.

r @mmihic 