### PR TITLE
go: Fix memory exchange leaks in Streaming tests

### DIFF
--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -275,6 +275,7 @@ func (response *InboundCallResponse) SendSystemError(err error) error {
 			response.conn.remotePeerInfo, response.mex.msgID, err)
 	}
 
+	response.errorSending()
 	return nil
 }
 
@@ -317,5 +318,10 @@ func (response *InboundCallResponse) doneSending() {
 	latency := timeNow().Sub(response.calledAt)
 	response.statsReporter.RecordTimer("inbound.calls.latency", response.commonStatsTags, latency)
 
+	response.mex.shutdown()
+}
+
+// errorSending shuts down the message exhcnage for this call, and records counters.
+func (response *InboundCallResponse) errorSending() {
 	response.mex.shutdown()
 }

--- a/golang/mex_utils_test.go
+++ b/golang/mex_utils_test.go
@@ -45,7 +45,7 @@ func CheckEmptyExchanges(c *Connection) string {
 		return ""
 	}
 
-	return fmt.Sprintf("Connection %p has leftover exchanges:\n\t%v", c, strings.Join(errors, "\n\t"))
+	return fmt.Sprintf("Connection %d has leftover exchanges:\n\t%v", c.connID, strings.Join(errors, "\n\t"))
 }
 
 // CheckEmptyExchangesConns checks that all exchanges for the given connections are empty.

--- a/golang/stream_test.go
+++ b/golang/stream_test.go
@@ -188,6 +188,7 @@ func TestStreamPartialArg(t *testing.T) {
 		n, err := io.Copy(ioutil.Discard, argReader)
 		assert.Equal(t, int64(0), n, "arg2 reader expected to EOF after arg3 writer is closed")
 		assert.NoError(t, err, "Copy should not fail")
+		assert.NoError(t, argReader.Close(), "close arg reader failed")
 	})
 }
 

--- a/golang/stream_test.go
+++ b/golang/stream_test.go
@@ -136,7 +136,7 @@ func testStreamArg(t *testing.T, f func(argWriter ArgWriter, argReader io.ReadCl
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 
-	require.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ch.Register(streamPartialHandler(t), "echoStream")
 
 		call, err := ch.BeginCall(ctx, hostPort, ch.PeerInfo().ServiceName, "echoStream", nil)
@@ -177,7 +177,7 @@ func testStreamArg(t *testing.T, f func(argWriter ArgWriter, argReader io.ReadCl
 		verifyBytes(1)
 
 		f(argWriter, argReader)
-	}))
+	})
 }
 
 func TestStreamPartialArg(t *testing.T) {


### PR DESCRIPTION
Update Streaming tests to use WithVerifiedServer which verifies that memory exchanges are empty at the end of a test. This found a bug when sending a system error where exchanges weren't shut down.