### PR TITLE
go: use int8 for byte to match Thrift compiler

### DIFF
--- a/golang/thrift/thrift-gen/names.go
+++ b/golang/thrift/thrift-gen/names.go
@@ -113,8 +113,10 @@ func goPublicFieldName(name string) string {
 }
 
 var thriftToGo = map[string]string{
-	"bool":   "bool",
-	"byte":   "byte",
+	"bool": "bool",
+	// TODO(prashant): The Thrift compiler uses int8 for byte - fix the Thrift
+	// compiler and update this.
+	"byte":   "int8",
 	"i16":    "int16",
 	"i32":    "int32",
 	"i64":    "int64",

--- a/golang/thrift/thrift-gen/test_files/byte.thrift
+++ b/golang/thrift/thrift-gen/test_files/byte.thrift
@@ -1,0 +1,11 @@
+typedef byte Z
+
+struct S {
+  1: byte s1
+  2: Z s2
+}
+
+service Test {
+  byte M1(1: byte arg1)
+  S M2(1: byte arg1, 2: S arg2)
+}


### PR DESCRIPTION
Even though Go has a byte type which should be used, the Thrift compiler uses int8. We need to match the Thrift compiler, so use int8 till we can fix the Thrift compiler.