### PR TITLE
go: Add frame pools that use sync.Pool and channels

### DIFF
--- a/golang/frame_pool.go
+++ b/golang/frame_pool.go
@@ -1,5 +1,7 @@
 package tchannel
 
+import "sync"
+
 // Copyright (c) 2015 Uber Technologies, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,10 +31,56 @@ type FramePool interface {
 	Release(f *Frame)
 }
 
-// The DefaultFramePool uses the heap as the pool
-var DefaultFramePool FramePool = defaultFramePool{}
+// DefaultFramePool is the disabled frame pool which uses the heap.
+var DefaultFramePool = DisabledFramePool
 
-type defaultFramePool struct{}
+// DisabledFramePool is a pool that uses the heap and relies on GC.
+var DisabledFramePool = disabledFramePool{}
 
-func (p defaultFramePool) Get() *Frame      { return NewFrame(MaxFramePayloadSize) }
-func (p defaultFramePool) Release(f *Frame) {}
+type disabledFramePool struct{}
+
+func (p disabledFramePool) Get() *Frame      { return NewFrame(MaxFramePayloadSize) }
+func (p disabledFramePool) Release(f *Frame) {}
+
+type syncFramePool struct {
+	pool *sync.Pool
+}
+
+// NewSyncFramePool returns a frame pool that uses a sync.Pool.
+func NewSyncFramePool() FramePool {
+	return &syncFramePool{
+		pool: &sync.Pool{New: func() interface{} { return NewFrame(MaxFramePayloadSize) }},
+	}
+}
+
+func (p syncFramePool) Get() *Frame {
+	return p.pool.Get().(*Frame)
+}
+
+func (p syncFramePool) Release(f *Frame) {
+	p.pool.Put(f)
+}
+
+type channelFramePool chan *Frame
+
+// NewChannelFramePool returns a frame pool backed by a channel that has a max capacity.
+func NewChannelFramePool(capacity int) FramePool {
+	return channelFramePool(make(chan *Frame, capacity))
+}
+
+func (c channelFramePool) Get() *Frame {
+	select {
+	case frame := <-c:
+		return frame
+	default:
+		return NewFrame(MaxFramePayloadSize)
+	}
+}
+
+func (c channelFramePool) Release(f *Frame) {
+	select {
+	case c <- f:
+	default:
+		// Too many frames in the channel, discard it.
+	}
+}

--- a/golang/frame_pool_b_test.go
+++ b/golang/frame_pool_b_test.go
@@ -1,0 +1,82 @@
+package tchannel_test
+
+import (
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/uber/tchannel/golang"
+)
+
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+func benchmarkUsing(b *testing.B, pool FramePool) {
+	const numGoroutines = 1000
+	const maxHoldFrames = 1000
+
+	var gotFrames uint64
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+
+			for {
+				if atomic.LoadUint64(&gotFrames) > uint64(b.N) {
+					break
+				}
+
+				framesToHold := rand.Intn(maxHoldFrames)
+				atomic.AddUint64(&gotFrames, uint64(framesToHold))
+
+				frames := make([]*Frame, framesToHold)
+				for i := 0; i < framesToHold; i++ {
+					frames[i] = pool.Get()
+				}
+
+				for i := 0; i < framesToHold; i++ {
+					pool.Release(frames[i])
+				}
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkFramePoolDisabled(b *testing.B) {
+	benchmarkUsing(b, DisabledFramePool)
+}
+
+func BenchmarkFramePoolSync(b *testing.B) {
+	benchmarkUsing(b, NewSyncFramePool())
+}
+
+func BenchmarkFramePoolChannel1000(b *testing.B) {
+	benchmarkUsing(b, NewChannelFramePool(1000))
+}
+
+func BenchmarkFramePoolChannel10000(b *testing.B) {
+	benchmarkUsing(b, NewChannelFramePool(10000))
+}

--- a/golang/testutils/relay.go
+++ b/golang/testutils/relay.go
@@ -68,8 +68,8 @@ func (r frameRelay) relayConn(c net.Conn) {
 }
 
 func (r frameRelay) relayBetween(outgoing bool, c net.Conn, outC net.Conn) {
+	frame := tchannel.NewFrame(tchannel.MaxFramePayloadSize)
 	for {
-		frame := tchannel.NewFrame(tchannel.MaxFramePayloadSize)
 		if !assert.NoError(r.t, frame.ReadIn(c), "read frame failed") {
 			return
 		}


### PR DESCRIPTION
The new pools are NOT used, the default is still to rely on the heap + GC.

This change adds pool that we can test before making them the default.