### PR TITLE
go: Make json Headers map[string]string

### DIFF
--- a/golang/context_header.go
+++ b/golang/context_header.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import "golang.org/x/net/context"
+
+// ContextWithHeaders is a Context which contains request and response headers.
+type ContextWithHeaders interface {
+	context.Context
+
+	// Headers returns the call request headers.
+	Headers() map[string]string
+
+	// ResponseHeaders returns the call response headers.
+	ResponseHeaders() map[string]string
+
+	// SetResponseHeaders sets the given response headers on the context.
+	SetResponseHeaders(map[string]string)
+}
+
+type headerCtx struct {
+	context.Context
+	reqHeaders  map[string]string
+	respHeaders map[string]string
+}
+
+// Headers gets application headers out of the context.
+func (c *headerCtx) Headers() map[string]string {
+	return c.reqHeaders
+}
+
+// ResponseHeaders returns the response headers.
+func (c *headerCtx) ResponseHeaders() map[string]string {
+	return c.respHeaders
+}
+
+// SetResponseHeaders sets the response headers.
+func (c *headerCtx) SetResponseHeaders(headers map[string]string) {
+	c.respHeaders = headers
+}
+
+// WrapWithHeaders returns a Context that can be used to make a call with request headers.
+func WrapWithHeaders(ctx context.Context, headers map[string]string) ContextWithHeaders {
+	return &headerCtx{
+		Context:    ctx,
+		reqHeaders: headers,
+	}
+}

--- a/golang/json/call.go
+++ b/golang/json/call.go
@@ -43,7 +43,7 @@ func makeCall(ctx Context, call *tchannel.OutboundCall, arg interface{}, resp in
 	}
 
 	// Call Arg2Reader before application error.
-	var respHeaders interface{}
+	var respHeaders map[string]string
 	if err := tchannel.NewArgReader(call.Response().Arg2Reader()).ReadJSON(&respHeaders); err != nil {
 		return fmt.Errorf("arg2 read failed: %v", err)
 	}

--- a/golang/json/context.go
+++ b/golang/json/context.go
@@ -28,52 +28,20 @@ import (
 )
 
 // Context is a JSON Context which contains request and response headers.
-type Context interface {
-	context.Context
-
-	// Headers returns the call request headers.
-	Headers() interface{}
-
-	// ResponseHeaders returns the call response headers.
-	ResponseHeaders() interface{}
-
-	// SetResponseHeaders sets the given response headers on the context.
-	SetResponseHeaders(headers interface{})
-}
-
-type jsonCtx struct {
-	context.Context
-	reqHeaders  interface{}
-	respHeaders interface{}
-}
-
-// Headers gets application headers out of the context.
-func (c *jsonCtx) Headers() interface{} {
-	return c.reqHeaders
-}
-
-// ResponseHeaders returns the response headers.
-func (c *jsonCtx) ResponseHeaders() interface{} {
-	return c.respHeaders
-}
-
-// SetResponseHeaders sets the response headers.
-func (c *jsonCtx) SetResponseHeaders(headers interface{}) {
-	c.respHeaders = headers
-}
+type Context tchannel.ContextWithHeaders
 
 // NewContext returns a Context that can be used to make JSON calls.
 func NewContext(timeout time.Duration) (Context, context.CancelFunc) {
-	tctx, cancel := tchannel.NewContext(timeout)
-	return &jsonCtx{
-		Context: tctx,
-	}, cancel
+	ctx, cancel := tchannel.NewContext(timeout)
+	return tchannel.WrapWithHeaders(ctx, nil), cancel
+}
+
+// Wrap returns a JSON Context that wraps around a Context.
+func Wrap(ctx context.Context) Context {
+	return tchannel.WrapWithHeaders(ctx, nil)
 }
 
 // WithHeaders returns a Context that can be used to make a call with request headers.
-func WithHeaders(ctx context.Context, headers interface{}) Context {
-	return &jsonCtx{
-		Context:    ctx,
-		reqHeaders: headers,
-	}
+func WithHeaders(ctx context.Context, headers map[string]string) Context {
+	return tchannel.WrapWithHeaders(ctx, headers)
 }

--- a/golang/json/handler.go
+++ b/golang/json/handler.go
@@ -119,7 +119,7 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 
 // Handle deserializes the JSON arguments and calls the underlying handler.
 func (h *handler) Handle(tctx context.Context, call *tchannel.InboundCall) error {
-	var headers interface{}
+	var headers map[string]string
 	if err := tchannel.NewArgReader(call.Arg2Reader()).ReadJSON(&headers); err != nil {
 		return fmt.Errorf("arg2 read failed: %v", err)
 	}

--- a/golang/thrift/context.go
+++ b/golang/thrift/context.go
@@ -28,59 +28,20 @@ import (
 )
 
 // Context is a Thrift Context which contains request and response headers.
-type Context interface {
-	context.Context
-
-	// Headers returns the call request headers.
-	Headers() map[string]string
-
-	// ResponseHeaders returns the call response headers.
-	ResponseHeaders() map[string]string
-
-	// SetResponseHeaders sets the given response headers on the context.
-	SetResponseHeaders(map[string]string)
-}
-
-type thriftCtx struct {
-	context.Context
-	reqHeaders  map[string]string
-	respHeaders map[string]string
-}
-
-// Headers gets application headers out of the context.
-func (c *thriftCtx) Headers() map[string]string {
-	return c.reqHeaders
-}
-
-// ResponseHeaders returns the response headers.
-func (c *thriftCtx) ResponseHeaders() map[string]string {
-	return c.respHeaders
-}
-
-// SetResponseHeaders sets the response headers.
-func (c *thriftCtx) SetResponseHeaders(headers map[string]string) {
-	c.respHeaders = headers
-}
+type Context tchannel.ContextWithHeaders
 
 // NewContext returns a Context that can be used to make Thrift calls.
 func NewContext(timeout time.Duration) (Context, context.CancelFunc) {
-	tctx, cancel := tchannel.NewContext(timeout)
-	return &thriftCtx{
-		Context: tctx,
-	}, cancel
+	ctx, cancel := tchannel.NewContext(timeout)
+	return tchannel.WrapWithHeaders(ctx, nil), cancel
 }
 
-// Wrap returns a Thrift Context that wraps around a Context
+// Wrap returns a Thrift Context that wraps around a Context.
 func Wrap(ctx context.Context) Context {
-	return &thriftCtx{
-		Context: ctx,
-	}
+	return tchannel.WrapWithHeaders(ctx, nil)
 }
 
 // WithHeaders returns a Context that can be used to make a call with request headers.
 func WithHeaders(ctx context.Context, headers map[string]string) Context {
-	return &thriftCtx{
-		Context:    ctx,
-		reqHeaders: headers,
-	}
+	return tchannel.WrapWithHeaders(ctx, headers)
 }

--- a/golang/thrift/thrift_test.go
+++ b/golang/thrift/thrift_test.go
@@ -51,7 +51,7 @@ type testArgs struct {
 }
 
 func ctxArg() mock.AnythingOfTypeArgument {
-	return mock.AnythingOfType("*thrift.thriftCtx")
+	return mock.AnythingOfType("*tchannel.headerCtx")
 }
 
 func TestThriftArgs(t *testing.T) {


### PR DESCRIPTION
Since json.Context and thrift.Context both use map[string]string, use a common tchannel.headerCtx to provide implementations for both.