### PR TITLE
[tchannel-go] - Allow subchannel handler registrations

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -96,15 +96,15 @@ type Channel struct {
 	connectionOptions ConnectionOptions
 	handlers          *handlerMap
 	peers             *PeerList
+	subChannels       *subChannelMap
 
 	// mutable contains all the members of Channel which are mutable.
 	mutable struct {
-		mut         sync.RWMutex // protects members of the mutable struct.
-		state       ChannelState
-		peerInfo    LocalPeerInfo // May be ephemeral if this is a client only channel
-		l           net.Listener  // May be nil if this is a client only channel
-		subChannels map[string]*SubChannel
-		conns       []*Connection
+		mut      sync.RWMutex // protects members of the mutable struct.
+		state    ChannelState
+		peerInfo LocalPeerInfo // May be ephemeral if this is a client only channel
+		l        net.Listener  // May be nil if this is a client only channel
+		conns    []*Connection
 	}
 }
 
@@ -142,6 +142,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		statsReporter:     statsReporter,
 		traceReporter:     traceReporter,
 		handlers:          &handlerMap{},
+		subChannels:       &subChannelMap{},
 	}
 	ch.mutable.peerInfo = LocalPeerInfo{
 		PeerInfo: PeerInfo{
@@ -150,7 +151,6 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		},
 		ServiceName: serviceName,
 	}
-	ch.mutable.subChannels = make(map[string]*SubChannel)
 	ch.mutable.state = ChannelClient
 	ch.peers = newPeerList(ch)
 	ch.createCommonStats()
@@ -231,34 +231,19 @@ func (ch *Channel) createCommonStats() {
 	// TODO(prashant): Allow user to pass extra tags (such as cluster, version).
 }
 
-func (ch *Channel) registerNewSubChannel(serviceName string) *SubChannel {
-	mutable := &ch.mutable
-	mutable.mut.Lock()
-	defer mutable.mut.Unlock()
-
-	// Recheck for the subchannel under the write lock.
-	if sc, ok := mutable.subChannels[serviceName]; ok {
-		return sc
-	}
-
-	sc := newSubChannel(serviceName, ch.peers)
-	mutable.subChannels[serviceName] = sc
-	return sc
-}
-
 // GetSubChannel returns a SubChannel for the given service name. If the subchannel does not
 // exist, it is created.
 func (ch *Channel) GetSubChannel(serviceName string) *SubChannel {
-	mutable := &ch.mutable
-	mutable.mut.RLock()
+	subChMap := ch.subChannels
+	subChMap.mut.RLock()
 
-	if sc, ok := mutable.subChannels[serviceName]; ok {
-		mutable.mut.RUnlock()
+	if sc, ok := subChMap.subchannels[serviceName]; ok {
+		subChMap.mut.RUnlock()
 		return sc
 	}
 
-	mutable.mut.RUnlock()
-	return ch.registerNewSubChannel(serviceName)
+	subChMap.mut.RUnlock()
+	return subChMap.registerNewSubChannel(serviceName, ch)
 }
 
 // Peers returns the PeerList for the channel.

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -129,6 +129,7 @@ type Connection struct {
 	inbound         messageExchangeSet
 	outbound        messageExchangeSet
 	handlers        *handlerMap
+	subchannels     *subChannelMap
 	nextMessageID   uint32
 	events          connectionEvents
 	commonStatsTags map[string]string
@@ -241,6 +242,7 @@ func (ch *Channel) newConnection(conn net.Conn, initialState connectionState, ev
 		handlers:        ch.handlers,
 		events:          events,
 		commonStatsTags: ch.commonStatsTags,
+		subchannels:     ch.subChannels,
 	}
 	c.inbound.onRemoved = c.checkExchanges
 	c.outbound.onRemoved = c.checkExchanges

--- a/golang/examples/ping/main.go
+++ b/golang/examples/ping/main.go
@@ -103,7 +103,7 @@ func main() {
 	subCh := ch.GetSubChannel("PingServiceOther")
 
 	// Register a handler on the subchannel
-	json.RegisterSub(subCh, json.Handlers{
+	json.Register(subCh, json.Handlers{
 		"pingOther": pingOtherHandler,
 	}, onError)
 

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -161,6 +161,11 @@ func (c *Connection) dispatchInbound(call *InboundCall) {
 	// https://github.com/golang/go/issues/3512
 	h := c.handlers.find(call.ServiceName(), call.Operation())
 	if h == nil {
+		// CHeck the subchannel map to see if we find one there
+		c.log.Debugf("Checking the subchannel's handlers for %s:%s", call.ServiceName(), call.Operation())
+		h = c.subchannels.find(call.ServiceName(), call.Operation())
+	}
+	if h == nil {
 		c.log.Errorf("Could not find handler for %s:%s", call.ServiceName(), call.Operation())
 		call.mex.shutdown()
 		call.Response().SendSystemError(ErrHandlerNotFound)


### PR DESCRIPTION
@prashantv 

This patch allows the subchannels to register their own set of handlers
independent of the topchannel. They will still be using the topchannel's
host/port for all the traffic.

The connection management involves maintaining a pointer to the
subchannel map (similar to handler map). When a request comes in, we
first look in the handler map to find the handler, if it fails, we try
the subchannel map to see if we can get one.
(In case of a non-existant handler, we will effectively be doing 3 O(1)
lookups. If all the traffic comes through subchannel servicename/op map we will
have one unnecessary lookup on the topchannel)

This shouldn't break any existing APIs. The ping test uses this new feature to register its
own handler on a subchannel.
TODO:
----
* Add peer support for subchannels - right now they are using the same
  peer list as the topchannel