### PR TITLE
Score within ranges for each pending requests tier

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -359,7 +359,10 @@ TChannelPeer.prototype.outPendingWeightedRandom = function outPendingWeightedRan
     // http://arxiv.org/pdf/1012.0256.pdf
     var self = this;
     var pending = self.pendingIdentified + self.countOutPending();
-    return Math.pow(self.random(), 1 + pending);
+    var max = Math.pow(0.5, pending);
+    var min = max / 2;
+    var diff = max - min;
+    return min + diff * self.random();
 };
 
 TChannelPeer.prototype.countOutPending = function countOutPending() {


### PR DESCRIPTION
A peer with fewer pending requests will always be favored over another
with more pending requests, and this provides a uniform probability
distribution for peers with the same number of pending requests.

This algorithm divides the score interval (0, 1) into an infinite series
of equivalence classes per quantity of pending requests. So, (0.5, 1)
for 0 pending requests, (0.25, 0.5) for 1 pending request, (0.125, 0.25)
for 2 pending requests, ad nauseaum.