### PR TITLE
go: Add RemainingBytes to TTransport

### DIFF
--- a/golang/Godeps/Godeps.json
+++ b/golang/Godeps/Godeps.json
@@ -7,7 +7,7 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/apache/thrift/lib/go/thrift",
-			"Rev": "211b82de11c3c5bb83f669a95373b3ea6601d666"
+			"Rev": "b2e90c143e266c9af9ed437a3ab0dbb229a0b722"
 		},
 		{
 			"ImportPath": "github.com/cactus/go-statsd-client/statsd",

--- a/golang/thrift/transport.go
+++ b/golang/thrift/transport.go
@@ -48,4 +48,11 @@ func (t *readWriterTransport) Close() error {
 	return nil
 }
 
+// RemainingBytes returns the max number of bytes (same as Thrift's StreamTransport) as we
+// do not know how many bytes we have left.
+func (t *readWriterTransport) RemainingBytes() uint64 {
+	const maxSize = ^uint64(0)
+	return maxSize
+}
+
 var _ thrift.TTransport = &readWriterTransport{}


### PR DESCRIPTION
Latest thrift library requires this method in TTransport.