### PR TITLE
go: Allow Hyperbahn node list to be specified as a file

### DIFF
--- a/golang/examples/hyperbahn/echo-server/main.go
+++ b/golang/examples/hyperbahn/echo-server/main.go
@@ -59,10 +59,13 @@ func main() {
 
 	// advertise service with Hyperbahn.
 	config := hyperbahn.Configuration{InitialNodes: os.Args[1:]}
-	client := hyperbahn.NewClient(tchan, config, &hyperbahn.ClientOptions{
+	client, err := hyperbahn.NewClient(tchan, config, &hyperbahn.ClientOptions{
 		Handler: eventHandler{},
 		Timeout: time.Second,
 	})
+	if err != nil {
+		log.Fatalf("hyperbahn.NewClient failed: %v", err)
+	}
 	if err := client.Advertise(); err != nil {
 		log.Fatalf("Advertise failed: %v", err)
 	}

--- a/golang/examples/keyvalue/server/server.go
+++ b/golang/examples/keyvalue/server/server.go
@@ -56,7 +56,10 @@ func main() {
 	if len(config.InitialNodes) == 0 {
 		log.Fatalf("No Autobahn nodes to advertise with")
 	}
-	client := hyperbahn.NewClient(ch, config, nil)
+	client, err := hyperbahn.NewClient(ch, config, nil)
+	if err != nil {
+		log.Fatalf("hyperbahn.NewClient failed: %v", err)
+	}
 	if err := client.Advertise(); err != nil {
 		log.Fatalf("Hyperbahn advertise failed: %v", err)
 	}

--- a/golang/hyperbahn/advertise_test.go
+++ b/golang/hyperbahn/advertise_test.go
@@ -61,8 +61,9 @@ func TestAdvertiseFailed(t *testing.T) {
 		require.NoError(t, err)
 		defer clientCh.Close()
 
-		client := NewClient(clientCh, configFor(hostPort), nil)
-		require.Error(t, client.Advertise())
+		client, err := NewClient(clientCh, configFor(hostPort), nil)
+		require.NoError(t, err, "NewClient")
+		assert.Error(t, client.Advertise(), "Advertise without handler should fail")
 	})
 }
 
@@ -122,10 +123,11 @@ func runRetryTest(t *testing.T, f func(r *retryTest)) {
 		require.NoError(t, err)
 		defer clientCh.Close()
 
-		r.client = NewClient(clientCh, configFor(hostPort), &ClientOptions{
+		r.client, err = NewClient(clientCh, configFor(hostPort), &ClientOptions{
 			Handler:      r,
 			FailStrategy: FailStrategyIgnore,
 		})
+		require.NoError(t, err, "NewClient")
 		f(r)
 		r.mock.AssertExpectations(t)
 	})

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -23,6 +23,7 @@ package hyperbahn
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -100,6 +101,12 @@ func parseConfig(config *Configuration) error {
 
 	if len(config.InitialNodes) == 0 {
 		return fmt.Errorf("hyperbahn Client requires at least one initial node")
+	}
+
+	for _, node := range config.InitialNodes {
+		if _, _, err := net.SplitHostPort(node); err != nil {
+			return fmt.Errorf("hyperbahn Client got invalid node %v: %v", node, err)
+		}
 	}
 
 	return nil

--- a/golang/hyperbahn/client.go
+++ b/golang/hyperbahn/client.go
@@ -21,6 +21,9 @@ package hyperbahn
 // THE SOFTWARE.
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/uber/tchannel/golang"
@@ -57,7 +60,7 @@ type ClientOptions struct {
 // NewClient creates a new Hyperbahn client using the given channel.
 // config is the environment-specific configuration for Hyperbahn such as the list of initial nodes.
 // opts are optional, and are used to customize the client.
-func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) *Client {
+func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) (*Client, error) {
 	client := &Client{tchan: ch}
 	if opts != nil {
 		client.opts = *opts
@@ -69,12 +72,37 @@ func NewClient(ch *tchannel.Channel, config Configuration, opts *ClientOptions) 
 		client.opts.Handler = nullHandler{}
 	}
 
+	if err := parseConfig(&config); err != nil {
+		return nil, err
+	}
+
 	// Add the given initial nodes as peers.
 	for _, node := range config.InitialNodes {
 		addPeer(ch, node)
 	}
 
-	return client
+	return client, nil
+}
+
+// parseConfig parses the configuration options (e.g. InitialNodesFile)
+func parseConfig(config *Configuration) error {
+	if config.InitialNodesFile != "" {
+		f, err := os.Open(config.InitialNodesFile)
+		if err != nil {
+			return err
+		}
+
+		decoder := json.NewDecoder(f)
+		if err := decoder.Decode(&config.InitialNodes); err != nil {
+			return err
+		}
+	}
+
+	if len(config.InitialNodes) == 0 {
+		return fmt.Errorf("hyperbahn Client requires at least one initial node")
+	}
+
+	return nil
 }
 
 // addPeer adds a peer to the Hyperbahn subchannel.

--- a/golang/hyperbahn/client_test.go
+++ b/golang/hyperbahn/client_test.go
@@ -1,0 +1,111 @@
+package hyperbahn
+
+import (
+	"io/ioutil"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang"
+	"github.com/uber/tchannel/golang/testutils"
+)
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+func getPeers(ch *tchannel.Channel) []string {
+	var peers []string
+	for k := range ch.Peers().Copy() {
+		peers = append(peers, k)
+	}
+	sort.Strings(peers)
+	return peers
+}
+
+func TestParseConfiguration(t *testing.T) {
+	expectedPeers1 := []string{"1.1.1.1:1", "2.2.2.2:2"}
+	expectedPeers2 := []string{"3.3.3.3:3", "4.4.4.4:4"}
+	peersFile2 := `["3.3.3.3:3", "4.4.4.4:4"]`
+
+	tests := []struct {
+		name      string
+		peersArg  []string
+		peersFile string
+		wantPeers []string
+		wantErr   bool
+	}{
+		{
+			name:    "no peers",
+			wantErr: true,
+		},
+		{
+			name:      "no peer list",
+			peersArg:  expectedPeers1,
+			wantPeers: expectedPeers1,
+		},
+		{
+			name:      "peer file",
+			peersFile: peersFile2,
+			wantPeers: expectedPeers2,
+		},
+		{
+			name:      "peer file overrides args",
+			peersArg:  expectedPeers1,
+			peersFile: peersFile2,
+			wantPeers: expectedPeers2,
+		},
+	}
+
+	for _, tt := range tests {
+		peerFile := ""
+		if tt.peersFile != "" {
+			f, err := ioutil.TempFile("", "hosts")
+			if !assert.NoError(t, err, "%v: TempFile failed", tt.name) {
+				continue
+			}
+			defer os.Remove(f.Name())
+
+			_, err = f.WriteString(tt.peersFile)
+			assert.NoError(t, err, "%v: write peer file failed", tt.name)
+
+			assert.NoError(t, err, "%v: write peer file failed", tt.name)
+			assert.NoError(t, f.Close(), "%v: close peer file failed", tt.name)
+			peerFile = f.Name()
+		}
+
+		config := Configuration{InitialNodes: tt.peersArg, InitialNodesFile: peerFile}
+		ch, err := testutils.NewClient(nil)
+		require.NoError(t, err, "%v: testutils.NewClient failed", tt.name)
+		defer ch.Close()
+
+		_, err = NewClient(ch, config, nil)
+		if tt.wantErr {
+			assert.Error(t, err, "%v: NewClient expected to fail")
+			continue
+		}
+		if !assert.NoError(t, err, "%v: hyperbahn.NewClient failed", tt.name) {
+			continue
+		}
+
+		assert.Equal(t, tt.wantPeers, getPeers(ch), "%v: got unexpected peers", tt.name)
+	}
+}

--- a/golang/hyperbahn/client_test.go
+++ b/golang/hyperbahn/client_test.go
@@ -42,8 +42,10 @@ func getPeers(ch *tchannel.Channel) []string {
 }
 
 func TestParseConfiguration(t *testing.T) {
-	expectedPeers1 := []string{"1.1.1.1:1", "2.2.2.2:2"}
-	expectedPeers2 := []string{"3.3.3.3:3", "4.4.4.4:4"}
+	peers1 := []string{"1.1.1.1:1", "2.2.2.2:2"}
+	peers2 := []string{"3.3.3.3:3", "4.4.4.4:4"}
+	invalidPeer1 := []string{"2:2:2:2"}
+	invalidPeer2 := []string{"2.2.2.2"}
 	peersFile2 := `["3.3.3.3:3", "4.4.4.4:4"]`
 
 	tests := []struct {
@@ -59,19 +61,29 @@ func TestParseConfiguration(t *testing.T) {
 		},
 		{
 			name:      "no peer list",
-			peersArg:  expectedPeers1,
-			wantPeers: expectedPeers1,
+			peersArg:  peers1,
+			wantPeers: peers1,
+		},
+		{
+			name:     "invalid peers invalid format",
+			peersArg: invalidPeer1,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid peers no port",
+			peersArg: invalidPeer2,
+			wantErr:  true,
 		},
 		{
 			name:      "peer file",
 			peersFile: peersFile2,
-			wantPeers: expectedPeers2,
+			wantPeers: peers2,
 		},
 		{
 			name:      "peer file overrides args",
-			peersArg:  expectedPeers1,
+			peersArg:  peers1,
 			peersFile: peersFile2,
-			wantPeers: expectedPeers2,
+			wantPeers: peers2,
 		},
 	}
 

--- a/golang/hyperbahn/configuration.go
+++ b/golang/hyperbahn/configuration.go
@@ -24,4 +24,7 @@ package hyperbahn
 type Configuration struct {
 	// InitialNodes is the list of known Hyperbahn nodes to add initially.
 	InitialNodes []string
+	// InitialNodesFile is a JSON file that contains the list of known Hyperbahn nodes.
+	// If this option is set, it overrides InitialNodes.
+	InitialNodesFile string
 }

--- a/golang/peer.go
+++ b/golang/peer.go
@@ -74,6 +74,18 @@ func (l *PeerList) GetOrAdd(hostPort string) *Peer {
 	return l.Add(hostPort)
 }
 
+// Copy returns a copy of the peer list. This method should only be used for testing.
+func (l *PeerList) Copy() map[string]*Peer {
+	l.mut.RLock()
+	defer l.mut.RUnlock()
+
+	listCopy := make(map[string]*Peer)
+	for k, v := range l.peersByHostPort {
+		listCopy[k] = v
+	}
+	return listCopy
+}
+
 // Close closes connections for all peers.
 func (l *PeerList) Close() {
 	l.mut.RLock()


### PR DESCRIPTION
Note: This is a breaking API change as hyperbahn.NewClient now returns an error where it previously didn't.

Allow specifying InitialNodes to be specified as a file, which is parsed on startup. In the future, we may want to watch the file for updates.

Validate that each node in InitialNodes is a valid host:port pair.

r @mmihic 