### PR TITLE
go: Update tchannel tests to use WithVerifiedServer

### DIFF
--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -64,7 +64,7 @@ func TestCloseStress(t *testing.T) {
 	for i := 0; i < numHandlers; i++ {
 		wg.Add(1)
 		go func() {
-			assert.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+			WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 				ch.Register(raw.Wrap(handler), "test")
 
 				chState := &channelState{
@@ -83,7 +83,7 @@ func TestCloseStress(t *testing.T) {
 				// Lock until the connection is closed.
 				lock.Lock()
 				chState.closed = true
-			}))
+			})
 			lock.Unlock()
 		}()
 	}

--- a/golang/connection_test.go
+++ b/golang/connection_test.go
@@ -88,7 +88,7 @@ func (h *testHandler) OnError(ctx context.Context, err error) {
 }
 
 func TestRoundTrip(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		handler := newTestHandler(t)
 		ch.Register(raw.Wrap(handler), "echo")
 
@@ -112,11 +112,11 @@ func TestRoundTrip(t *testing.T) {
 		assert.Equal(t, JSON, handler.format)
 		assert.Equal(t, testServiceName, handler.caller)
 		assert.Equal(t, JSON, call.Response().Format(), "response Format should match request Format")
-	}))
+	})
 }
 
 func TestDefaultFormat(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		handler := newTestHandler(t)
 		ch.Register(raw.Wrap(handler), "echo")
 
@@ -130,7 +130,7 @@ func TestDefaultFormat(t *testing.T) {
 		require.Equal(t, testArg3, arg3)
 		require.Equal(t, Raw, handler.format)
 		assert.Equal(t, Raw, resp.Format(), "response Format should match request Format")
-	}))
+	})
 }
 
 func TestReuseConnection(t *testing.T) {
@@ -138,9 +138,9 @@ func TestReuseConnection(t *testing.T) {
 	defer cancel()
 
 	s1Opts := &testutils.ChannelOpts{ServiceName: "s1"}
-	require.Nil(t, testutils.WithServer(s1Opts, func(ch1 *Channel, hostPort1 string) {
+	WithVerifiedServer(t, s1Opts, func(ch1 *Channel, hostPort1 string) {
 		s2Opts := &testutils.ChannelOpts{ServiceName: "s2"}
-		require.Nil(t, testutils.WithServer(s2Opts, func(ch2 *Channel, hostPort2 string) {
+		WithVerifiedServer(t, s2Opts, func(ch2 *Channel, hostPort2 string) {
 			ch1.Register(raw.Wrap(newTestHandler(t)), "echo")
 			ch2.Register(raw.Wrap(newTestHandler(t)), "echo")
 
@@ -180,45 +180,45 @@ func TestReuseConnection(t *testing.T) {
 				}(call)
 			}
 			wg.Wait()
-		}))
-	}))
+		})
+	})
 }
 
 func TestPing(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ctx, cancel := NewContext(time.Second * 5)
 		defer cancel()
 
 		clientCh, err := testutils.NewClient(nil)
 		require.NoError(t, err)
 		require.NoError(t, clientCh.Ping(ctx, hostPort))
-	}))
+	})
 }
 
 func TestBadRequest(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ctx, cancel := NewContext(time.Second * 5)
 		defer cancel()
 
 		_, _, _, err := raw.Call(ctx, ch, hostPort, "Nowhere", "Noone", []byte("Headers"), []byte("Body"))
 		require.NotNil(t, err)
 		assert.Equal(t, ErrCodeBadRequest, GetSystemErrorCode(err))
-	}))
+	})
 }
 
 func TestNoTimeout(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ch.Register(raw.Wrap(newTestHandler(t)), "Echo")
 
 		ctx := context.Background()
 		_, _, _, err := raw.Call(ctx, ch, hostPort, "svc", "Echo", []byte("Headers"), []byte("Body"))
 		require.NotNil(t, err)
 		assert.Equal(t, ErrTimeoutRequired, err)
-	}))
+	})
 }
 
 func TestServerBusy(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ch.Register(raw.Wrap(newTestHandler(t)), "busy")
 
 		ctx, cancel := NewContext(time.Second * 5)
@@ -227,7 +227,7 @@ func TestServerBusy(t *testing.T) {
 		_, _, _, err := raw.Call(ctx, ch, hostPort, testServiceName, "busy", []byte("Arg2"), []byte("Arg3"))
 		require.NotNil(t, err)
 		assert.Equal(t, ErrCodeBusy, GetSystemErrorCode(err), "err: %v", err)
-	}))
+	})
 }
 
 func TestTimeout(t *testing.T) {
@@ -256,7 +256,7 @@ func TestLargeOperation(t *testing.T) {
 }
 
 func TestFragmentation(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		ch.Register(raw.Wrap(newTestHandler(t)), "echo")
 
 		arg2 := make([]byte, MaxFramePayloadSize*2)
@@ -276,5 +276,5 @@ func TestFragmentation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, arg2, respArg2)
 		assert.Equal(t, arg3, respArg3)
-	}))
+	})
 }

