### PR TITLE
Fix as raw docs

### DIFF
--- a/docs/raw.md
+++ b/docs/raw.md
@@ -10,6 +10,6 @@ before using `as=raw`.
 
 ## Arguments
 
- - `arg1` : raw bytes
+ - `arg1` : endpoint
  - `arg2` : raw bytes
  - `arg3` : raw bytes


### PR DESCRIPTION
We incorrectly say that `arg1` is raw bytes instead of endpoint, leading @willsalz to think there can only be 1 raw endpoint per service and myself to create this https://github.com/uber/tchannel-python/issues/113