### PR TITLE
Improve req/res error handling and visibility

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -91,33 +91,14 @@ function connBaseRequest(options) {
 
 TChannelConnectionBase.prototype.handleCallRequest = function handleCallRequest(req) {
     var self = this;
-    
-    self.ops.addInReq(req);
 
     req.remoteAddr = self.remoteName;
-    req.errorEvent.on(onReqError);
+    self.ops.addInReq(req);
 
     process.nextTick(runHandler);
 
-    function onReqError(err) {
-        self.onReqError(req, err);
-    }
-
     function runHandler() {
         self.runHandler(req);
-    }
-};
-
-TChannelConnectionBase.prototype.onReqError = function onReqError(req, err) {
-    var self = this;
-    if (!req.res) self.buildResponse(req, {});
-    if (err.type === 'tchannel.timeout' ||
-        err.type === 'tchannel.request.timeout'
-    ) {
-        req.res.sendError('Timeout', err.message);
-    } else {
-        var errName = err.name || err.constructor.name;
-        req.res.sendError('UnexpectedError', errName + ': ' + err.message);
     }
 };
 

--- a/node/test/regression-conn-double-buildResponse.js
+++ b/node/test/regression-conn-double-buildResponse.js
@@ -77,7 +77,7 @@ allocCluster.test('conn double buildResponse: build send build sendError', {
             msg: 'outgoing response has an error',
             errorType: 'tchannel.response-already-done',
             errorMessage: 'cannot send send error frame: ' +
-                          'UnexpectedError: TchannelResponseAlreadyStartedError: response already started (state 2)' +
+                          'UnexpectedError: response already started (state 2)' +
                           ', response already done in state: 2'
         }, 'expected first error log');
 

--- a/node/test/streaming-resp-err.js
+++ b/node/test/streaming-resp-err.js
@@ -85,8 +85,8 @@ allocCluster.test('end response with error frame', {
     }
 
     function onError(err) {
-        assert.ifError(err);
-        assert.ok(false, 'expected no req error event');
+        assert.equal(err && err.type, 'tchannel.unexpected', 'expected an UnexpectedError');
+        assert.equal(err && err.message, 'oops', 'expected "oops"');
     }
 
     function streamHandler(inreq, buildRes) {

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -906,7 +906,9 @@ TChannelV2Handler.prototype.onReqError = function onReqError(err, req) {
     var self = this;
 
     var codeName = errors.classify(err);
-    if (codeName) {
+    if (codeName &&
+        codeName !== 'ProtocolError'
+    ) {
         // TODO: move req to error state?
         if (!req.res) {
             req.res = self.buildOutResponse(req);

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -193,16 +193,7 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
 
     var err = self.checkCallReqFrame(reqFrame);
     if (err) {
-        req.res = self.buildOutResponse(req);
-        var codeName = errors.classify(err) || 'ProtocolError';
-        // TODO: would UnexpectedError be a better default?
-        // - on the one hand, if the error isn't classified, we may be safer
-        //   "failing closed" and terminating the connection
-        // - on the other hand, that may be too heavy handed for a forwarding
-        //   entity, since it may cause undue connection thrashing in the
-        //   presence of bad actors
-        // all the more reason to kill every "TODO typed error"
-        req.res.sendError(codeName, err.message);
+        req.errorEvent.emit(req, err);
         return;
     }
 
@@ -339,7 +330,7 @@ TChannelV2Handler.prototype.handleCallResponse = function handleCallResponse(res
 
     var err = self.checkCallResFrame(resFrame);
     if (err) {
-        self.errorEvent.emit(self, err);
+        res.errorEvent.emit(res, err);
         return;
     }
 
@@ -536,7 +527,7 @@ TChannelV2Handler.prototype._handleCallFrame = function _handleCallFrame(r, fram
 
     if (err) {
         // TODO wrap context
-        self.errorEvent.emit(self, err);
+        r.errorEvent.emit(r, err);
         return false;
     }
 


### PR DESCRIPTION
- add req error handling to send error frames out of handler
- add in-res error handling to re-emit errors on the corresponding out-req
- emit classified non-protocol errors from request handling paths on the corresponding request

TODO:
- [x] maybe kill off TChannelConnectionBase#onReqError
- [x] pass tests

r @Raynos @kriskowal 