### PR TITLE
go: Fix lint / govet failures

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -323,7 +323,7 @@ func (ch *Channel) serve() {
 			netConn.Close()
 			continue
 		}
-		c.onCloseStateChange = ch.ConnectionCloseStateChange
+		c.onCloseStateChange = ch.connectionCloseStateChange
 	}
 }
 
@@ -362,7 +362,7 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string, connectionOptio
 	if err != nil {
 		return nil, err
 	}
-	c.onCloseStateChange = ch.ConnectionCloseStateChange
+	c.onCloseStateChange = ch.connectionCloseStateChange
 
 	if err := c.sendInit(ctx); err != nil {
 		return nil, err
@@ -384,7 +384,8 @@ func (ch *Channel) Connect(ctx context.Context, hostPort string, connectionOptio
 	return c, err
 }
 
-func (ch *Channel) ConnectionCloseStateChange(c *Connection) {
+// connectionCloseStateChange is called when a connection's close state changes.
+func (ch *Channel) connectionCloseStateChange(c *Connection) {
 	switch chState := ch.State(); chState {
 	case ChannelStartClose, ChannelInboundClosed:
 		ch.mutable.mut.RLock()

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -586,7 +586,7 @@ func (c *Connection) readState() connectionState {
 func (c *Connection) readFrames() {
 	for {
 		frame := c.framePool.Get()
-		if err := frame.ReadFrom(c.conn); err != nil {
+		if err := frame.ReadIn(c.conn); err != nil {
 			c.framePool.Release(frame)
 			c.connectionError(err)
 			return
@@ -630,7 +630,7 @@ func (c *Connection) writeFrames() {
 	for f := range c.sendCh {
 		c.log.Debugf("Writing frame %s", f.Header)
 
-		err := f.WriteTo(c.conn)
+		err := f.WriteOut(c.conn)
 		c.framePool.Release(f)
 		if err != nil {
 			c.connectionError(err)

--- a/golang/examples/thrift/main.go
+++ b/golang/examples/thrift/main.go
@@ -145,7 +145,9 @@ type firstHandler struct{}
 
 func (h *firstHandler) Healthcheck(ctx thrift.Context) (*gen.HealthCheckRes, error) {
 	log.Printf("first: HealthCheck()\n")
-	return &gen.HealthCheckRes{true, "OK"}, nil
+	return &gen.HealthCheckRes{
+		Healthy: true,
+		Msg:     "OK"}, nil
 }
 
 func (h *firstHandler) Echo(ctx thrift.Context, msg string) (r string, err error) {

--- a/golang/fragmentation_test.go
+++ b/golang/fragmentation_test.go
@@ -375,7 +375,7 @@ func (ch fragmentChannel) newFragment(initial bool, checksum Checksum) (*writabl
 	wbuf := typed.NewWriteBuffer(make([]byte, testFragmentSize))
 	fragment := new(writableFragment)
 	fragment.flagsRef = wbuf.DeferByte()
-	wbuf.WriteByte(byte(checksum.TypeCode()))
+	wbuf.WriteSingleByte(byte(checksum.TypeCode()))
 	fragment.checksumRef = wbuf.DeferBytes(checksum.Size())
 	fragment.checksum = checksum
 	fragment.contents = wbuf
@@ -393,8 +393,8 @@ func (ch fragmentChannel) recvNextFragment(initial bool) (*readableFragment, err
 	rbuf := typed.NewReadBuffer(<-ch)
 	fragment := new(readableFragment)
 	fragment.done = func() {}
-	fragment.flags = rbuf.ReadByte()
-	fragment.checksumType = ChecksumType(rbuf.ReadByte())
+	fragment.flags = rbuf.ReadSingleByte()
+	fragment.checksumType = ChecksumType(rbuf.ReadSingleByte())
 	fragment.checksum = rbuf.ReadBytes(fragment.checksumType.ChecksumSize())
 	fragment.contents = rbuf
 	return fragment, rbuf.Err()

--- a/golang/frame.go
+++ b/golang/frame.go
@@ -76,8 +76,8 @@ func (fh FrameHeader) String() string { return fmt.Sprintf("%v[%d]", fh.messageT
 
 func (fh *FrameHeader) read(r *typed.ReadBuffer) error {
 	fh.size = r.ReadUint16()
-	fh.messageType = messageType(r.ReadByte())
-	fh.reserved1 = r.ReadByte()
+	fh.messageType = messageType(r.ReadSingleByte())
+	fh.reserved1 = r.ReadSingleByte()
 	fh.ID = r.ReadUint32()
 	r.ReadBytes(len(fh.reserved))
 	return r.Err()
@@ -85,8 +85,8 @@ func (fh *FrameHeader) read(r *typed.ReadBuffer) error {
 
 func (fh *FrameHeader) write(w *typed.WriteBuffer) error {
 	w.WriteUint16(fh.size)
-	w.WriteByte(byte(fh.messageType))
-	w.WriteByte(fh.reserved1)
+	w.WriteSingleByte(byte(fh.messageType))
+	w.WriteSingleByte(fh.reserved1)
 	w.WriteUint32(fh.ID)
 	w.WriteBytes(fh.reserved[:])
 	return w.Err()

--- a/golang/frame.go
+++ b/golang/frame.go
@@ -113,8 +113,8 @@ func NewFrame(payloadCapacity int) *Frame {
 	return f
 }
 
-// ReadFrom reads the frame from the given io.Reader
-func (f *Frame) ReadFrom(r io.Reader) error {
+// ReadIn reads the frame from the given io.Reader
+func (f *Frame) ReadIn(r io.Reader) error {
 	var rbuf typed.ReadBuffer
 	rbuf.Wrap(f.headerBuffer)
 
@@ -134,8 +134,8 @@ func (f *Frame) ReadFrom(r io.Reader) error {
 	return nil
 }
 
-// WriteTo writes the frame to the given io.Writer
-func (f *Frame) WriteTo(w io.Writer) error {
+// WriteOut writes the frame to the given io.Writer
+func (f *Frame) WriteOut(w io.Writer) error {
 	var wbuf typed.WriteBuffer
 	wbuf.Wrap(f.headerBuffer)
 

--- a/golang/frame_test.go
+++ b/golang/frame_test.go
@@ -66,12 +66,12 @@ func TestPartialRead(t *testing.T) {
 		f.Payload[i] = byte(val)
 	}
 	buf := &bytes.Buffer{}
-	require.NoError(t, f.WriteTo(buf))
+	require.NoError(t, f.WriteOut(buf))
 	assert.Equal(t, f.Header.size, uint16(buf.Len()), "frame size should match written bytes")
 
 	// Read the data back, from a reader that fragments.
 	f2 := NewFrame(MaxFramePayloadSize)
-	require.NoError(t, f2.ReadFrom(iotest.OneByteReader(buf)))
+	require.NoError(t, f2.ReadIn(iotest.OneByteReader(buf)))
 
 	// Ensure header and payload are the same.
 	require.Equal(t, f.Header, f2.Header, "frame headers don't match")
@@ -85,11 +85,11 @@ func TestEmptyPayload(t *testing.T) {
 
 	// Write out the frame.
 	buf := &bytes.Buffer{}
-	require.NoError(t, f.WriteTo(buf))
+	require.NoError(t, f.WriteOut(buf))
 	assert.Equal(t, FrameHeaderSize, buf.Len())
 
 	// Read the frame from the buffer.
 	// net.Conn returns io.EOF if you try to read 0 bytes at the end.
 	// This is also simulated by the LimitedReader so we use that here.
-	require.NoError(t, f.ReadFrom(&io.LimitedReader{R: buf, N: FrameHeaderSize}))
+	require.NoError(t, f.ReadIn(&io.LimitedReader{R: buf, N: FrameHeaderSize}))
 }

--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -15,12 +15,12 @@ func writeMessage(w io.Writer, msg message) error {
 	if err := f.write(msg); err != nil {
 		return err
 	}
-	return f.WriteTo(w)
+	return f.WriteOut(w)
 }
 
 func readFrame(r io.Reader) (*Frame, error) {
 	f := NewFrame(MaxFramePayloadSize)
-	return f, f.ReadFrom(r)
+	return f, f.ReadIn(r)
 }
 
 func TestUnexpectedInitReq(t *testing.T) {

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -162,7 +162,7 @@ const (
 type transportHeaders map[TransportHeaderName]string
 
 func (ch transportHeaders) read(r *typed.ReadBuffer) {
-	nh := r.ReadByte()
+	nh := r.ReadSingleByte()
 	for i := 0; i < int(nh); i++ {
 		k := r.ReadLen8String()
 		v := r.ReadLen8String()
@@ -171,7 +171,7 @@ func (ch transportHeaders) read(r *typed.ReadBuffer) {
 }
 
 func (ch transportHeaders) write(w *typed.WriteBuffer) {
-	w.WriteByte(byte(len(ch)))
+	w.WriteSingleByte(byte(len(ch)))
 
 	for k, v := range ch {
 		w.WriteLen8String(k.String())
@@ -236,7 +236,7 @@ func (m *callRes) ID() uint32               { return m.id }
 func (m *callRes) messageType() messageType { return messageTypeCallRes }
 
 func (m *callRes) read(r *typed.ReadBuffer) error {
-	m.ResponseCode = ResponseCode(r.ReadByte())
+	m.ResponseCode = ResponseCode(r.ReadSingleByte())
 	m.Tracing.read(r)
 	m.Headers = transportHeaders{}
 	m.Headers.read(r)
@@ -244,7 +244,7 @@ func (m *callRes) read(r *typed.ReadBuffer) error {
 }
 
 func (m *callRes) write(w *typed.WriteBuffer) error {
-	w.WriteByte(byte(m.ResponseCode))
+	w.WriteSingleByte(byte(m.ResponseCode))
 	m.Tracing.write(w)
 	m.Headers.write(w)
 	return w.Err()
@@ -270,14 +270,14 @@ type errorMessage struct {
 func (m *errorMessage) ID() uint32               { return m.id }
 func (m *errorMessage) messageType() messageType { return messageTypeError }
 func (m *errorMessage) read(r *typed.ReadBuffer) error {
-	m.errCode = SystemErrCode(r.ReadByte())
+	m.errCode = SystemErrCode(r.ReadSingleByte())
 	m.id = r.ReadUint32()
 	m.message = r.ReadLen16String()
 	return r.Err()
 }
 
 func (m *errorMessage) write(w *typed.WriteBuffer) error {
-	w.WriteByte(byte(m.errCode))
+	w.WriteSingleByte(byte(m.errCode))
 	w.WriteUint32(m.id)
 	w.WriteLen16String(m.message)
 	return w.Err()

--- a/golang/reqres.go
+++ b/golang/reqres.go
@@ -125,7 +125,7 @@ func (w *reqResWriter) newFragment(initial bool, checksum Checksum) (*writableFr
 	if err := message.write(wbuf); err != nil {
 		return nil, err
 	}
-	wbuf.WriteByte(byte(checksum.TypeCode()))
+	wbuf.WriteSingleByte(byte(checksum.TypeCode()))
 	fragment.checksumRef = wbuf.DeferBytes(checksum.Size())
 	fragment.checksum = checksum
 	fragment.contents = wbuf
@@ -252,12 +252,12 @@ func (r *reqResReader) failed(err error) error {
 func parseInboundFragment(framePool FramePool, frame *Frame, message message) (*readableFragment, error) {
 	rbuf := typed.NewReadBuffer(frame.SizedPayload())
 	fragment := new(readableFragment)
-	fragment.flags = rbuf.ReadByte()
+	fragment.flags = rbuf.ReadSingleByte()
 	if err := message.read(rbuf); err != nil {
 		return nil, err
 	}
 
-	fragment.checksumType = ChecksumType(rbuf.ReadByte())
+	fragment.checksumType = ChecksumType(rbuf.ReadSingleByte())
 	fragment.checksum = rbuf.ReadBytes(fragment.checksumType.ChecksumSize())
 	fragment.contents = rbuf
 	fragment.done = func() {

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -51,7 +51,7 @@ func (s *Span) read(r *typed.ReadBuffer) error {
 	s.traceID = r.ReadUint64()
 	s.parentID = r.ReadUint64()
 	s.spanID = r.ReadUint64()
-	s.flags = r.ReadByte()
+	s.flags = r.ReadSingleByte()
 	return r.Err()
 }
 
@@ -59,7 +59,7 @@ func (s *Span) write(w *typed.WriteBuffer) error {
 	w.WriteUint64(s.traceID)
 	w.WriteUint64(s.parentID)
 	w.WriteUint64(s.spanID)
-	w.WriteByte(s.flags)
+	w.WriteSingleByte(s.flags)
 	return w.Err()
 }
 

--- a/golang/typed/buffer.go
+++ b/golang/typed/buffer.go
@@ -52,8 +52,8 @@ func NewReadBufferWithSize(size int) *ReadBuffer {
 	return &ReadBuffer{buffer: make([]byte, size), remaining: nil}
 }
 
-// ReadByte reads the next byte from the buffer
-func (r *ReadBuffer) ReadByte() byte {
+// ReadSingleByte reads the next byte from the buffer
+func (r *ReadBuffer) ReadSingleByte() byte {
 	if r.err != nil {
 		return 0
 	}
@@ -123,7 +123,7 @@ func (r *ReadBuffer) ReadUint64() uint64 {
 
 // ReadLen8String reads an 8-bit length preceded string value
 func (r *ReadBuffer) ReadLen8String() string {
-	n := r.ReadByte()
+	n := r.ReadSingleByte()
 	return r.ReadString(int(n))
 }
 
@@ -177,8 +177,8 @@ func NewWriteBufferWithSize(size int) *WriteBuffer {
 	return NewWriteBuffer(make([]byte, size))
 }
 
-// WriteByte writes a single byte to the buffer
-func (w *WriteBuffer) WriteByte(n byte) {
+// WriteSingleByte writes a single byte to the buffer
+func (w *WriteBuffer) WriteSingleByte(n byte) {
 	if w.err != nil {
 		return
 	}
@@ -231,7 +231,7 @@ func (w *WriteBuffer) WriteString(s string) {
 
 // WriteLen8String writes an 8-bit length preceded string
 func (w *WriteBuffer) WriteLen8String(s string) {
-	w.WriteByte(byte(len(s)))
+	w.WriteSingleByte(byte(len(s)))
 	w.WriteString(s)
 }
 

--- a/golang/typed/buffer_test.go
+++ b/golang/typed/buffer_test.go
@@ -36,9 +36,9 @@ func TestSimple(t *testing.T) {
 
 	{
 		w.Wrap(buf)
-		w.WriteByte(0xFC)
+		w.WriteSingleByte(0xFC)
 		r.Wrap(buf)
-		assert.Equal(t, byte(0xFC), r.ReadByte())
+		assert.Equal(t, byte(0xFC), r.ReadSingleByte())
 	}
 
 	{
@@ -70,7 +70,7 @@ func TestReadWrite(t *testing.T) {
 	w.WriteUint64(0x0123456789ABCDEF)
 	w.WriteUint32(0xABCDEF01)
 	w.WriteUint16(0x2345)
-	w.WriteByte(0xFF)
+	w.WriteSingleByte(0xFF)
 	w.WriteString(s)
 	w.WriteBytes(bslice)
 	w.WriteLen8String("hello")
@@ -86,7 +86,7 @@ func TestReadWrite(t *testing.T) {
 	assert.Equal(t, uint64(0x0123456789ABCDEF), r.ReadUint64())
 	assert.Equal(t, uint32(0xABCDEF01), r.ReadUint32())
 	assert.Equal(t, uint16(0x2345), r.ReadUint16())
-	assert.Equal(t, byte(0xFF), r.ReadByte())
+	assert.Equal(t, byte(0xFF), r.ReadSingleByte())
 	assert.Equal(t, s, r.ReadString(len(s)))
 	assert.Equal(t, bslice, r.ReadBytes(len(bslice)))
 	assert.Equal(t, "hello", r.ReadLen8String())
@@ -144,7 +144,7 @@ func TestDeferredWrites(t *testing.T) {
 	s := r.ReadString(5)
 	assert.Equal(t, "where", s)
 
-	u8 := r.ReadByte()
+	u8 := r.ReadSingleByte()
 	assert.Equal(t, byte(0x44), u8)
 	assert.NoError(t, r.Err())
 }


### PR DESCRIPTION
Use slightly less ideal names for internally used APIs to avoid govet failures.