### PR TITLE
change protocol doc to point to external docs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -633,12 +633,12 @@ used for interop with other systems.
 The following table describes the valid `as` values and their corresponding
 arg1, arg2, and arg3 forms:
 
-| value    | arg1                  | arg2                                     | arg3
-| -------- | --------------------- | ---------------------------------------- | --------------
-| `thrift` | string method name    | application headers `nh:2 (k~2 v~2){nh}` | thrift payload
-| `json`   | method name as string | application headers as JSON              | body as JSON
-| `http`   | method + URI          | headers as JSON array                    | raw body
-| `raw`    | raw bytes             | raw bytes                                | raw bytes
+
+ - For `as=thrift` see [thrift arg scheme definition](./thrift.md)
+ - For `as=sthrift` see [streaming thrift arg scheme definition](./sthrift.md)
+ - For `as=json` see [json arg scheme definition](./json.md)
+ - For `as=http` see [http arg scheme definition](./http.md)
+ - For `as=raw` see [raw arg scheme definition](./raw.md)
 
 ### Transport Header `cas` -- Claim At Start
 

--- a/docs/raw.md
+++ b/docs/raw.md
@@ -1,0 +1,15 @@
+# as=raw for TChannel
+
+This document outlines what the raw encoding is.
+
+The `as=raw` encoded is intended for any custom encodings you want to do that
+are not part of tchannel but are application specific.
+
+Consider using the `thrift`, `sthrift`, `json` or `http` encodigns
+before using `as=raw`.
+
+## Arguments
+
+ - `arg1` : raw bytes
+ - `arg2` : raw bytes
+ - `arg3` : raw bytes


### PR DESCRIPTION
The definition of the "Arg Scheme" in the protocol document was
stale.

To avoid confusion I rewrote this section to point to other
documents that explain each arg scheme in detail

r: @blampe @breerly @abhinav