### PR TITLE
WIP - choose from max score candidates

### DIFF
--- a/node/test/pool-of-servers.js
+++ b/node/test/pool-of-servers.js
@@ -25,7 +25,10 @@ var parallel = require('run-parallel');
 var allocCluster = require('./lib/alloc-cluster.js');
 
 allocCluster.test('request().send() to a pool of servers', {
-    numPeers: 5
+    numPeers: 5,
+    channelOptions: {
+        choosePeerWithHeap: true
+    }
 }, function t(cluster, assert) {
     var client = cluster.channels[0];
 
@@ -174,7 +177,7 @@ allocCluster.test('request().send() to a pool of servers', {
         }
 
         var keys = Object.keys(byServer);
-        assert.equal(keys.length, numPeers, 'expected 25 servers');
+        assert.equal(keys.length, numPeers, 'expected responses from all servers');
 
         for (var k = 0; k < keys.length; k++) {
             var count = byServer[keys[k]];


### PR DESCRIPTION
This is an alternative approach to peer selection where randomness is eliminated from the score number and all peers with the same score are considered and weighed evenly for each request.

This degenerates to O(n) when there are many peers with the same score, e.g., initial conditions. Will follow-up with an alternate approach that will choose the max peer and sift it down a random path until it butts up against a peer with a lower score. This would give us O(log n) worst case peer selection, O(1) best case.

This approach does not pass the pool test, so further investigation required.