### PR TITLE
Improve logging around stale tombstone operations

### DIFF
--- a/node/monitor.js
+++ b/node/monitor.js
@@ -32,6 +32,7 @@ function ChanConnMonitor(channel, options) {
     self.channel = channel;
     self.interval = options.interval;
     self.byBucket = options.byBucket;
+    self.byTTL = options.byTTL;
     self.timers = channel.timers;
     self.timer = null;
     self.running = false;
@@ -170,17 +171,17 @@ OpKindMonitor.prototype.summary = function summary() {
         self.inCounts.length = 0;
     }
 
-    // if (self.outCounts.length && self.byBucket) {
-    //     self.log('= %s OUT COUNTS BY BUCKET: %j',
-    //         self.options.desc,
-    //         reduceByBucket(self.outCounts, self.byBucket));
-    // }
+    if (self.outCounts.length && self.byBucket) {
+        self.log('= %s OUT COUNTS BY BUCKET: %j',
+            self.options.desc,
+            reduceByBucket(self.outCounts, self.byBucket));
+    }
 
-    // if (self.outCounts.length) {
-    //     self.log('= %s OUT COUNTS BY TTL: %j',
-    //         self.options.desc,
-    //         reduceByTTL(self.outCounts));
-    // }
+    if (self.outCounts.length && self.byTTL) {
+        self.log('= %s OUT COUNTS BY TTL: %j',
+            self.options.desc,
+            reduceByTTL(self.outCounts));
+    }
 
     if (self.outCounts.length) {
         self.log('= %s OUT COUNTS: %j',

--- a/node/monitor.js
+++ b/node/monitor.js
@@ -170,6 +170,18 @@ OpKindMonitor.prototype.summary = function summary() {
         self.inCounts.length = 0;
     }
 
+    // if (self.outCounts.length && self.byBucket) {
+    //     self.log('= %s OUT COUNTS BY BUCKET: %j',
+    //         self.options.desc,
+    //         reduceByBucket(self.outCounts, self.byBucket));
+    // }
+
+    // if (self.outCounts.length) {
+    //     self.log('= %s OUT COUNTS BY TTL: %j',
+    //         self.options.desc,
+    //         reduceByTTL(self.outCounts));
+    // }
+
     if (self.outCounts.length) {
         self.log('= %s OUT COUNTS: %j',
                     self.options.desc,
@@ -177,6 +189,67 @@ OpKindMonitor.prototype.summary = function summary() {
         self.outCounts.length = 0;
     }
 };
+
+function reduceByBucket(list) {
+    var info = {};
+
+    for (var i = 0; i < list.length; i++) {
+        var constrs = list[i];
+
+        var keys = Object.keys(constrs);
+        for (var j = 0; j < keys.length; j++) {
+            var name = keys[j];
+            var opCount = constrs[keys[j]];
+
+            if (!info[name]) {
+                info[name] = {};
+            }
+
+            var bucketKeys = Object.keys(opCount.buckets);
+            for (var k = 0; k < bucketKeys.length; k++) {
+                var bucketKey = bucketKeys[k];
+                if (!info[name][bucketKey]) {
+                    info[name][bucketKey] = 0;
+                }
+
+                info[name][bucketKey] += opCount.buckets[bucketKey].length;
+            }
+        }
+    }
+
+    return info;
+}
+
+function reduceByTTL(list) {
+    var info = {};
+
+    for (var i = 0; i < list.length; i++) {
+        var constrs = list[i];
+
+        var keys = Object.keys(constrs);
+        for (var j = 0; j < keys.length; j++) {
+            var name = keys[j];
+            var opCount = constrs[keys[j]];
+
+            if (!info[name]) {
+                info[name] = {};
+            }
+
+            var timeoutKeys = Object.keys(opCount.timeouts);
+            for (var k = 0; k < timeoutKeys.length; k++) {
+                var timeoutKey = timeoutKeys[k];
+                if (!info[name][timeoutKey]) {
+                    info[name][timeoutKey] = 0;
+                }
+
+                info[name][timeoutKey] += opCount.timeouts[timeoutKey];
+            }
+        }
+    }
+
+    return info;
+}
+
 
 function sumCounts(a, b) {
     Object.keys(b).forEach(function eachB(key) {

--- a/node/operations.js
+++ b/node/operations.js
@@ -51,6 +51,7 @@ function Operations(opts) {
 function OperationTombstone(operations, id, time, timeout) {
     var self = this;
 
+    self.type = 'tchannel.operation.tombstone';
     self.isTombstone = true;
     self.logger = operations.logger;
     self.operations = operations;

--- a/node/operations.js
+++ b/node/operations.js
@@ -59,6 +59,7 @@ function OperationTombstone(operations, id, time, timeout) {
     self.time = time;
     self.timeout = timeout;
     self.timeHeapHandle = null;
+    self.destroyed = false;
 }
 
 OperationTombstone.prototype.extendLogInfo = function extendLogInfo(info) {
@@ -86,8 +87,24 @@ OperationTombstone.prototype.extendLogInfo = function extendLogInfo(info) {
     return info;
 };
 
+OperationTombstone.prototype.destroy = function destroy(now) {
+    var self = this;
+
+    self.destroyed = true;
+
+    self.onTimeout(now);
+};
+
 OperationTombstone.prototype.onTimeout = function onTimeout(now) {
     var self = this;
+
+    if (!self.destroyed && now < self.timeout + self.time) {
+        self.logger.error('tombstone timed out too early', self.extendLogInfo({
+            now: now,
+            expireTime: self.timeout + self.time,
+            delta: (self.timeout + self.time) - now
+        }));
+    }
 
     if (self.operations &&
         self.operations.requests.out[self.id] === self) {
@@ -271,7 +288,7 @@ Operations.prototype.clear = function clear() {
         if (tombstone.timeHeapHandle) {
             tombstone.timeHeapHandle.cancel();
         }
-        tombstone.onTimeout(now);
+        tombstone.destroy(now);
     }
 };
 

--- a/node/time_heap.js
+++ b/node/time_heap.js
@@ -77,6 +77,7 @@ function TimeHeap(options) {
     self.lastTime = self.timers.now();
     self.timer = null;
     self.end = 0;
+    self.lastRun = 0;
 }
 
 TimeHeap.prototype.clear = function clear() {
@@ -139,6 +140,7 @@ TimeHeap.prototype.onTimeout = function onTimeout(now) {
     var self = this;
 
     self.timer = null;
+    self.lastRun = now;
     self.drainExpired(now);
     if (self.end) {
         self.setNextTimer(now);


### PR DESCRIPTION
Trying to track down stale tombstones. Turns out that
the relay was a dead end.

The relay has more tombstones then the clients because
the clients re-cycle connections and thus clear tombstones.

If you we do 200k requests instead of 20k requests per test
batch you find that relay & clients have same number of
tombstones.

I also fixed a race condition between heap & stale tombstone
reaper that would prematurely warn about stale tombstones.

r: @jcorbin @shannili