### PR TITLE
Add lbpool option in as-http

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -163,13 +163,14 @@ TChannelHTTP.prototype.sendResponse = function send(buildResponse, hres, body, c
     }
     var arg2 = arg2res.value;
     if (body) {
-        callback(null);
-        return buildResponse({
+        buildResponse({
             streamed: false,
             headers: {
                 as: 'http'
             }
         }).sendOk(arg2, body);
+        callback(null);
+        return;
     }
 
     return buildResponse({
@@ -303,7 +304,7 @@ TChannelHTTP.prototype._forwardToNodeHTTP = function _forwardToNodeHTTP(options,
     function onResponse(inres) {
         if (!sent) {
             sent = true;
-            outres.sendResponse(inres, null);
+            outres.sendResponse(inres);
             callback(null);
         }
     }

--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -1,0 +1,102 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var http = require('http');
+var parseArgs = require('minimist');
+var TChannel = require('../channel');
+var TChannelAsHTTP = require('../as/http');
+var LBPool = require('lb_pool').Pool;
+
+/* Minimal working example of an HTTP "bridge" over TChannel:
+ * 1) start an http service:
+ *    $ python -m SimpleHTTPServer # listens on port 8000
+ *
+ * 2) start an ingress proxy which will convert TChannel calls to http requests:
+ *    $ node examples/lbpool_ingress.js --tchannel-port 4040 example 127.0.0.1:8000
+ *
+ * 3) start an egress proxy which will convert HTTP requests to TChannel calls:
+ *    $ node examples/http_egress.js --http-port 8080 --peers 127.0.0.1:4040 example
+ *
+ * 4) use it through the egress node:
+ *    $ curl http://localhost:8080 # or open in browser to taste
+ */
+
+var argv = parseArgs(process.argv.slice(2), {
+    default: {
+        bind: '127.0.0.1',
+        tchannelPort: 0
+    },
+    alias: {
+        'tchannel-port': 'tchannelPort'
+    }
+});
+
+function usage() {
+    console.error('usage http_relay [options] <serviceName> <dest>');
+    console.error('\nOptions:');
+    console.error('  --bind <address>');
+    console.error('  --tchannel-port <port>');
+    process.exit(1);
+}
+
+if (argv._.length !== 2) usage();
+
+var serviceName = argv._[0];
+var dest = argv._[1];
+var parts = dest.split(':');
+assert(parts.length === 2);
+
+var destHost = parts[0];
+var destPort = parts[1];
+
+var servers = [dest];
+var lbpool = new LBPool(http, servers, {
+    max_pending: 50,
+    timeout: 5000,
+    max_sockets: 5
+});
+var asHTTP = TChannelAsHTTP(lbpool);
+
+var tchan = TChannel();
+tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);
+
+var svcChan = tchan.makeSubChannel({
+    serviceName: serviceName
+});
+asHTTP.setHandler(svcChan, onRequest);
+
+function onChannelListening() {
+    var addr = tchan.address();
+    console.log('tchannel listening on %s:%s', addr.address, addr.port);
+}
+
+function onRequest(inreq, outres) {
+    asHTTP.forwardToHTTP(svcChan, {
+        host: destHost,
+        port: destPort,
+    }, inreq, outres, function onComplete(error) {
+        if (error) {
+            console.error('forward to HTTP failed', error);
+        }
+    });
+}

--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -71,9 +71,7 @@ var destPort = parts[1];
 
 var servers = [dest];
 var lbpool = new LBPool(http, servers, {
-    max_pending: 50,
-    timeout: 5000,
-    max_sockets: 5
+    keep_alive: true
 });
 var asHTTP = TChannelAsHTTP(lbpool);
 

--- a/node/examples/lbpool_ingress.js
+++ b/node/examples/lbpool_ingress.js
@@ -73,7 +73,7 @@ var servers = [dest];
 var lbpool = new LBPool(http, servers, {
     keep_alive: true
 });
-var asHTTP = TChannelAsHTTP(lbpool);
+var asHTTP = TChannelAsHTTP({lbpool: lbpool});
 
 var tchan = TChannel();
 tchan.listen(argv.tchannelPort, argv.bind, onChannelListening);

--- a/node/package.json
+++ b/node/package.json
@@ -53,6 +53,7 @@
     "format-stack": "4.1.1",
     "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
+    "lb_pool": "^1.3.0",
     "ldjson-stream": "^1.2.1",
     "logtron": "^8.1.0",
     "metrics": "^0.1.8",

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -259,9 +259,10 @@ function allocHTTPBridge(opts) {
         cluster.requestOptions.host = addr.address;
         cluster.requestOptions.port = addr.port;
         if (opts.enableLBPool) {
-            var addr = cluster.httpService.address();
-            opts.lbpool = new LBPool(http, [addr.address + ':' + addr.port], {
-                keep_alive: true
+            var dest = cluster.httpService.address().address + ':' +
+                cluster.httpService.address().port;
+            opts.lbpool = new LBPool(http, [dest], {
+                'keep_alive': true
             });
         }
         cluster.asHTTP = new TChannelHTTP(opts);

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -29,8 +29,9 @@ var test = require('tape');
 
 var TChannelHTTP = require('../as/http.js');
 var allocCluster = require('./lib/alloc-cluster.js');
+var LBPool = require('lb_pool').Pool;
 
-allocHTTPTest('as/http can bridge a service', {
+allocHTTPTest('as/http can bridge a service using node http', {
     onServiceRequest: handleTestHTTPRequest
 }, function t(cluster, assert) {
 
@@ -77,6 +78,56 @@ allocHTTPTest('as/http can bridge a service', {
         }),
 
     ], assert.end);
+});
+
+allocHTTPTest('as/http can bridge a service using lbpool', {
+    onServiceRequest: handleTestHTTPRequest,
+    enableLBPool: true
+}, function t(cluster, assert) {
+
+    var egressHost = cluster.httpEgress.address().address + ':' +
+                     cluster.httpEgress.address().port;
+    parallel([
+
+        cluster.sendRequest.thunk({
+            method: 'GET',
+            path: '/such/stuff',
+        }, null, {
+            statusCode: 200,
+            statusMessage: 'Ok',
+            body:
+                '{"request":{"method":"GET","url":"/such/stuff","headers":{"host":"' + egressHost + '","connection":"keep-alive"}}}\n'
+        }),
+
+        cluster.sendRequest.thunk({
+            method: 'PUT',
+            path: '/wat/even/is',
+            headers: {
+                'Content-Type': 'text/plain',
+                'X-Test-Header': 'test header value'
+            }
+        }, 'hello world', {
+            statusCode: 200,
+            statusMessage: 'Ok',
+            body:
+                '{"request":{"method":"PUT","url":"/wat/even/is","headers":{"content-type":"text/plain","x-test-header":"test header value","host":"' +
+                egressHost +
+                '","connection":"keep-alive","transfer-encoding":"chunked"}}}\n' +
+                '{"chunk":"hello world"}\n'
+        }),
+
+        cluster.sendRequest.thunk({
+            method: 'GET',
+            path: '/returnStatus/420/obviously',
+        }, null, {
+            statusCode: 420,
+            statusMessage: 'obviously',
+            body:
+                '{"request":{"method":"GET","url":"/returnStatus/420/obviously","headers":{"host":"' + egressHost + '","connection":"keep-alive"}}}\n'
+        }),
+
+    ], assert.end);
+
 });
 
 allocHTTPTest('as/http can handle a timeout', {
@@ -140,6 +191,7 @@ function handleTestHTTPRequest(hreq, hres) {
 
     function onEnd() {
         hres.end();
+        hreq.connection.destroy();
     }
 }
 
@@ -173,7 +225,6 @@ function allocHTTPBridge(opts) {
     cluster.ready(cready.signal);
     cluster.httpEgress = allocHTTPServer(opts.onEgressRequest, cready.signal);
     cluster.httpService = allocHTTPServer(opts.onServiceRequest, cready.signal);
-
     var serviceName = opts.serviceName || 'test_http';
     var chanOpts = {
         serviceName: serviceName,
@@ -191,8 +242,6 @@ function allocHTTPBridge(opts) {
     cluster.ingressChan = cluster.ingressServer.makeSubChannel(chanOpts);
     cluster.egressChan = cluster.egressServer.makeSubChannel(chanOpts);
 
-    cluster.asHTTP = new TChannelHTTP();
-    cluster.asHTTP.setHandler(cluster.ingressChan, onIngressRequest);
     cluster.httpEgress.on('request', onEgressRequest);
 
     cluster.requestOptions = {
@@ -209,6 +258,14 @@ function allocHTTPBridge(opts) {
         var addr = cluster.httpEgress.address();
         cluster.requestOptions.host = addr.address;
         cluster.requestOptions.port = addr.port;
+        if (opts.enableLBPool) {
+            var addr = cluster.httpService.address();
+            opts.lbpool = new LBPool(http, [addr.address + ':' + addr.port], {
+                keep_alive: true
+            });
+        }
+        cluster.asHTTP = new TChannelHTTP(opts);
+        cluster.asHTTP.setHandler(cluster.ingressChan, onIngressRequest);
     }
 
     function onIngressRequest(treq, tres) {
@@ -251,6 +308,7 @@ function allocHTTPBridge(opts) {
         tdestroy(closed.signal);
         cluster.httpEgress.close(closed.signal);
         cluster.httpService.close(closed.signal);
+        if (opts.lbpool) opts.lbpool.close();
         if (callback) closed(callback);
     }
 


### PR DESCRIPTION
without lbpool, I got 1000+ RPS, along with 10%+ timeout and EADDRNOTAVAIL errors
with lbpool (keep_alive = true), I got 1700+ RPS, no errors
so lbpool is awesome, except it doesn't expose readable stream
@mranney @jcorbin @Raynos @ShanniLi 