### PR TITLE
go: Rename callHeader to transportHeader

### DIFF
--- a/golang/calloptions.go
+++ b/golang/calloptions.go
@@ -44,7 +44,7 @@ type CallOptions struct {
 
 var defaultCallOptions = &CallOptions{}
 
-func (c *CallOptions) setHeaders(headers callHeaders) {
+func (c *CallOptions) setHeaders(headers transportHeaders) {
 	if c == nil {
 		c = defaultCallOptions
 	}
@@ -58,6 +58,6 @@ func (c *CallOptions) setHeaders(headers callHeaders) {
 }
 
 // setResponseHeaders copies some headers from the incoming call request to the response.
-func setResponseHeaders(reqHeaders, respHeaders callHeaders) {
+func setResponseHeaders(reqHeaders, respHeaders transportHeaders) {
 	respHeaders[ArgScheme] = reqHeaders[ArgScheme]
 }

--- a/golang/calloptions_test.go
+++ b/golang/calloptions_test.go
@@ -29,16 +29,16 @@ import (
 func TestSetHeaders(t *testing.T) {
 	tests := []struct {
 		format          Format
-		expectedHeaders callHeaders
+		expectedHeaders transportHeaders
 	}{
 		{
 			// When no format is specified, Raw should be used by default.
 			format:          "",
-			expectedHeaders: callHeaders{ArgScheme: Raw.String()},
+			expectedHeaders: transportHeaders{ArgScheme: Raw.String()},
 		},
 		{
 			format:          Thrift,
-			expectedHeaders: callHeaders{ArgScheme: Thrift.String()},
+			expectedHeaders: transportHeaders{ArgScheme: Thrift.String()},
 		},
 	}
 
@@ -46,7 +46,7 @@ func TestSetHeaders(t *testing.T) {
 		callOpts := &CallOptions{
 			Format: tt.format,
 		}
-		headers := make(callHeaders)
+		headers := make(transportHeaders)
 		callOpts.setHeaders(headers)
 		assert.Equal(t, tt.expectedHeaders, headers)
 	}

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -64,7 +64,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.cancel = cancel
 	response.span = callReq.Tracing
 	response.log = c.log.WithField(LogField{"In-Response", callReq.ID()})
-	response.headers = callHeaders{}
+	response.headers = transportHeaders{}
 	response.messageForFragment = func(initial bool) message {
 		if initial {
 			callRes := new(callRes)
@@ -156,7 +156,7 @@ type InboundCall struct {
 	response        *InboundCallResponse
 	serviceName     string
 	operation       []byte
-	headers         callHeaders
+	headers         transportHeaders
 	span            Span
 	statsReporter   StatsReporter
 	commonStatsTags map[string]string
@@ -221,7 +221,7 @@ type InboundCallResponse struct {
 	// calledAt is the time the inbound call was routed to the application.
 	calledAt         time.Time
 	applicationError bool
-	headers          callHeaders
+	headers          transportHeaders
 	span             Span
 	statsReporter    StatsReporter
 	commonStatsTags  map[string]string

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -126,51 +126,51 @@ type initRes struct {
 
 func (m *initRes) messageType() messageType { return messageTypeInitRes }
 
-// CallHeaderName is a type for call header names.
-type CallHeaderName string
+// TransportHeaderName is a type for transport header names.
+type TransportHeaderName string
 
-func (cn CallHeaderName) String() string { return string(cn) }
+func (cn TransportHeaderName) String() string { return string(cn) }
 
 // Known transport header keys for call requests. See protocol docs for more information.
 const (
 	// ArgScheme header specifies the format of the args.
-	ArgScheme CallHeaderName = "as"
+	ArgScheme TransportHeaderName = "as"
 
 	// CallerName header specifies the name of the service making the call.
-	CallerName CallHeaderName = "cn"
+	CallerName TransportHeaderName = "cn"
 
 	// ClaimAtFinish header value is host:port specifying the instance to send a claim message
 	// to when response is being sent.
-	ClaimAtFinish CallHeaderName = "caf"
+	ClaimAtFinish TransportHeaderName = "caf"
 
 	// ClaimAtStart header value is host:port specifying another instance to send a claim message
 	// to when work is started.
-	ClaimAtStart CallHeaderName = "cas"
+	ClaimAtStart TransportHeaderName = "cas"
 
 	// FailureDomain header describes a group of related requests to the same service that are
 	// likely to fail in the same way if they were to fail.
-	FailureDomain CallHeaderName = "fd"
+	FailureDomain TransportHeaderName = "fd"
 
 	// RetryFlags header specifies whether retry policies.
-	RetryFlags CallHeaderName = "re"
+	RetryFlags TransportHeaderName = "re"
 
 	// SpeculativeExecution header specifies the number of nodes on which to run the request.
-	SpeculativeExecution CallHeaderName = "se"
+	SpeculativeExecution TransportHeaderName = "se"
 )
 
-// callHeaders are passed as part of a CallReq/CallRes
-type callHeaders map[CallHeaderName]string
+// transportHeaders are passed as part of a CallReq/CallRes
+type transportHeaders map[TransportHeaderName]string
 
-func (ch callHeaders) read(r *typed.ReadBuffer) {
+func (ch transportHeaders) read(r *typed.ReadBuffer) {
 	nh := r.ReadByte()
 	for i := 0; i < int(nh); i++ {
 		k := r.ReadLen8String()
 		v := r.ReadLen8String()
-		ch[CallHeaderName(k)] = v
+		ch[TransportHeaderName(k)] = v
 	}
 }
 
-func (ch callHeaders) write(w *typed.WriteBuffer) {
+func (ch transportHeaders) write(w *typed.WriteBuffer) {
 	w.WriteByte(byte(len(ch)))
 
 	for k, v := range ch {
@@ -184,7 +184,7 @@ type callReq struct {
 	id         uint32
 	TimeToLive time.Duration
 	Tracing    Span
-	Headers    callHeaders
+	Headers    transportHeaders
 	Service    string
 }
 
@@ -194,7 +194,7 @@ func (m *callReq) read(r *typed.ReadBuffer) error {
 	m.TimeToLive = time.Duration(r.ReadUint32()) * time.Millisecond
 	m.Tracing.read(r)
 	m.Service = r.ReadLen8String()
-	m.Headers = callHeaders{}
+	m.Headers = transportHeaders{}
 	m.Headers.read(r)
 	return r.Err()
 }
@@ -229,7 +229,7 @@ type callRes struct {
 	id           uint32
 	ResponseCode ResponseCode
 	Tracing      Span
-	Headers      callHeaders
+	Headers      transportHeaders
 }
 
 func (m *callRes) ID() uint32               { return m.id }
@@ -238,7 +238,7 @@ func (m *callRes) messageType() messageType { return messageTypeCallRes }
 func (m *callRes) read(r *typed.ReadBuffer) error {
 	m.ResponseCode = ResponseCode(r.ReadByte())
 	m.Tracing.read(r)
-	m.Headers = callHeaders{}
+	m.Headers = transportHeaders{}
 	m.Headers.read(r)
 	return r.Err()
 }

--- a/golang/messages_test.go
+++ b/golang/messages_test.go
@@ -75,7 +75,7 @@ func TestCallReq(t *testing.T) {
 			spanID:   12762782,
 			flags:    0x01,
 		},
-		Headers: callHeaders{
+		Headers: transportHeaders{
 			"r": "c",
 			"f": "d",
 		},
@@ -101,7 +101,7 @@ func TestCallRes(t *testing.T) {
 	r := callRes{
 		id:           0xDEADBEEF,
 		ResponseCode: responseApplicationError,
-		Headers: callHeaders{
+		Headers: transportHeaders{
 			"r": "c",
 			"f": "d",
 		},

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -61,7 +61,7 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		return nil, err
 	}
 
-	headers := callHeaders{
+	headers := transportHeaders{
 		CallerName: c.localPeerInfo.ServiceName,
 	}
 	callOptions.setHeaders(headers)


### PR DESCRIPTION
This makes go consistent with the other languages and the protocol docs.