### PR TITLE
Add lbpool option in as-http

### DIFF
--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var http = require('http');
+var parseArgs = require('minimist');
+var TChannel = require('../channel');
+var TChannelAsHTTP = require('../as/http');
+var LBPool = require('lb_pool').Pool;
+
+/* Minimal working example of an HTTP "bridge" over TChannel:
+ * 1) start an http service:
+ *    $ python -m SimpleHTTPServer # listens on port 8000
+ *
+ * 2) start an ingress proxy which will convert TChannel calls to http requests:
+ *    $ node examples/lbpool_ingress.js --tchannel-port 4040 example 127.0.0.1:8000
+ *
+ * 3) start an egress proxy which will convert HTTP requests to TChannel calls:
+ *    $ node examples/http_egress.js --http-port 8080 --peers 127.0.0.1:4040 example
+ *
+ * 4) use it through the egress node:
+ *    $ curl http://localhost:8080 # or open in browser to taste
+ */
+
+var argv = parseArgs(process.argv.slice(2), {
+    default: {
+        bind: '127.0.0.1',
+        tchannelPort: 0
+    },
+    alias: {
+        'tchannel-port': 'tchannelPort'
+    }
+});
+
+function usage() {
+    console.error('usage http_relay [options] <serviceName> <dest>');
+    console.error('\nOptions:');
+    console.error('  --bind <address>');
+    console.error('  --tchannel-port <port>');
+    process.exit(1);
+}
+
+if (argv._.length !== 2) usage();
+
+var serviceName = argv._[0];
+var dest = argv._[1];
+var parts = dest.split(':');
+assert(parts.length === 2);
+
+var destHost = parts[0];
+var destPort = parts[1];
+
+var servers = [dest];
+var lbpool = new LBPool(http, servers, {
+    max_pending: 50,
+    timeout: 5000,
+    max_sockets: 5
+});
+var asHTTP = TChannelAsHTTP(lbpool);
+
+var tchan = TChannel();
+tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);
+
+var svcChan = tchan.makeSubChannel({
+    serviceName: serviceName
+});
+asHTTP.setHandler(svcChan, onRequest);
+
+function onChannelListening() {
+    var addr = tchan.address();
+    console.log('tchannel listening on %s:%s', addr.address, addr.port);
+}
+
+function onRequest(inreq, outres) {
+    asHTTP.forwardToHTTP(svcChan, {
+        host: destHost,
+        port: destPort,
+    }, inreq, outres, function onComplete(error) {
+        if (error) {
+            console.error('forward to HTTP failed', error);
+        }
+    });
+}

--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -71,9 +71,7 @@ var destPort = parts[1];
 
 var servers = [dest];
 var lbpool = new LBPool(http, servers, {
-    max_pending: 50,
-    timeout: 5000,
-    max_sockets: 5
+    keep_alive: true
 });
 var asHTTP = TChannelAsHTTP(lbpool);
 

--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -73,7 +73,7 @@ var servers = [dest];
 var lbpool = new LBPool(http, servers, {
     keep_alive: true
 });
-var asHTTP = TChannelAsHTTP(lbpool);
+var asHTTP = TChannelAsHTTP({lbpool: lbpool});
 
 var tchan = TChannel();
 tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);

--- a/node/package.json
+++ b/node/package.json
@@ -53,6 +53,7 @@
     "format-stack": "4.1.1",
     "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
+    "lb_pool": "^1.3.0",
     "ldjson-stream": "^1.2.1",
     "logtron": "^8.1.0",
     "metrics": "^0.1.8",


### PR DESCRIPTION
without lbpool, I got 1000+ RPS, along with 10%+ timeout and EADDRNOTAVAIL errors
with lbpool (keep_alive = true), I got 1700+ RPS, no errors
so lbpool is awesome, except it doesn't expose readable stream
@mranney @jcorbin @Raynos  @ShanniLi 