### PR TITLE
Update protocol documentation for errors

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -338,6 +338,7 @@ If the ttl expires an error response should be generated.
 #### tracing:25
 
 Tracing payload, see tracing section.
+
 #### service~1
 
 UTF-8 string identifying the destination service to which this request should be
@@ -526,6 +527,11 @@ specific exception data in the args.
 
 Message id of the original request that triggered this error, or `0xFFFFFFFF` if
 no message id is available.
+
+#### tracing: 25
+
+Tracing payload, see tracing section. If tracing information is not available
+(e.g. on a bad init message), then an empty span (all 0's) should be used.
 
 #### message~2
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -508,6 +508,9 @@ unable to invoke the requested RPC for some reason. Application errors do not
 go here. Application errors are sent with "call res" messages and application
 specific exception data in the args.
 
+The `id` in the frame header should be the message id of the original request
+that triggered this error, or `0xFFFFFFFF` if no message id is available.
+
 #### code:1
 
 | code   | name                 | description
@@ -522,11 +525,6 @@ specific exception data in the args.
 | `0x07` | network error        | A network error (e.g. socket error) occurred.
 | `0x08` | unhealthy            | A relay on the network declined to forward the request to an unhealthy node, do not retry.
 | `0xFF` | fatal protocol error | Connection will close after this frame. message ID of this frame should be `0xFFFFFFFF`.
-
-#### id:4
-
-Message id of the original request that triggered this error, or `0xFFFFFFFF` if
-no message id is available.
 
 #### tracing: 25
 


### PR DESCRIPTION
Error messages contain the id, not the trace ID as the summary shows.

r @Raynos 