### PR TITLE
Hyperbahn: upgrade ringpop to 10.3.0 (again)

### DIFF
--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -35,7 +35,7 @@
     "raynos-replr": "0.2.5-port-0-support",
     "readable-stream": "1.0.33-2",
     "ready-signal": "1.2.0",
-    "ringpop": "10.0.0-beta6",
+    "ringpop": "10.3.0",
     "run-parallel": "1.0.0",
     "safe-json-parse": "4.0.0",
     "static-config": "2.1.0",


### PR DESCRIPTION
Now that we've ship the test_ringpop_10.3 branch, and not been able to reproduce the problems that caused us to back it out.

r @kriskowal 