### PR TITLE
Improve tombstone destroy/timeout logic

### DIFF
--- a/node/operations.js
+++ b/node/operations.js
@@ -88,6 +88,14 @@ OperationTombstone.prototype.extendLogInfo = function extendLogInfo(info) {
 OperationTombstone.prototype.onTimeout = function onTimeout(now) {
     var self = this;
 
+    if (now < self.timeout + self.time) {
+        self.logger.error('tombstone timed out too early', self.extendLogInfo({
+            now: now,
+            expireTime: self.timeout + self.time,
+            delta: (self.timeout + self.time) - now
+        }));
+    }
+
     if (self.operations &&
         self.operations.requests.out[self.id] === self) {
         delete self.operations.requests.out[self.id];


### PR DESCRIPTION
This adds a gaurd against early timeout. I saw this in the
benchmarks but it turned out to be a poorly implemented destroy
in the connection close logic.

I fixed this by improving destroy() logic in the tombstone

r: @jcorbin @kriskowal @shannili