### PR TITLE
v2/handler: use res.sendError rather than handler.sendErrorFrame

### DIFF
--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -202,7 +202,7 @@ TChannelV2Handler.prototype.handleCallRequest = function handleCallRequest(reqFr
         //   entity, since it may cause undue connection thrashing in the
         //   presence of bad actors
         // all the more reason to kill every "TODO typed error"
-        self.sendErrorFrame(req.res, codeName, err.message);
+        req.res.sendError(codeName, err.message);
         return;
     }
 


### PR DESCRIPTION
Per feedback from @raynos on #1145, except this one had already made it to master in #1140.