### PR TITLE
Fix tombstone + timeheap race + more logging

### DIFF
--- a/node/operations.js
+++ b/node/operations.js
@@ -48,7 +48,7 @@ function Operations(opts) {
     self.lastTimeoutTime = 0;
 }
 
-function OperationTombstone(operations, id, time, timeout) {
+function OperationTombstone(operations, id, time, req) {
     var self = this;
 
     self.type = 'tchannel.operation.tombstone';
@@ -57,9 +57,12 @@ function OperationTombstone(operations, id, time, timeout) {
     self.operations = operations;
     self.id = id;
     self.time = time;
-    self.timeout = timeout;
+    self.timeout = TOMBSTONE_TTL_OFFSET + req.timeout;
     self.timeHeapHandle = null;
     self.destroyed = false;
+    self.serviceName = req.serviceName;
+    self.callerName = req.headers.cn;
+    self.endpoint = req.endpoint;
 }
 
 OperationTombstone.prototype.extendLogInfo = function extendLogInfo(info) {
@@ -68,6 +71,9 @@ OperationTombstone.prototype.extendLogInfo = function extendLogInfo(info) {
     var conn = self.operations && self.operations.connection;
 
     info.id = self.id;
+    info.serviceName = self.serviceName;
+    info.callerName = self.callerName;
+    info.endpoint = self.endpoint;
     info.tombstoneTime = self.time;
     info.tombstoneTTL = self.timeout;
     info.heapCanceled = self.timeHeapHandle && !self.timeHeapHandle.item;
@@ -226,8 +232,7 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
     }
 
     var now = self.timers.now();
-    var timeout = TOMBSTONE_TTL_OFFSET + req.timeout;
-    var tombstone = new OperationTombstone(self, id, now, timeout);
+    var tombstone = new OperationTombstone(self, id, now, req);
     req.operations = null;
     self.requests.out[id] = tombstone;
     self.pending.out--;

--- a/node/operations.js
+++ b/node/operations.js
@@ -361,6 +361,9 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction) {
                 self.logger.warn('stale tombstone', op.extendLogInfo({
                     direction: direction,
                     opKey: id,
+                    now: now,
+                    staleDelta: op.time + op.timeout - now,
+                    expireTime: expireTime,
                     heapLastRun: heap.lastRun
                 }));
                 delete ops[id];

--- a/node/operations.js
+++ b/node/operations.js
@@ -345,6 +345,9 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction) {
                 self.popOutReq(id);
             }
         } else if (op.isTombstone) {
+            var heap = self.connection.channel.timeHeap;
+            var expireTime = op.time + op.timeout;
+
             if (!op.operations) {
                 self.logger.warn('zombie tombstone', op.extendLogInfo({
                     direction: direction,
@@ -354,10 +357,11 @@ Operations.prototype._sweepOps = function _sweepOps(ops, direction) {
                 op.operations = null;
                 op.timeHeapHandle.cancel();
                 op.timeHeapHandle = null;
-            } else if (op.time + op.timeout < now) {
+            } else if (expireTime < now && heap.lastRun > expireTime) {
                 self.logger.warn('stale tombstone', op.extendLogInfo({
                     direction: direction,
-                    opKey: id
+                    opKey: id,
+                    heapLastRun: heap.lastRun
                 }));
                 delete ops[id];
                 op.operations = null;

--- a/node/time_heap.js
+++ b/node/time_heap.js
@@ -77,6 +77,7 @@ function TimeHeap(options) {
     self.lastTime = self.timers.now();
     self.timer = null;
     self.end = 0;
+    self.lastRun = 0;
 }
 
 TimeHeap.prototype.clear = function clear() {
@@ -139,6 +140,7 @@ TimeHeap.prototype.onTimeout = function onTimeout(now) {
     var self = this;
 
     self.timer = null;
+    self.lastRun = now;
     self.drainExpired(now);
     if (self.end) {
         self.setNextTimer(now);


### PR DESCRIPTION
This PR improves the stale tombstone detection by avoiding a 
tombstone reaper + timeHeap race condition.

It also improves logging to get more visibility into the
production stale tombstones.

r: @jcorbin @kriskowal @shannili