### PR TITLE
go: errorFrame contains tracing span, and uses ID from the header 

### DIFF
--- a/golang/init_test.go
+++ b/golang/init_test.go
@@ -36,27 +36,27 @@ func TestUnexpectedInitReq(t *testing.T) {
 				InitParamProcessName: "test",
 			}}},
 			expectedError: errorMessage{
-				id:      invalidMessageID,
+				id:      1,
 				errCode: ErrCodeProtocol,
 			},
 		},
 		{
 			name: "missing InitParamHostPort",
-			initMsg: &initReq{initMessage{id: 1, Version: CurrentProtocolVersion, initParams: initParams{
+			initMsg: &initReq{initMessage{id: 2, Version: CurrentProtocolVersion, initParams: initParams{
 				InitParamProcessName: "test",
 			}}},
 			expectedError: errorMessage{
-				id:      invalidMessageID,
+				id:      2,
 				errCode: ErrCodeProtocol,
 			},
 		},
 		{
 			name: "missing InitParamProcessName",
-			initMsg: &initReq{initMessage{id: 1, Version: CurrentProtocolVersion, initParams: initParams{
+			initMsg: &initReq{initMessage{id: 3, Version: CurrentProtocolVersion, initParams: initParams{
 				InitParamHostPort: "0.0.0.0:0",
 			}}},
 			expectedError: errorMessage{
-				id:      invalidMessageID,
+				id:      3,
 				errCode: ErrCodeProtocol,
 			},
 		},
@@ -86,7 +86,7 @@ func TestUnexpectedInitReq(t *testing.T) {
 		if !assert.NoError(t, f.read(&errMsg), "parse frame to errorMessage") {
 			continue
 		}
-		assert.Equal(t, tt.expectedError.ID(), errMsg.ID(), "test %v got bad ID", tt.name)
+		assert.Equal(t, tt.expectedError.ID(), f.Header.ID, "test %v got bad ID", tt.name)
 		assert.Equal(t, tt.expectedError.errCode, errMsg.errCode, "test %v got bad code", tt.name)
 		assert.NoError(t, conn.Close(), "closing connection failed")
 	}

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -264,6 +264,7 @@ func (c *callResContinue) write(w *typed.WriteBuffer) error { return nil }
 type errorMessage struct {
 	id      uint32
 	errCode SystemErrCode
+	tracing Span
 	message string
 }
 
@@ -271,14 +272,14 @@ func (m *errorMessage) ID() uint32               { return m.id }
 func (m *errorMessage) messageType() messageType { return messageTypeError }
 func (m *errorMessage) read(r *typed.ReadBuffer) error {
 	m.errCode = SystemErrCode(r.ReadSingleByte())
-	m.id = r.ReadUint32()
+	m.tracing.read(r)
 	m.message = r.ReadLen16String()
 	return r.Err()
 }
 
 func (m *errorMessage) write(w *typed.WriteBuffer) error {
 	w.WriteSingleByte(byte(m.errCode))
-	w.WriteUint32(m.id)
+	m.tracing.write(w)
 	w.WriteLen16String(m.message)
 	return w.Err()
 }

--- a/golang/mex.go
+++ b/golang/mex.go
@@ -88,7 +88,9 @@ func (mex *messageExchange) recvPeerFrameOfType(msgType messageType) (*Frame, er
 		return frame, nil
 
 	case messageTypeError:
-		var errMsg errorMessage
+		errMsg := errorMessage{
+			id: frame.Header.ID,
+		}
 		var rbuf typed.ReadBuffer
 		rbuf.Wrap(frame.SizedPayload())
 		if err := errMsg.read(&rbuf); err != nil {

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -248,17 +248,19 @@ func (response *OutboundCallResponse) Arg3Reader() (io.ReadCloser, error) {
 // channel and converted into a SystemError returned from the next reader or
 // access call.
 func (c *Connection) handleError(frame *Frame) {
-	var errorMessage errorMessage
+	errMsg := errorMessage{
+		id: frame.Header.ID,
+	}
 	rbuf := typed.NewReadBuffer(frame.SizedPayload())
-	if err := errorMessage.read(rbuf); err != nil {
+	if err := errMsg.read(rbuf); err != nil {
 		c.log.Warnf("Unable to read Error frame from %s: %v", c.remotePeerInfo, err)
 		c.connectionError(err)
 		return
 	}
 
-	if errorMessage.errCode == ErrCodeProtocol {
-		c.log.Warnf("Peer %s reported protocol error: %s", c.remotePeerInfo, errorMessage.message)
-		c.connectionError(errorMessage.AsSystemError())
+	if errMsg.errCode == ErrCodeProtocol {
+		c.log.Warnf("Peer %s reported protocol error: %s", c.remotePeerInfo, errMsg.message)
+		c.connectionError(errMsg.AsSystemError())
 		return
 	}
 


### PR DESCRIPTION
Related: #1147 for information about how tracing information should be filled.