### PR TITLE
Update default advertise timeouts

### DIFF
--- a/node/hyperbahn/handler.js
+++ b/node/hyperbahn/handler.js
@@ -32,7 +32,7 @@ var TChannelEndpointHandler = require('../endpoint-handler');
 
 var MAX_RELAY_AD_ATTEMPTS = 2;
 var RELAY_AD_RETRY_TIME = 1 * 1000;
-var RELAY_AD_TIMEOUT = 50;
+var RELAY_AD_TIMEOUT = 500;
 
 module.exports = HyperbahnHandler;
 

--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -60,6 +60,7 @@ var DEFAULT_ERROR_RETRY_TIMES = [
 
     10000 // Max out at 10 seconds
 ];
+var DEFAULT_TIMEOUT = 500;
 
 module.exports = HyperbahnClient;
 
@@ -140,6 +141,7 @@ function HyperbahnClient(options) {
     self.attemptCounter = 0;
     self.state = States.UNADVERTISED;
     self._destroyed = false;
+    self.defaultAdTimeout = options.defaultAdTimeout || DEFAULT_TIMEOUT;
 
     var advertisementTimeout = options.advertisementTimeout ||
         options.registrationTimeout;
@@ -243,7 +245,7 @@ function sendAdvertiseRequest(opts, cb) {
 
     var req = self.hyperbahnChannel.request({
         serviceName: 'hyperbahn',
-        timeout: (opts && opts.timeout) || 50,
+        timeout: (opts && opts.timeout) || self.defaultAdTimeout,
         hasNoParent: true,
         trace: false,
         retryLimit: 1,


### PR DESCRIPTION
The ad timeouts in production are too aggressive.

We need to allow more breathing room.

r: @jcorbin @shannili @rf