### PR TITLE
go: Fix goroutine leaks and add tests to detect leaks

### DIFF
--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -26,14 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	. "github.com/uber/tchannel/golang"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel/golang/raw"
 	"github.com/uber/tchannel/golang/testutils"
+	"golang.org/x/net/context"
 )
 
 type channelState struct {
@@ -232,4 +231,9 @@ func TestCloseSemantics(t *testing.T) {
 	s2C <- struct{}{}
 	<-call1
 	assert.Equal(t, ChannelClosed, s1.State())
+}
+
+func TestCloseGoroutines(t *testing.T) {
+	// Make sure that all client and server Goroutines are closed when a connection is closed.
+
 }

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -669,10 +669,9 @@ func (c *Connection) checkExchanges() {
 
 	if updated {
 		curState := c.readState()
-		// If the connection is closed, we can safely close the channel and network.
+		// If the connection is closed, we can safely close the channel.
 		if curState == connectionClosed {
 			close(c.sendCh)
-			c.closeNetwork()
 		}
 
 		c.log.Debugf("checkExchanges updated connection state to %v", curState)

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -545,9 +545,8 @@ func (c *Connection) SendSystemError(id uint32, err error) {
 
 // connectionError handles a connection level error
 func (c *Connection) connectionError(err error) error {
-	c.log.Debugf("connectionError: %v", err)
-	c.tryClose()
-
+	c.log.Warnf("connectionError: %v", err)
+	c.Close()
 	return NewWrappedSystemError(ErrCodeNetwork, err)
 }
 

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -669,10 +669,12 @@ func (c *Connection) checkExchanges() {
 
 	if updated {
 		curState := c.readState()
-		// Close the network when the connection is closed.
+		// If the connection is closed, we can safely close the channel and network.
 		if curState == connectionClosed {
+			close(c.sendCh)
 			c.closeNetwork()
 		}
+
 		c.log.Debugf("checkExchanges updated connection state to %v", curState)
 		c.callOnCloseStateChange()
 	}

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -240,8 +240,8 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, on
 	c.inbound.onRemoved = c.checkExchanges
 	c.outbound.onRemoved = c.checkExchanges
 
-	go c.readFrames()
-	go c.writeFrames()
+	go c.readFrames(connID)
+	go c.writeFrames(connID)
 	return c
 }
 
@@ -578,7 +578,7 @@ func (c *Connection) readState() connectionState {
 // prevent overlapping reads on the socket.  Most handlers simply send the
 // incoming frame to a channel; the init handlers are a notable exception,
 // since we cannot process new frames until the initialization is complete.
-func (c *Connection) readFrames() {
+func (c *Connection) readFrames(_ uint32) {
 	for {
 		frame := c.framePool.Get()
 		if err := frame.ReadIn(c.conn); err != nil {
@@ -621,7 +621,7 @@ func (c *Connection) readFrames() {
 
 // writeFrames is the main loop that pulls frames from the send channel and
 // writes them to the connection.
-func (c *Connection) writeFrames() {
+func (c *Connection) writeFrames(_ uint32) {
 	for f := range c.sendCh {
 		c.log.Debugf("Writing frame %s", f.Header)
 

--- a/golang/goroutines_utils_test.go
+++ b/golang/goroutines_utils_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func getStacks() []byte {
@@ -18,12 +19,32 @@ func getStacks() []byte {
 	}
 }
 
-func VerifyNoBlockedGoroutines(t *testing.T) {
+type goroutineStack struct {
+	leakLine  string
+	fullStack []string
+	goState   string
+}
+
+func parseGoState(line string) string {
+	// parse state from 'goroutine 10 [syscall]:'
+	i1 := strings.Index(line, "[")
+	i2 := strings.Index(line, "]")
+	if i1 < 0 || i2 < 0 {
+		return ""
+	}
+	return line[i1+1 : i2]
+}
+
+func getMatchingGoStacks() []goroutineStack {
 	badMatches := []string{
+		"(*Channel).Serve",
 		"(*Connection).readFrames",
 		"(*Connection).writeFrames",
 	}
 
+	var matching []goroutineStack
+	var curStack []string
+	var goState string
 	stackReader := bufio.NewReader(bytes.NewReader(getStacks()))
 	for {
 		line, err := stackReader.ReadString('\n')
@@ -31,13 +52,63 @@ func VerifyNoBlockedGoroutines(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("Stack reader failed: %v", err)
+			panic("stack reader failed")
 		}
 
+		// If we see the goroutine header, start a new stack.
+		if strings.HasPrefix(line, "goroutine ") {
+			curStack = nil
+			goState = parseGoState(line)
+		}
+		curStack = append(curStack, line)
+
+		// If the line matches any of our badMatches, log it.
 		for _, m := range badMatches {
 			if strings.Contains(line, m) {
-				t.Errorf("Found leaked goroutine, stack line:\n  %s", line)
+				matching = append(matching, goroutineStack{
+					leakLine:  line,
+					fullStack: curStack,
+					goState:   goState,
+				})
 			}
 		}
 	}
+
+	return matching
+}
+
+// VerifyNoBlockedGoroutines verifies that there are no goroutines in the global space
+// that are stuck inside of readFrames or writeFrames.
+// Since some goroutines may still be performing work in the background, we retry the
+// checks if any goroutines are fine in a running state a finite number of times.
+func VerifyNoBlockedGoroutines(t *testing.T) {
+	retryStates := map[string]struct{}{
+		"runnable": struct{}{},
+		"running":  struct{}{},
+		"syscall":  struct{}{},
+	}
+	const maxAttempts = 10
+
+retry:
+	for i := 0; i < maxAttempts; i++ {
+		runtime.Gosched()
+		if i > maxAttempts/2 {
+			time.Sleep(time.Millisecond)
+		}
+
+		matching := getMatchingGoStacks()
+		for _, v := range matching {
+			if _, ok := retryStates[v.goState]; ok {
+				continue retry
+			}
+		}
+
+		for _, v := range matching {
+			t.Errorf("Found leaked goroutine in state %q, leakLine:\n  %s  Full stack:\n%s",
+				v.goState, v.leakLine, strings.Join(v.fullStack, ""))
+		}
+		return
+	}
+
+	t.Errorf("VerifyNoBlockedGoroutines failed: too many retries")
 }

--- a/golang/goroutines_utils_test.go
+++ b/golang/goroutines_utils_test.go
@@ -1,0 +1,43 @@
+package tchannel_test
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func getStacks() []byte {
+	for i := 4096; ; i *= 2 {
+		buf := make([]byte, i)
+		if n := runtime.Stack(buf, true /* all */); n < i {
+			return buf
+		}
+	}
+}
+
+func VerifyNoBlockedGoroutines(t *testing.T) {
+	badMatches := []string{
+		"(*Connection).readFrames",
+		"(*Connection).writeFrames",
+	}
+
+	stackReader := bufio.NewReader(bytes.NewReader(getStacks()))
+	for {
+		line, err := stackReader.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Errorf("Stack reader failed: %v", err)
+		}
+
+		for _, m := range badMatches {
+			if strings.Contains(line, m) {
+				t.Errorf("Found leaked goroutine, stack line:\n  %s", line)
+			}
+		}
+	}
+}

--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -82,6 +82,7 @@ func TestUnexpectedInitReq(t *testing.T) {
 		require.NoError(t, f.read(&errMsg))
 		assert.Equal(t, tt.expectedError.ID(), errMsg.ID(), "test %v got bad ID", tt.name)
 		assert.Equal(t, tt.expectedError.errCode, errMsg.errCode, "test %v got bad code", tt.name)
+		assert.NoError(t, conn.Close(), "closing connection failed")
 	}
 }
 

--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -73,13 +73,19 @@ func TestUnexpectedInitReq(t *testing.T) {
 		require.NoError(t, err)
 		conn.SetReadDeadline(time.Now().Add(time.Second))
 
-		require.NoError(t, writeMessage(conn, tt.initMsg))
+		if !assert.NoError(t, writeMessage(conn, tt.initMsg), "write to conn failed") {
+			continue
+		}
 
 		f, err := readFrame(conn)
-		require.NoError(t, err)
+		if !assert.NoError(t, err, "read frame failed") {
+			continue
+		}
 		assert.Equal(t, messageTypeError, f.Header.messageType)
 		var errMsg errorMessage
-		require.NoError(t, f.read(&errMsg))
+		if !assert.NoError(t, f.read(&errMsg), "parse frame to errorMessage") {
+			continue
+		}
 		assert.Equal(t, tt.expectedError.ID(), errMsg.ID(), "test %v got bad ID", tt.name)
 		assert.Equal(t, tt.expectedError.errCode, errMsg.errCode, "test %v got bad code", tt.name)
 		assert.NoError(t, conn.Close(), "closing connection failed")

--- a/golang/z_leak_test.go
+++ b/golang/z_leak_test.go
@@ -1,0 +1,31 @@
+package tchannel_test
+
+import "testing"
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// This file is named z_* so that it is the last test file compiled by Go, and so
+// is run after all the other tests.
+
+// TestNoGoroutinesLeaked verifies that no tests have leaked goroutines.
+func TestNoGoroutinesLeaked(t *testing.T) {
+	VerifyNoBlockedGoroutines(t)
+}


### PR DESCRIPTION
Add a test which checks all stacks for goroutines started by tchannel and makes sure there are none. The verification is run as the last test to make sure no previous tests have left any leaks.

Fixes the following leaks:
 - When a connection is closed on the remote side, the writeFrames goroutine did not end as it blocked on sendCh forever. Wire up Close to close the sendCh.
 - Fix race condition when a channel is closed and an outgoing call is made where a connection may not be closed even though the channel is closing.
 - On a protocol error, close the channel after the queued errorMessage is sent
 - Fix tests that created channels and did not close them before the end of the test

r: @mmihic 