### PR TITLE
Hyperbahn (down/up)Grades: --ringop ++tchannel

### DIFF
--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -41,7 +41,7 @@
     "static-config": "2.1.0",
     "tape-cluster": "2.0.1",
     "tcap": "5.4.2",
-    "tchannel": "2.6.3",
+    "tchannel": "2.6.4",
     "tcurl": "4.8.1",
     "thriftify": "1.0.0-alpha14",
     "uber-statsd-client": "1.3.2",

--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -35,7 +35,7 @@
     "raynos-replr": "0.2.5-port-0-support",
     "readable-stream": "1.0.33-2",
     "ready-signal": "1.2.0",
-    "ringpop": "10.3.0",
+    "ringpop": "10.0.0-beta6",
     "run-parallel": "1.0.0",
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",


### PR DESCRIPTION
Towards isolating change of behavior seen in production, and getting the init vs call timeout clarity of #1211.