### PR TITLE
allocCluster: suppert logVerbose option

### DIFF
--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -35,7 +35,8 @@ function allocCluster(opts) {
 
     var host = 'localhost';
     var logger = debugLogtron('tchannel', {
-        enabled: true
+        enabled: true,
+        verbose: !!opts.logVerbose
     });
 
     var cluster = {


### PR DESCRIPTION
Makes it super easy to get moar logs out of a test case without needing to futz with environment variables, speeding iteration.