### PR TITLE
Fixed cut tarballing for all

### DIFF
--- a/hyperbahn/cut.sh
+++ b/hyperbahn/cut.sh
@@ -64,6 +64,5 @@ DEV_BRANCH=$DEV_BRANCH make -C hyperbahn update_dev
 git tag -a -m "Tag $tag" "$tag" "$DEV_BRANCH"
 git push origin master dev_hyperbahn --tags
 
-git checkout dev_hyperbahn
-npm publish --tag "${NPM_TAG:-alpha}"
-git checkout master
+git archive --prefix=package/ --format tgz dev_hyperbahn >package.tgz
+npm publish package.tgz --tag "${NPM_TAG:-alpha}"

--- a/node/cut.sh
+++ b/node/cut.sh
@@ -63,6 +63,6 @@ DEV_BRANCH=$DEV_BRANCH make -C node update_dev
 
 git tag -a -m "Tag $tag" "$tag" "$DEV_BRANCH"
 git push origin master dev_node --tags
-git archive --format tgz dev_node >package.tgz
+git archive --prefix=package/ --format tgz dev_node >package.tgz
 npm publish package.tgz --tag "${NPM_TAG:-alpha}"
 rm package.tgz


### PR DESCRIPTION
Turns out the tarballs need to have a prefix inside, looking at past npm-made ones, it's just called "package/".