--- a/golang/frame_pool_test.go
+++ b/golang/frame_pool_test.go
@@ -66,7 +66,7 @@ func TestFramesReleased(t *testing.T) {
 
 	var connections []*Connection
 	pool := NewRecordingFramePool()
-	require.NoError(t, testutils.WithServer(&testutils.ChannelOpts{
+	WithVerifiedServer(t, &testutils.ChannelOpts{
 		ServiceName: "swap-server",
 		DefaultConnectionOptions: ConnectionOptions{
 			FramePool: pool,
@@ -118,7 +118,7 @@ func TestFramesReleased(t *testing.T) {
 
 		connections = append(connections, GetConnections(serverCh)...)
 		connections = append(connections, GetConnections(clientCh)...)
-	}))
+	})
 
 	// Wait a few milliseconds for the closing of channels to take effect.
 	time.Sleep(10 * time.Millisecond)

--- a/golang/largereq_test.go
+++ b/golang/largereq_test.go
@@ -44,7 +44,7 @@ func TestLargeRequest(t *testing.T) {
 		maxRequestSize = 1 * GB
 	)
 
-	require.NoError(t, testutils.WithServer(nil, func(serverCh *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(serverCh *Channel, hostPort string) {
 		serverCh.Register(raw.Wrap(newTestHandler(t)), "echo")
 
 		for reqSize := 2; reqSize <= maxRequestSize; reqSize *= 2 {
@@ -67,5 +67,5 @@ func TestLargeRequest(t *testing.T) {
 			}
 			cancel()
 		}
-	}))
+	})
 }

--- a/golang/stats_test.go
+++ b/golang/stats_test.go
@@ -72,7 +72,7 @@ func TestStatsCalls(t *testing.T) {
 	serverOpts := &testutils.ChannelOpts{
 		StatsReporter: serverStats,
 	}
-	require.NoError(t, testutils.WithServer(serverOpts, func(serverCh *Channel, hostPort string) {
+	WithVerifiedServer(t, serverOpts, func(serverCh *Channel, hostPort string) {
 		handler := raw.Wrap(newTestHandler(t))
 		serverCh.Register(handler, "echo")
 		serverCh.Register(handler, "app-error")
@@ -111,7 +111,7 @@ func TestStatsCalls(t *testing.T) {
 		serverStats.Expected.IncCounter("inbound.calls.recvd", inboundTags, 1)
 		serverStats.Expected.IncCounter("inbound.calls.app-errors", inboundTags, 1)
 		serverStats.Expected.RecordTimer("inbound.calls.latency", inboundTags, 70*time.Millisecond)
-	}))
+	})
 
 	clientStats.Validate(t)
 	serverStats.Validate(t)

--- a/golang/tracing_test.go
+++ b/golang/tracing_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel/golang/json"
-	"github.com/uber/tchannel/golang/testutils"
 	"golang.org/x/net/context"
 )
 
@@ -76,7 +75,7 @@ func (h *traceHandler) onError(ctx context.Context, err error) {
 }
 
 func TestTracingPropagates(t *testing.T) {
-	require.Nil(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		handler := &traceHandler{t: t, ch: ch}
 		json.Register(ch, json.Handlers{
 			"call": handler.call,
@@ -106,5 +105,5 @@ func TestTracingPropagates(t *testing.T) {
 		assert.Equal(t, clientSpan.TraceID(), nestedResponse.TraceID)
 		assert.Equal(t, response.SpanID, nestedResponse.ParentID)
 		assert.NotEqual(t, response.SpanID, nestedResponse.SpanID)
-	}))
+	})
 }


### PR DESCRIPTION
WithVerifiedServer will verify that there are no leaks so all tests
inside of the tchannel package should use it.