### PR TITLE
go: fix panic caused by closed sendCh when running ringpop-go tests

### DIFF
--- a/golang/connection.go
+++ b/golang/connection.go
@@ -641,11 +641,6 @@ func (c *Connection) readFrames(_ uint32) {
 // writes them to the connection.
 func (c *Connection) writeFrames(_ uint32) {
 	for f := range c.sendCh {
-		if f == nil {
-			close(c.sendCh)
-			break
-		}
-
 		c.log.Debugf("Writing frame %s", f.Header)
 		err := f.WriteOut(c.conn)
 		c.framePool.Release(f)

--- a/golang/connection.go
+++ b/golang/connection.go
@@ -667,31 +667,30 @@ func (c *Connection) checkExchanges() {
 		return err == nil
 	}
 
-	var updated bool
+	var updated connectionState
 	if c.readState() == connectionStartClose {
 		if c.inbound.count() == 0 && moveState(connectionStartClose, connectionInboundClosed) {
-			updated = true
+			updated = connectionInboundClosed
 		}
 		// If there was no update to the state, there's no more processing to do.
-		if !updated {
+		if updated == 0 {
 			return
 		}
 	}
 
 	if c.readState() == connectionInboundClosed {
 		if c.outbound.count() == 0 && moveState(connectionInboundClosed, connectionClosed) {
-			updated = true
+			updated = connectionClosed
 		}
 	}
 
-	if updated {
-		curState := c.readState()
+	if updated != 0 {
 		// If the connection is closed, we can safely close the channel.
-		if curState == connectionClosed {
+		if updated == connectionClosed {
 			close(c.sendCh)
 		}
 
-		c.log.Debugf("checkExchanges updated connection state to %v", curState)
+		c.log.Debugf("checkExchanges updated connection state to %v", updated)
 		c.callOnCloseStateChange()
 	}
 }

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -70,6 +70,12 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 		return true
 	}
 
+	// Close may have been called between the time we checked the state and us creating the exchange.
+	if c.readState() != connectionActive {
+		mex.shutdown()
+		return true
+	}
+
 	call.AddBinaryAnnotation(BinaryAnnotation{Key: "cn", Value: callReq.Headers[CallerName]})
 	call.AddBinaryAnnotation(BinaryAnnotation{Key: "as", Value: callReq.Headers[ArgScheme]})
 	call.AddAnnotation(AnnotationKeyServerReceive)

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -121,7 +121,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.commonStatsTags = call.commonStatsTags
 
 	setResponseHeaders(call.headers, response.headers)
-	go c.dispatchInbound(c.connID, call)
+	go c.dispatchInbound(c.connID, callReq.ID(), call)
 	return false
 }
 
@@ -147,7 +147,7 @@ func (call *InboundCall) createStatsTags(connectionTags map[string]string) {
 }
 
 // dispatchInbound ispatches an inbound call to the appropriate handler
-func (c *Connection) dispatchInbound(_ uint32, call *InboundCall) {
+func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall) {
 	c.log.Debugf("Received incoming call for %s from %s", call.ServiceName(), c.remotePeerInfo)
 
 	if err := call.readOperation(); err != nil {

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -115,7 +115,7 @@ func (c *Connection) handleCallReq(frame *Frame) bool {
 	response.commonStatsTags = call.commonStatsTags
 
 	setResponseHeaders(call.headers, response.headers)
-	go c.dispatchInbound(call)
+	go c.dispatchInbound(c.connID, call)
 	return false
 }
 
@@ -141,7 +141,7 @@ func (call *InboundCall) createStatsTags(connectionTags map[string]string) {
 }
 
 // dispatchInbound ispatches an inbound call to the appropriate handler
-func (c *Connection) dispatchInbound(call *InboundCall) {
+func (c *Connection) dispatchInbound(_ uint32, call *InboundCall) {
 	c.log.Debugf("Received incoming call for %s from %s", call.ServiceName(), c.remotePeerInfo)
 
 	if err := call.readOperation(); err != nil {

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -60,6 +60,12 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		return nil, err
 	}
 
+	// Close may have been called between the time we checked the state and us creating the exchange.
+	if state := c.readState(); state != connectionStartClose && state != connectionActive {
+		mex.shutdown()
+		return nil, ErrConnectionClosed
+	}
+
 	headers := transportHeaders{
 		CallerName: c.localPeerInfo.ServiceName,
 	}


### PR DESCRIPTION
This fixes the race conditions between receiving calls/making calls and closing the connection.

There is still one race condition left caused by timeouts. There is already a TODO on line 175 which requires a larger refactoring.