### PR TITLE
Add error logging in as-http example

### DIFF
--- a/node/examples/http_egress.js
+++ b/node/examples/http_egress.js
@@ -87,7 +87,7 @@ function onHTTPListening() {
 }
 
 function onHTTPRequest(hreq, hres) {
-    asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function(error) {
+    asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function onComplete(error) {
         if (error) {
             console.log('forward to tchannel failed', error);
         }

--- a/node/examples/http_egress.js
+++ b/node/examples/http_egress.js
@@ -87,5 +87,9 @@ function onHTTPListening() {
 }
 
 function onHTTPRequest(hreq, hres) {
-    asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function() { return true; });
+    asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function(error) {
+        if (error) {
+            console.log('forward to tchannel failed', error);
+        }
+    });
 }

--- a/node/examples/http_egress.js
+++ b/node/examples/http_egress.js
@@ -89,7 +89,7 @@ function onHTTPListening() {
 function onHTTPRequest(hreq, hres) {
     asHTTP.forwardToTChannel(svcChan, hreq, hres, {}, function onComplete(error) {
         if (error) {
-            console.log('forward to tchannel failed', error);
+            console.error('forward to tchannel failed', error);
         }
     });
 }

--- a/node/examples/http_ingress.js
+++ b/node/examples/http_ingress.js
@@ -86,7 +86,7 @@ function onRequest(inreq, outres) {
     asHTTP.forwardToHTTP(svcChan, {
         host: destHost,
         port: destPort,
-    }, inreq, outres, function(error) {
+    }, inreq, outres, function onComplete(error) {
         if (error) {
             console.log('forward to http failed', error);
         }

--- a/node/examples/http_ingress.js
+++ b/node/examples/http_ingress.js
@@ -88,7 +88,7 @@ function onRequest(inreq, outres) {
         port: destPort,
     }, inreq, outres, function onComplete(error) {
         if (error) {
-            console.log('forward to http failed', error);
+            console.error('forward to http failed', error);
         }
     });
 }

--- a/node/examples/http_ingress.js
+++ b/node/examples/http_ingress.js
@@ -86,5 +86,9 @@ function onRequest(inreq, outres) {
     asHTTP.forwardToHTTP(svcChan, {
         host: destHost,
         port: destPort,
-    }, inreq, outres, function() { return true; });
+    }, inreq, outres, function(error) {
+        if (error) {
+            console.log('forward to http failed', error);
+        }
+    });
 }


### PR DESCRIPTION
Update as-http example with error logging
Useful for reproducing and debugging as-http/tchannel error
@ShanniLi @Raynos @davewhat 