### PR TITLE
enforce outgoing connection

### DIFF
--- a/node/hyperbahn/service_proxy.js
+++ b/node/hyperbahn/service_proxy.js
@@ -296,7 +296,7 @@ function refreshServicePeer(serviceName, hostPort) {
     var self = this;
 
     var peer = self.getServicePeer(serviceName, hostPort);
-    peer.connect();
+    peer.connect(true);
 
     var time = self.channel.timers.now();
     self.exitServices[serviceName] = time;

--- a/node/peer.js
+++ b/node/peer.js
@@ -443,7 +443,7 @@ PreferOutgoingHandler.prototype.getScore = function getScore() {
     switch (qos) {
         case TIER_ONLY_INCOMING:
             if (!self.peer.channel.destroyed) {
-                self.peer.connect();
+                self.peer.connect(true);
             }
             /* falls through */
         case TIER_UNCONNECTED:


### PR DESCRIPTION
This fixes the hyperbahn race condition we've seen during workshops

I suspect that for a small ring or a low k value the outgoing
socket from the worker is favored. I also suspect that when an
incoming connection dies on a peer it is not properly removed
from the peer.

I work around this edge case by more aggresively favoring out
going connections which do get cleaned up. This also makes the
peer selection of two bands (identified vs non-identified) work
again.

I suspect the situation in which the bug is found is where there 
are two peers and they both have an incoming connection and 
one of them is open where as the other is dead.

r: @jcorbin @kriskowal @rf