### PR TITLE
Delegate call frame handling

### DIFF
--- a/node/argstream.js
+++ b/node/argstream.js
@@ -93,14 +93,9 @@ function InArgStream() {
 
 inherits(InArgStream, ArgStream);
 
-InArgStream.prototype.handleFrame = function handleFrame(parts) {
+InArgStream.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
     var stream = self.streams[self._iStream];
-
-    if (parts === null) {
-        while (stream) stream = advance();
-        return;
-    }
 
     if (self.finished) {
         self.errorEvent.emit(self, new Error('arg stream finished')); // TODO typed error
@@ -113,6 +108,10 @@ InArgStream.prototype.handleFrame = function handleFrame(parts) {
     }
     if (i < parts.length) {
         self.errorEvent.emit(self, new Error('frame parts exceeded stream arity')); // TODO clearer / typed error
+    }
+
+    if (isLast) {
+        while (stream) stream = advance();
     }
 
     function advance() {

--- a/node/argstream.js
+++ b/node/argstream.js
@@ -98,7 +98,9 @@ InArgStream.prototype.handleFrame = function handleFrame(parts, isLast) {
     var stream = self.streams[self._iStream];
 
     if (self.finished) {
-        self.errorEvent.emit(self, new Error('arg stream finished')); // TODO typed error
+        // TODO typed error, similar condition to in_{req,res}:
+        // return new Error('unknown frame handling state');
+        return new Error('arg stream finished');
     }
 
     for (var i = 0; i < parts.length; i++) {
@@ -107,12 +109,15 @@ InArgStream.prototype.handleFrame = function handleFrame(parts, isLast) {
         if (parts[i].length) stream.write(parts[i]);
     }
     if (i < parts.length) {
-        self.errorEvent.emit(self, new Error('frame parts exceeded stream arity')); // TODO clearer / typed error
+        // TODO clearer / typed error
+        return new Error('frame parts exceeded stream arity');
     }
 
     if (isLast) {
         while (stream) stream = advance();
     }
+
+    return null;
 
     function advance() {
         if (self._iStream < self.streams.length) {

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -95,8 +95,8 @@ TChannelInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
 
     if (parts.length !== 3 || self.state !== States.Initial || !isLast) {
-        self.errorEvent.emit(self, new Error(
-            'un-streamed argument defragmentation is not implemented'));
+        // TODO: typed error
+        return new Error('un-streamed argument defragmentation is not implemented');
     }
 
     self.arg1 = parts[0] || emptyBuffer;
@@ -109,6 +109,8 @@ TChannelInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     }
 
     self.emitFinish();
+
+    return null;
 };
 
 TChannelInRequest.prototype.emitFinish = function emitFinish() {

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -91,13 +91,10 @@ TChannelInRequest.prototype.setupTracing = function setupTracing(options) {
     self.span.annotate('sr');
 };
 
-TChannelInRequest.prototype.handleFrame = function handleFrame(parts) {
+TChannelInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
-    if (!parts) {
-        return;
-    }
 
-    if (parts.length !== 3 || self.state !== States.Initial) {
+    if (parts.length !== 3 || self.state !== States.Initial || !isLast) {
         self.errorEvent.emit(self, new Error(
             'un-streamed argument defragmentation is not implemented'));
     }

--- a/node/in_response.js
+++ b/node/in_response.js
@@ -66,18 +66,21 @@ TChannelInResponse.prototype.onFinish = function onFinish(_arg, self) {
     self.state = States.Done;
 };
 
-TChannelInResponse.prototype.handleFrame = function handleFrame(parts) {
+TChannelInResponse.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
-    if (!parts) return;
-    if (parts.length !== 3 ||
-        self.state !== States.Initial) {
-        self.errorEvent.emit(self, new Error(
-            'un-streamed argument defragmentation is not implemented'));
+
+    if (parts.length !== 3 || self.state !== States.Initial || !isLast) {
+        // TODO: typed error
+        return new Error('un-streamed argument defragmentation is not implemented');
     }
+
     self.arg1 = parts[0] || emptyBuffer;
     self.arg2 = parts[1] || emptyBuffer;
     self.arg3 = parts[2] || emptyBuffer;
+
     self.finishEvent.emit(self);
+
+    return null;
 };
 
 TChannelInResponse.prototype.withArg23 = function withArg23(callback) {

--- a/node/self_out_request.js
+++ b/node/self_out_request.js
@@ -84,8 +84,7 @@ SelfOutRequest.prototype._sendCallRequestCont =
 SelfStreamingOutRequest.prototype._sendCallRequestCont =
 function passRequestParts(args, isLast ) {
     var self = this;
-    self.inreq.handleFrame(args);
-    if (isLast) self.inreq.handleFrame(null);
+    self.inreq.handleFrame(args, isLast);
     if (!self.closing) self.conn.ops.lastTimeoutTime = 0;
 };
 

--- a/node/self_out_response.js
+++ b/node/self_out_response.js
@@ -65,8 +65,7 @@ SelfOutResponse.prototype._sendCallResponseCont =
 SelfStreamingOutResponse.prototype._sendCallResponseCont =
 function passResponse(args, isLast ) {
     var self = this;
-    self.inres.handleFrame(args);
-    if (isLast) self.inres.handleFrame(null);
+    self.inres.handleFrame(args, isLast);
     if (self.first) {
         self.inres.code = self.code;
         self.inres.ok = self.ok;

--- a/node/streaming_in_request.js
+++ b/node/streaming_in_request.js
@@ -52,9 +52,13 @@ inherits(StreamingInRequest, InRequest);
 
 StreamingInRequest.prototype.type = 'tchannel.incoming-request.streaming';
 
-StreamingInRequest.prototype.handleFrame = function handleFrame(parts) {
+StreamingInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
+
     self._argstream.handleFrame(parts);
+    if (isLast) {
+        self._argstream.handleFrame(null);
+    }
 };
 
 StreamingInRequest.prototype.withArg1 = function withArg1(callback) {

--- a/node/streaming_in_request.js
+++ b/node/streaming_in_request.js
@@ -24,6 +24,7 @@ var parallel = require('run-parallel');
 var InRequest = require('./in_request');
 var inherits = require('util').inherits;
 
+var States = require('./reqres_states');
 var InArgStream = require('./argstream').InArgStream;
 
 function StreamingInRequest(id, options) {
@@ -55,7 +56,21 @@ StreamingInRequest.prototype.type = 'tchannel.incoming-request.streaming';
 StreamingInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
 
+    if (self.state === States.Initial) {
+        self.state = States.Streaming;
+    } else if (self.state !== States.Streaming) {
+        // TODO: typed error
+        return new Error('unknown frame handling state');
+    }
+
     self._argstream.handleFrame(parts, isLast);
+
+    if (!isLast && self.state !== States.Streaming) {
+        // TODO: typed error
+        return new Error('unknown frame handling state');
+    }
+
+    return null;
 };
 
 StreamingInRequest.prototype.withArg1 = function withArg1(callback) {

--- a/node/streaming_in_request.js
+++ b/node/streaming_in_request.js
@@ -55,10 +55,7 @@ StreamingInRequest.prototype.type = 'tchannel.incoming-request.streaming';
 StreamingInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
 
-    self._argstream.handleFrame(parts);
-    if (isLast) {
-        self._argstream.handleFrame(null);
-    }
+    self._argstream.handleFrame(parts, isLast);
 };
 
 StreamingInRequest.prototype.withArg1 = function withArg1(callback) {

--- a/node/streaming_in_request.js
+++ b/node/streaming_in_request.js
@@ -63,7 +63,10 @@ StreamingInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
         return new Error('unknown frame handling state');
     }
 
-    self._argstream.handleFrame(parts, isLast);
+    var err = self._argstream.handleFrame(parts, isLast);
+    if (err) {
+        return err;
+    }
 
     if (!isLast && self.state !== States.Streaming) {
         // TODO: typed error

--- a/node/streaming_in_response.js
+++ b/node/streaming_in_response.js
@@ -24,6 +24,7 @@ var parallel = require('run-parallel');
 var InResponse = require('./in_response');
 var inherits = require('util').inherits;
 
+var States = require('./reqres_states');
 var InArgStream = require('./argstream').InArgStream;
 
 function StreamingInResponse(id, options) {
@@ -52,9 +53,24 @@ inherits(StreamingInResponse, InResponse);
 
 StreamingInResponse.prototype.type = 'tchannel.incoming-response.streaming';
 
-StreamingInResponse.prototype.handleFrame = function handleFrame(parts) {
+StreamingInResponse.prototype.handleFrame = function handleFrame(parts, isLast) {
     var self = this;
-    self._argstream.handleFrame(parts);
+
+    if (self.state === States.Initial) {
+        self.state = States.Streaming;
+    } else if (self.state !== States.Streaming) {
+        // TODO: typed error
+        return new Error('unknown frame handling state');
+    }
+
+    self._argstream.handleFrame(parts, isLast);
+
+    if (!isLast && self.state !== States.Streaming) {
+        // TODO: typed error
+        return new Error('unknown frame handling state');
+    }
+
+    return null;
 };
 
 StreamingInResponse.prototype.withArg23 = function withArg23(callback) {

--- a/node/streaming_in_response.js
+++ b/node/streaming_in_response.js
@@ -63,7 +63,10 @@ StreamingInResponse.prototype.handleFrame = function handleFrame(parts, isLast) 
         return new Error('unknown frame handling state');
     }
 
-    self._argstream.handleFrame(parts, isLast);
+    var err = self._argstream.handleFrame(parts, isLast);
+    if (err) {
+        return err;
+    }
 
     if (!isLast && self.state !== States.Streaming) {
         // TODO: typed error

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -487,9 +487,8 @@ TChannelV2Handler.prototype._handleCallFrame = function _handleCallFrame(r, fram
     r.checksum = frame.body.csum;
 
     var isLast = !(frame.body.flags & v2.CallFlags.Fragment);
-    r.handleFrame(frame.body.args);
+    r.handleFrame(frame.body.args, isLast);
     if (isLast) {
-        r.handleFrame(null);
         r.state = States.Done;
     } else if (r.state === States.Initial) {
         r.state = States.Streaming;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -487,13 +487,9 @@ TChannelV2Handler.prototype._handleCallFrame = function _handleCallFrame(r, fram
     r.checksum = frame.body.csum;
 
     var isLast = !(frame.body.flags & v2.CallFlags.Fragment);
-    r.handleFrame(frame.body.args, isLast);
-    if (isLast) {
-        r.state = States.Done;
-    } else if (r.state === States.Initial) {
-        r.state = States.Streaming;
-    } else if (r.state !== States.Streaming) {
-        self.errorEvent.emit(self, new Error('unknown frame handling state'));
+    err = r.handleFrame(frame.body.args, isLast);
+    if (err) {
+        self.errorEvent.emit(self, err);
         return false;
     }
 


### PR DESCRIPTION
Delegates more logic to the req/res paths.

Changed `handleFrame(parts :: null | Array<Buffer>) -> void` to `handleFrame(parts :: Array<Buffer>, isLast ::Boolean) -> null | Error` all the way down thru argstream; key benefits:
- pushed down state machine checking logic into the req/res; this allows the non-streamed path to not have dead branches
- directly exposed argstream state errors to handler; they used to be event emissions
- eliminates the double-call pattern (`handleFrame(frame.args); handleFrame(null);` at end of stream or for un-streamed calls)

This did however remind me that we have quite a bit of lurking un-typed error debt in this path, recorded in: #1042

r @Raynos @kriskowal @ShanniLi 