### PR TITLE
Send error on duplicate ID for a call

### DIFF
--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -62,7 +62,11 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 
 	mex, err := c.inbound.newExchange(ctx, c.framePool, callReq.messageType(), frame.Header.ID, 512)
 	if err != nil {
+		if err == errDuplicateMex {
+			err = errInboundRequestAlreadyActive
+		}
 		c.log.Errorf("could not register exchange for %s", frame.Header)
+		c.SendSystemError(frame.Header.ID, nil, err)
 		return true
 	}
 

--- a/golang/inbound_test.go
+++ b/golang/inbound_test.go
@@ -1,0 +1,78 @@
+package tchannel_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	. "github.com/uber/tchannel/golang"
+	"github.com/uber/tchannel/golang/raw"
+	"github.com/uber/tchannel/golang/testutils"
+)
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+func TestActiveCallReq(t *testing.T) {
+	ctx, cancel := NewContext(time.Second)
+	defer cancel()
+
+	// Note: This test leaks a message exchange due to the modification of IDs in the relay.
+	require.NoError(t, testutils.WithServer(nil, func(ch *Channel, hostPort string) {
+		gotCall := make(chan struct{})
+		unblock := make(chan struct{})
+
+		registerFunc(t, ch, "blocked", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+			gotCall <- struct{}{}
+			<-unblock
+			return &raw.Res{}, nil
+		})
+
+		relayFunc := func(outgoing bool, frame *Frame) *Frame {
+			if outgoing && frame.Header.ID == 2 {
+				frame.Header.ID = 3
+			}
+			return frame
+		}
+
+		relayHostPort, closeRelay := testutils.FrameRelay(t, hostPort, relayFunc)
+		defer closeRelay()
+
+		go func() {
+			// This call will block until we close unblock.
+			raw.Call(ctx, ch, relayHostPort, ch.PeerInfo().ServiceName, "blocked", nil, nil)
+		}()
+
+		// Wait for the first call to be received by the server
+		<-gotCall
+
+		// Make a new call, which should fail
+		_, _, _, err := raw.Call(ctx, ch, relayHostPort, ch.PeerInfo().ServiceName, "blocked", nil, nil)
+		assert.Error(t, err, "Expect error")
+		assert.True(t, strings.Contains(err.Error(), "already active"),
+			"expected already active error, got %v", err)
+
+		close(unblock)
+	}))
+}

--- a/golang/testutils/relay.go
+++ b/golang/testutils/relay.go
@@ -1,0 +1,87 @@
+package testutils
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang"
+)
+
+type frameRelay struct {
+	t           *testing.T
+	destination string
+	relayFunc   func(outgoing bool, f *tchannel.Frame) *tchannel.Frame
+}
+
+func (r frameRelay) listen() (listenHostPort string, cancel func()) {
+	closed := uint32(0)
+
+	conn, err := net.Listen("tcp", ":0")
+	require.NoError(r.t, err, "net.Listen failed")
+
+	go func() {
+		for {
+			c, err := conn.Accept()
+			if err != nil && atomic.LoadUint32(&closed) == 0 {
+				r.t.Errorf("Accept failed: %v", err)
+			}
+
+			r.relayConn(c)
+		}
+	}()
+
+	return conn.Addr().String(), func() {
+		atomic.AddUint32(&closed, 1)
+		conn.Close()
+	}
+}
+
+func (r frameRelay) relayConn(c net.Conn) {
+	outC, err := net.Dial("tcp", r.destination)
+	require.NoError(r.t, err, "relay outgoing connection failed")
+
+	go r.relayBetween(true /* outgoing */, c, outC)
+	go r.relayBetween(false /* outgoing */, outC, c)
+}
+
+func (r frameRelay) relayBetween(outgoing bool, c net.Conn, outC net.Conn) {
+	for {
+		frame := tchannel.NewFrame(tchannel.MaxFramePayloadSize)
+		if !assert.NoError(r.t, frame.ReadIn(c), "read frame failed") {
+			return
+		}
+
+		frame = r.relayFunc(outgoing, frame)
+		if !assert.NoError(r.t, frame.WriteOut(outC), "write frame failed") {
+			return
+		}
+	}
+}
+
+// FrameRelay sets up a relay that can modify frames using relayFunc.
+func FrameRelay(t *testing.T, destination string, relayFunc func(outgoing bool, f *tchannel.Frame) *tchannel.Frame) (listenHostPort string, cancel func()) {
+	return frameRelay{t, destination, relayFunc}.listen()
+}


### PR DESCRIPTION
If a callReq is received with a duplicate ID, send an error.
Add test helpers to support an intermediate relay that can modify
frames to test error scenarios.