### PR TITLE
Copy meta.thrift and remove thriftIDL

### DIFF
--- a/thrift/meta.thrift
+++ b/thrift/meta.thrift
@@ -1,0 +1,9 @@
+struct HealthStatus {
+    1: required bool ok
+    2: optional string message
+}
+
+service Meta {
+    HealthStatus health()
+    string thriftIDL()
+}

--- a/thrift/meta.thrift
+++ b/thrift/meta.thrift
@@ -5,5 +5,4 @@ struct HealthStatus {
 
 service Meta {
     HealthStatus health()
-    string thriftIDL()
 }


### PR DESCRIPTION
Move the meta.thrift file out of `node/as` since it is common to all languages.

Removed the thriftIDL method till we figure out the correct solution and add library support to implement it.

r: @ShanniLi @Raynos 
cc: @blampe 