### PR TITLE
No take overhead

### DIFF
--- a/node/benchmarks/Makefile
+++ b/node/benchmarks/Makefile
@@ -30,19 +30,19 @@ top-benchmark:
 	top -d1 -cp `pgrep -f nodejs-benchmarks | tr "\\n" "," | sed 's/,$$//'`;
 
 take:
-	node index.js -o $$(git rev-parse --short HEAD).json -- \
+	node index.js --noEndpointOverhead -o $$(git rev-parse --short HEAD).json -- \
 		-m 5 -s 4,4096,16384 -p 1000,10000,20000
 	ln -sf $$(git rev-parse --short HEAD).json $$(basename $$(git symbolic-ref HEAD)).json
 
 take_relay:
-	node index.js --relay -o relay-$$(git rev-parse --short HEAD).json \
+	node index.js --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
 		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000,20000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 
 take_trace:
 	# Cannot take --trace flag to multi_bench due to timeout+OOM.
 	# Cannot take 20k concurrency as it totally falls over
-	node index.js --relay --trace -o trace-$$(git rev-parse --short HEAD).json \
+	node index.js --relay --trace --noEndpointOverhead -o trace-$$(git rev-parse --short HEAD).json \
 		-- --relay -m 5 -c 10 -s 4096,16384 -p 1000,10000
 	ln -sf trace-$$(git rev-parse --short HEAD).json trace-$$(basename $$(git symbolic-ref HEAD)).json
 

--- a/node/benchmarks/index.js
+++ b/node/benchmarks/index.js
@@ -130,14 +130,16 @@ function startServer(serverPort, instances) {
       return self.startGoServer(serverPort, instances);
     }
 
+    var noOverhead = self.opts.noEndpointOverhead;
+
     var serverProc = run(server, [
         self.opts.trace ? '--trace' : '--no-trace',
         '--traceRelayHostPort', '127.0.0.1:' + RELAY_TRACE_PORT,
         '--port', String(serverPort),
         '--instances', String(instances),
-        '--pingOverhead', 'norm:10,5',
-        '--setOverhead', 'norm:200,20',
-        '--getOverhead', 'norm:100,10'
+        '--pingOverhead', noOverhead ? 'none' : 'norm:10,5',
+        '--setOverhead', noOverhead ? 'none' : 'norm:200,20',
+        '--getOverhead', noOverhead ? 'none' : 'norm:100,10'
     ]);
     self.serverProcs.push(serverProc);
     serverProc.stdout.pipe(process.stderr);
@@ -314,7 +316,7 @@ if (require.main === module) {
         alias: {
             o: 'output'
         },
-        boolean: ['relay', 'trace', 'debug']
+        boolean: ['relay', 'trace', 'debug', 'noEndpointOverhead']
     });
     var runner = BenchmarkRunner(argv);
     runner.start();


### PR DESCRIPTION
So that we can get at-full-saturation numbers again from our comparison approach; otherwise most micro performance wins aren't noticeable since the endpoint overhead dominates the run time.