### PR TITLE
Clarify stale vs init timeouts

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -83,6 +83,14 @@ function TChannelConnection(channel, socket, direction, socketRemoteAddr) {
 }
 inherits(TChannelConnection, TChannelConnectionBase);
 
+TChannelConnection.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+
+    info.hostPort = self.channel.hostPort;
+
+    return info;
+};
+
 TChannelConnection.prototype.setupSocket = function setupSocket() {
     var self = this;
 
@@ -239,9 +247,7 @@ function sendProtocolError(type, err) {
 TChannelConnection.prototype.onTimedOut = function onTimedOut(err) {
     var self = this;
 
-    self.logger.warn('destroying socket from timeouts', {
-        hostPort: self.channel.hostPort
-    });
+    self.logger.warn('destroying socket from timeouts', self.extendLogInfo({}));
     self.resetAll(err);
 };
 

--- a/node/connection.js
+++ b/node/connection.js
@@ -603,7 +603,11 @@ InitOperation.prototype.onTimeout = function onTimeout(now) {
         elapsed: elapsed,
         timeout: self.timeout
     });
-    self.connection.timedOutEvent.emit(self.connection, err);
+
+    self.connection.logger.warn('destroying due to init timeout', self.connection.extendLogInfo({
+        error: err
+    }));
+    self.connection.resetAll(err);
 };
 
 module.exports = TChannelConnection;

--- a/node/connection.js
+++ b/node/connection.js
@@ -152,7 +152,6 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     self.handler.callIncomingResponseEvent.on(onCallResponse);
     self.handler.pingIncomingResponseEvent.on(onPingResponse);
     self.handler.callIncomingErrorEvent.on(onCallError);
-    self.timedOutEvent.on(onTimedOut);
 
     // TODO: restore dumping from old:
     // var stream = self.socket;
@@ -173,10 +172,6 @@ TChannelConnection.prototype.setupHandler = function setupHandler() {
     // stream = stream
     //     .pipe(self.socket)
     //     ;
-
-    function onTimedOut(err) {
-        self.onTimedOut(err);
-    }
 
     function onWriteError(err) {
         self.onWriteError(err);
@@ -243,13 +238,6 @@ function sendProtocolError(type, err) {
         // TODO: what if you have a write error in a call req cont frame
         self.resetAll(protocolError);
     }
-};
-
-TChannelConnection.prototype.onTimedOut = function onTimedOut(err) {
-    var self = this;
-
-    self.logger.warn('destroying socket from timeouts', self.extendLogInfo({}));
-    self.resetAll(err);
 };
 
 TChannelConnection.prototype.onWriteError = function onWriteError(err) {

--- a/node/connection.js
+++ b/node/connection.js
@@ -87,6 +87,7 @@ TChannelConnection.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
     info.hostPort = self.channel.hostPort;
+    info.socketRemoteAddr = self.socketRemoteAddr;
 
     return info;
 };

--- a/node/errors.js
+++ b/node/errors.js
@@ -110,6 +110,8 @@ module.exports.ConnectionStaleTimeoutError = TypedError({
     type: 'tchannel.connection-stale.timeout',
     message: 'Connection got two timeouts in a row.\n' +
         'Connection has been marked as stale and will be timed out',
+    period: null,
+    elapsed: null,
     lastTimeoutTime: null
 });
 

--- a/node/operations.js
+++ b/node/operations.js
@@ -122,7 +122,10 @@ Operations.prototype._deferResetDueToTimeouts = function _deferResetDueToTimeout
     process.nextTick(opCheckLastTimedout);
 
     function opCheckLastTimedout() {
-        self.connection.timedOutEvent.emit(self.connection, err);
+        self.logger.warn('destroying socket from timeouts', self.connection.extendLogInfo({
+            error: err
+        }));
+        self.connection.resetAll(err);
     }
 };
 

--- a/node/operations.js
+++ b/node/operations.js
@@ -116,7 +116,10 @@ Operations.prototype.checkLastTimeoutTime = function checkLastTimeoutTime(now) {
 Operations.prototype._deferResetDueToTimeouts = function _deferResetDueToTimeouts(now) {
     var self = this;
 
+    var elapsed = now - self.lastTimeoutTime;
     var err = errors.ConnectionStaleTimeoutError({
+        period: self.connectionStalePeriod,
+        elapsed: elapsed,
         lastTimeoutTime: self.lastTimeoutTime
     });
     process.nextTick(opCheckLastTimedout);

--- a/node/operations.js
+++ b/node/operations.js
@@ -105,15 +105,24 @@ Operations.prototype.checkLastTimeoutTime = function checkLastTimeoutTime(now) {
     var self = this;
 
     if (self.lastTimeoutTime &&
-        now > self.lastTimeoutTime + self.connectionStalePeriod) {
-        var err = errors.ConnectionStaleTimeoutError({
-            lastTimeoutTime: self.lastTimeoutTime
-        });
-        process.nextTick(function opCheckLastTimedout() {
-            self.connection.timedOutEvent.emit(self.connection, err);
-        });
+        now > self.lastTimeoutTime + self.connectionStalePeriod
+    ) {
+        self._deferResetDueToTimeouts(now);
     } else if (!self.lastTimeoutTime) {
         self.lastTimeoutTime = now;
+    }
+};
+
+Operations.prototype._deferResetDueToTimeouts = function _deferResetDueToTimeouts(now) {
+    var self = this;
+
+    var err = errors.ConnectionStaleTimeoutError({
+        lastTimeoutTime: self.lastTimeoutTime
+    });
+    process.nextTick(opCheckLastTimedout);
+
+    function opCheckLastTimedout() {
+        self.connection.timedOutEvent.emit(self.connection, err);
     }
 };
 

--- a/node/test/relay-to-dead.js
+++ b/node/test/relay-to-dead.js
@@ -73,17 +73,21 @@ allocCluster.test('relaying to init timeout server', {
             );
 
             assert.equal(cluster.logger.items().length, 0);
-            cluster.logger.whitelist('warn', 'destroying socket from timeouts');
+            cluster.logger.whitelist('warn', 'destroying due to init timeout');
             cluster.logger.whitelist('warn', 'resetting connection');
             cluster.logger.whitelist('warn', 'Got a connection error');
 
             setTimeout(function onTimeout() {
                 var logs = cluster.logger.items();
-                assert.equal(
-                    logs[0].msg, 'destroying socket from timeouts'
-                );
-                assert.equal(logs[1].msg, 'resetting connection');
-                assert.equal(logs[2].msg, 'Got a connection error');
+                assert.equal(logs.length, 3, 'expected 3 logs');
+
+                var record1 = logs[0];
+                var record2 = logs[1];
+                var record3 = logs[2];
+
+                assert.equal(record1.msg, 'destroying due to init timeout');
+                assert.equal(record2.msg, 'resetting connection');
+                assert.equal(record3.msg, 'Got a connection error');
 
                 deadServer.close();
                 assert.end();


### PR DESCRIPTION
- also dropped a (perhaps common) closure allocation in else branch of `Operations#checkLastTimeoutTime`-
- added more log context
- started the `conn.extendLogInfo` pattern

r @kriskowal 