### PR TITLE
Workaround http response status message issue

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -229,8 +229,7 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
                 headers[pair[0]] = pair[1];
             }
             // work-arround a node issue where default statusMessage is missing
-            // from the client side when server side try to set it
-            // https://github.com/joyent/node/issues/25490
+            // from the client side when server side set as optional parameter
             if (head.message) {
                 hres.writeHead(head.statusCode, head.message, headers);
             } else {

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -228,7 +228,12 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
                 var pair = head.headerPairs[i];
                 headers[pair[0]] = pair[1];
             }
-            hres.writeHead(head.statusCode, head.message, headers);
+            // work-around https://github.com/joyent/node/issues/25490
+            if (head.message) {
+                hres.writeHead(head.statusCode, head.message, headers);
+            } else {
+                hres.writeHead(head.statusCode, headers);
+            }
             body.pipe(hres);
         }
         callback(err);

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -228,7 +228,9 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
                 var pair = head.headerPairs[i];
                 headers[pair[0]] = pair[1];
             }
-            // work-around https://github.com/joyent/node/issues/25490
+            // work-arround a node issue where default statusMessage is missing
+            // from the client side when server side try to set it
+            // https://github.com/joyent/node/issues/25490
             if (head.message) {
                 hres.writeHead(head.statusCode, head.message, headers);
             } else {


### PR DESCRIPTION
this is a workaround for issue that http response writeHead doesn't handle status message well
since our current node version is 0.10, so head.message is an empty string and the else block will always be executed.
it's not clear to me if this issue will be resolved in 0.12 or not:
https://github.com/joyent/node/issues/25490
@jcorbin @Raynos @ShanniLi 
cc: @davewhat @vipulaneja 
