### PR TITLE
go: Close with no connections should close immediately

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -442,7 +442,11 @@ func (ch *Channel) Close() {
 	if ch.mutable.l != nil {
 		ch.mutable.l.Close()
 	}
+
 	ch.mutable.state = ChannelStartClose
+	if len(ch.mutable.conns) == 0 {
+		ch.mutable.state = ChannelClosed
+	}
 	ch.mutable.mut.Unlock()
 
 	ch.peers.Close()

--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -51,6 +51,26 @@ func makeCall(ch *Channel, hostPort, service string) error {
 	return err
 }
 
+func TestCloseOnlyListening(t *testing.T) {
+	ch, err := testutils.NewServer(nil)
+	require.NoError(t, err, "NewServer failed")
+
+	// If there are no connections, then the channel should close immediately.
+	ch.Close()
+	assert.Equal(t, ChannelClosed, ch.State())
+	assert.True(t, ch.Closed(), "Channel should be closed")
+}
+
+func TestCloseNewClient(t *testing.T) {
+	ch, err := testutils.NewClient(nil)
+	require.NoError(t, err, "NewServer failed")
+
+	// If there are no connections, then the channel should close immediately.
+	ch.Close()
+	assert.Equal(t, ChannelClosed, ch.State())
+	assert.True(t, ch.Closed(), "Channel should be closed")
+}
+
 // TestCloseStress ensures that once a Channel is closed, it cannot be reached.
 func TestCloseStress(t *testing.T) {
 	CheckStress(t)


### PR DESCRIPTION
cc: @slantin 