### PR TITLE
Make peers.delete() defensive

### DIFF
--- a/node/sub_peers.js
+++ b/node/sub_peers.js
@@ -83,8 +83,12 @@ TChannelSubPeers.prototype.clear = function clear() {
 TChannelSubPeers.prototype._delete = function _del(peer) {
     var self = this;
 
-    delete self._map[peer.hostPort];
     var index = self._keys.indexOf(peer.hostPort);
+    if (index === -1) {
+        return;
+    }
+
+    delete self._map[peer.hostPort];
     popout(self._keys, index);
 
     for (var i = 0; i < peer.heapElements.length; i++) {

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -20,78 +20,78 @@
 
 'use strict';
 
-require('./errors.js');
-require('./event_emitter.js');
-require('./argstream.js');
-require('./circuits.js');
-require('./safe-quit.js');
-require('./timeouts.js');
-require('./send.js');
-require('./retry.js');
-require('./relay.js');
-require('./streaming.js');
-require('./streaming_bisect.js');
-require('./register.js');
-require('./identify.js');
-require('./max_pending.js');
-require('./tchannel.js');
-require('./regression-inOps-leak.js');
-require('./regression-listening-on-used-port.js');
-require('./as-thrift.js');
-require('./as-json.js');
-require('./as-http.js');
-require('./peer.js');
-require('./peers.js');
-require('./streaming-resp-err.js');
-require('./double-response.js');
-require('./ping.js');
-require('./request-stats.js');
-require('./request-with-statsd.js');
-require('./response-stats.js');
-require('./response-with-statsd.js');
-require('./ping.js');
-require('./permissions_cache.js');
-require('./connection-stats.js');
-require('./connection-with-statsd.js');
-require('./request-error-context.js');
-require('./max-call-overhead.js');
-require('./non-zero-ttl.js');
-require('./examples.js');
-require('./busy.js');
-require('./ephemeral-client.js');
-require('./relay-to-dead.js');
-require('./rate-limiter.js');
-require('./time_heap.js');
-require('./balance_peer_requests.js');
-require('./tcollector-reporter.js');
-require('./pool-of-servers.js');
-
-require('./trace/basic_server.js');
-require('./trace/server_2_requests.js');
-require('./trace/outpeer_span_handle.js');
-
-require('./v2/frame.js');
-require('./v2/init.js');
-require('./v2/checksum.js');
-require('./v2/header.js');
-require('./v2/tracing.js');
-require('./v2/call.js');
-require('./v2/cancel.js');
-require('./v2/cont.js');
-require('./v2/claim.js');
-require('./v2/ping.js');
-require('./v2/error_response.js');
-require('./v2/args.js');
-require('./v2/lazy_frame.js');
-
-require('./hyperbahn/constructor.js');
-require('./hyperbahn/todo.js');
-require('./hyperbahn/sub-channel.js');
-require('./hyperbahn/kill-switch.js');
-
 module.exports = runTests;
 
 if (require.main === module) {
+    require('./errors.js');
+    require('./event_emitter.js');
+    require('./argstream.js');
+    require('./circuits.js');
+    require('./safe-quit.js');
+    require('./timeouts.js');
+    require('./send.js');
+    require('./retry.js');
+    require('./relay.js');
+    require('./streaming.js');
+    require('./streaming_bisect.js');
+    require('./register.js');
+    require('./identify.js');
+    require('./max_pending.js');
+    require('./tchannel.js');
+    require('./regression-inOps-leak.js');
+    require('./regression-listening-on-used-port.js');
+    require('./as-thrift.js');
+    require('./as-json.js');
+    require('./as-http.js');
+    require('./peer.js');
+    require('./peers.js');
+    require('./streaming-resp-err.js');
+    require('./double-response.js');
+    require('./ping.js');
+    require('./request-stats.js');
+    require('./request-with-statsd.js');
+    require('./response-stats.js');
+    require('./response-with-statsd.js');
+    require('./ping.js');
+    require('./permissions_cache.js');
+    require('./connection-stats.js');
+    require('./connection-with-statsd.js');
+    require('./request-error-context.js');
+    require('./max-call-overhead.js');
+    require('./non-zero-ttl.js');
+    require('./examples.js');
+    require('./busy.js');
+    require('./ephemeral-client.js');
+    require('./relay-to-dead.js');
+    require('./rate-limiter.js');
+    require('./time_heap.js');
+    require('./balance_peer_requests.js');
+    require('./tcollector-reporter.js');
+    require('./pool-of-servers.js');
+
+    require('./trace/basic_server.js');
+    require('./trace/server_2_requests.js');
+    require('./trace/outpeer_span_handle.js');
+
+    require('./v2/frame.js');
+    require('./v2/init.js');
+    require('./v2/checksum.js');
+    require('./v2/header.js');
+    require('./v2/tracing.js');
+    require('./v2/call.js');
+    require('./v2/cancel.js');
+    require('./v2/cont.js');
+    require('./v2/claim.js');
+    require('./v2/ping.js');
+    require('./v2/error_response.js');
+    require('./v2/args.js');
+    require('./v2/lazy_frame.js');
+
+    require('./hyperbahn/constructor.js');
+    require('./hyperbahn/todo.js');
+    require('./hyperbahn/sub-channel.js');
+    require('./hyperbahn/kill-switch.js');
+
     runTests(require('./lib/hyperbahn-cluster.js'));
 }
 


### PR DESCRIPTION
There are edge cases where we tried to delete non-existant
ephemeral peers.

r: @shannili @kriskowal