### PR TITLE
go: Unexpected short buffer should throw error, not panic

### DIFF
--- a/golang/mex.go
+++ b/golang/mex.go
@@ -88,11 +88,13 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 		return frame, nil
 
 	case messageTypeError:
-		var err errorMessage
+		var errMsg errorMessage
 		var rbuf typed.ReadBuffer
 		rbuf.Wrap(frame.SizedPayload())
-		err.read(&rbuf)
-		return nil, err.AsSystemError()
+		if err := errMsg.read(&rbuf); err != nil {
+			return nil, err
+		}
+		return nil, errMsg.AsSystemError()
 
 	default:
 		// TODO(mmihic): Should be treated as a protocol error

--- a/golang/thrift/headers.go
+++ b/golang/thrift/headers.go
@@ -49,11 +49,11 @@ func readHeaders(r io.Reader) (map[string]string, error) {
 	buffer := typed.NewReadBuffer(bs)
 	numHeaders := buffer.ReadUint16()
 	if numHeaders == 0 {
-		return nil, nil
+		return nil, buffer.Err()
 	}
 
 	headers := make(map[string]string)
-	for i := 0; i < int(numHeaders); i++ {
+	for i := 0; i < int(numHeaders) && buffer.Err() == nil; i++ {
 		k := buffer.ReadLen16String()
 		v := buffer.ReadLen16String()
 		headers[k] = v

--- a/golang/typed/buffer.go
+++ b/golang/typed/buffer.go
@@ -59,7 +59,7 @@ func (r *ReadBuffer) ReadByte() byte {
 	}
 
 	if len(r.remaining) == 0 {
-		r.err = io.EOF
+		r.err = ErrEOF
 		return 0
 	}
 
@@ -75,10 +75,8 @@ func (r *ReadBuffer) ReadBytes(n int) []byte {
 	}
 
 	if len(r.remaining) < n {
-		b := r.remaining
-		r.remaining = nil
-		r.err = io.EOF
-		return b
+		r.err = ErrEOF
+		return nil
 	}
 
 	b := r.remaining[0:n]

--- a/golang/typed/buffer_test.go
+++ b/golang/typed/buffer_test.go
@@ -54,7 +54,12 @@ func TestSimple(t *testing.T) {
 		r.Wrap(buf)
 		assert.Equal(t, uint32(0xBEEFDEAD), r.ReadUint32())
 	}
+}
 
+func TestShortBuffer(t *testing.T) {
+	r := NewReadBuffer([]byte{23})
+	assert.EqualValues(t, 0, r.ReadUint16())
+	assert.Equal(t, ErrEOF, r.Err())
 }
 
 func TestReadWrite(t *testing.T) {


### PR DESCRIPTION
cc @jsu1212 

It will return an error on a short buffer instead of a panic.