### PR TITLE
Update as-http monitorable

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -235,7 +235,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
     }
 };
 
-TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options, inreq, outres) {
+TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options, inreq, outres, callback) {
     // TODO: should use lb_pool
     var self = this;
     self.logger = self.logger || tchannel.logger;
@@ -260,6 +260,7 @@ TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options,
         if (!sent) {
             sent = true;
             outres.sendResponse(inres);
+            callback(null);
         }
     }
 
@@ -270,6 +271,7 @@ TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options,
                 error: err
             });
             outres.sendError(err);
+            callback(err);
         }
     }
 };

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -195,7 +195,6 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
         return null;
     }
 
-    self.logger.debug('Waiting for peer to be identified');
     peer.waitForIdentified(onIdentified);
     function onIdentified(err) {
         if (err) {
@@ -210,7 +209,6 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
 
         options.host = peer.hostPort;
         var treq = tchannel.request(options);
-        self.logger.debug('Forwarding to tchannel started');
         self.sendRequest(treq, hreq, forwarded);
     }
 
@@ -232,7 +230,6 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
             }
             hres.writeHead(head.statusCode, head.message, headers);
             body.pipe(hres);
-            self.logger.debug('Forwarding to tchannel succeeded');
         }
         callback(err);
     }
@@ -254,7 +251,6 @@ TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options,
     }
 
     var sent = false;
-    self.logger.debug('Forwarding to HTTP started');
     var outreq = http.request(options, onResponse);
     outreq.on('error', onError);
     // TODO: more http state machine integration
@@ -263,7 +259,6 @@ TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options,
     function onResponse(inres) {
         if (!sent) {
             sent = true;
-            self.logger.debug('Forwarding to HTTP succeeded');
             outres.sendResponse(inres);
         }
     }
@@ -355,14 +350,12 @@ AsHTTPHandler.prototype.handleRequest = function handleRequest(req, buildRespons
             sendResponse: sendResponse
         };
 
-        self.logger.debug('Handling request started');
         self.handler.handleRequest(hreq, hres);
     }
 
     function sendResponse(hres) {
         if (!sent) {
             sent = true;
-            self.logger.debug('Handling request succeeded');
             self.asHTTP.sendResponse(buildResponse, hres, sendError);
         }
     }

--- a/node/examples/http_ingress.js
+++ b/node/examples/http_ingress.js
@@ -86,5 +86,5 @@ function onRequest(inreq, outres) {
     asHTTP.forwardToHTTP(svcChan, {
         host: destHost,
         port: destPort,
-    }, inreq, outres);
+    }, inreq, outres, function() { return true; });
 }

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -217,7 +217,7 @@ function allocHTTPBridge(opts) {
         cluster.asHTTP.forwardToHTTP(cluster.ingressChan, {
             host: addr.address,
             port: addr.port
-        }, treq, tres);
+        }, treq, tres, onIngressComplete);
     }
 
     function onEgressRequest(hreq, hres) {
@@ -227,6 +227,10 @@ function allocHTTPBridge(opts) {
             hres,
             {},
             onEgressComplete);
+    }
+
+    function onIngressComplete(err) {
+        opts.assert.error(err);
     }
 
     function onEgressComplete(err) {


### PR DESCRIPTION
Add callback to forwardToHTTP so that xlate can log and measure the latency of ingress http traffic
Remove all debug level log entries based on the logging convention
@Raynos @ShanniLi @jcorbin 
cc: @davewhat @vipulaneja 