### PR TITLE
Relay refactor

### DIFF
--- a/node/in_request.js
+++ b/node/in_request.js
@@ -69,6 +69,24 @@ inherits(TChannelInRequest, EventEmitter);
 
 TChannelInRequest.prototype.type = 'tchannel.incoming-request';
 
+TChannelInRequest.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+
+    // TODO: add:
+    // - request id?
+    // - tracing id?
+    // - other?
+    info.inRemoteAddr = self.remoteAddr;
+    info.serviceName = self.serviceName;
+    if (self.endpoint !== null) {
+        info.arg1 = self.endpoint;
+    } else {
+        info.arg1 = String(self.arg1);
+    }
+
+    return info;
+};
+
 TChannelInRequest.prototype.setupTracing = function setupTracing(options) {
     var self = this;
 

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -91,6 +91,16 @@ function RelayRequest(channel, inreq, buildRes) {
     self.peer = null;
 
     self.error = null;
+
+    self.boundOnIdentified = onIdentified;
+
+    function onIdentified(err) {
+        if (err) {
+            self.onError(err);
+        } else {
+            self.onIdentified();
+        }
+    }
 }
 
 RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
@@ -122,20 +132,11 @@ RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
         return;
     }
 
-    self.peer.waitForIdentified(onIdentified);
-
-    function onIdentified(err) {
-        self.onIdentified(err);
-    }
+    self.peer.waitForIdentified(self.boundOnIdentified);
 };
 
-RelayRequest.prototype.onIdentified = function onIdentified(err1) {
+RelayRequest.prototype.onIdentified = function onIdentified() {
     var self = this;
-
-    if (err1) {
-        self.onError(err1);
-        return;
-    }
 
     var identified = false;
     var closing = false;
@@ -189,8 +190,8 @@ RelayRequest.prototype.onIdentified = function onIdentified(err1) {
         self.onResponse(res);
     }
 
-    function onError(err2) {
-        self.onError(err2);
+    function onError(err) {
+        self.onError(err);
     }
 };
 

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -280,19 +280,24 @@ RelayRequest.prototype.onError = function onError(err) {
     // TODO: stat in some cases, e.g. declined / peer not available
 };
 
+RelayRequest.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+
+    info.outRemoteAddr = self.outreq && self.outreq.remoteAddr;
+    info = self.inreq.extendLogInfo(info);
+
+    return info;
+};
+
 RelayRequest.prototype.logError = function logError(err, codeName) {
     var self = this;
 
     var level = errorLogLevel(err, codeName);
 
-    var logOptions = {
+    var logOptions = self.extendLogInfo({
         error: err,
-        isErrorFrame: err.isErrorFrame,
-        outRemoteAddr: self.outreq && self.outreq.remoteAddr,
-        inRemoteAddr: self.inreq.remoteAddr,
-        serviceName: self.inreq.serviceName,
-        outArg1: String(self.inreq.arg1)
-    };
+        isErrorFrame: err.isErrorFrame
+    });
 
     if (err.isErrorFrame) {
         if (level === 'warn') {

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -92,7 +92,12 @@ function RelayRequest(channel, inreq, buildRes) {
 
     self.error = null;
 
+    self.boundOnError = onError;
     self.boundOnIdentified = onIdentified;
+
+    function onError(err) {
+        self.onError(err);
+    }
 
     function onIdentified(err) {
         if (err) {
@@ -178,7 +183,7 @@ RelayRequest.prototype.onIdentified = function onIdentified() {
         retryFlags: self.inreq.retryFlags
     });
     self.outreq.responseEvent.on(onResponse);
-    self.outreq.errorEvent.on(onError);
+    self.outreq.errorEvent.on(self.boundOnError);
 
     if (self.outreq.streamed) {
         self.outreq.sendStreams(self.inreq.arg1, self.inreq.arg2, self.inreq.arg3);
@@ -188,10 +193,6 @@ RelayRequest.prototype.onIdentified = function onIdentified() {
 
     function onResponse(res) {
         self.onResponse(res);
-    }
-
-    function onError(err) {
-        self.onError(err);
     }
 };
 

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -148,24 +148,14 @@ RelayRequest.prototype.createOutRequest = function createOutRequest(host) {
 RelayRequest.prototype.onIdentified = function onIdentified() {
     var self = this;
 
-    var identified = false;
-    var closing = false;
-    for (var i = 0; i < self.peer.connections.length; i++) {
-        if (self.peer.connections[i].remoteName) {
-            identified = true;
-            closing = self.peer.connections[i].closing;
-            if (!closing) break;
-        }
-    }
-
-    if (!identified) {
+    var conn = chooseRelayPeerConnection(self.peer);
+    if (!conn.remoteName) {
         // we get the problem
         self.logger.error('onIdentified called on no connection identified', {
             hostPort: self.peer.hostPort
         });
     }
-
-    if (closing) {
+    if (conn.closing) {
         // most likely
         self.logger.error('onIdentified called on connection closing', {
             hostPort: self.peer.hostPort
@@ -346,4 +336,13 @@ function errorLogLevel(err, codeName) {
         default:
             return 'error';
     }
+}
+
+function chooseRelayPeerConnection(peer) {
+    var conn = null;
+    for (var i = 0; i < peer.connections.length; i++) {
+        conn = peer.connections[i];
+        if (conn.remoteName && !conn.closing) break;
+    }
+    return conn;
 }

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -93,10 +93,15 @@ function RelayRequest(channel, inreq, buildRes) {
     self.error = null;
 
     self.boundOnError = onError;
+    self.boundExtendLogInfo = extendLogInfo;
     self.boundOnIdentified = onIdentified;
 
     function onError(err) {
         self.onError(err);
+    }
+
+    function extendLogInfo(info) {
+        self.extendLogInfo(info);
     }
 
     function onIdentified(err) {
@@ -291,30 +296,33 @@ RelayRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     return info;
 };
 
-RelayRequest.prototype.logError = function logError(err, codeName) {
+RelayRequest.prototype.logError = function relayRequestLogError(err, codeName) {
     var self = this;
+    logError(self.logger, err, codeName, self.boundExtendLogInfo);
+};
 
+function logError(logger, err, codeName, extendLogInfo) {
     var level = errorLogLevel(err, codeName);
 
-    var logOptions = self.extendLogInfo({
+    var logOptions = extendLogInfo({
         error: err,
         isErrorFrame: err.isErrorFrame
     });
 
     if (err.isErrorFrame) {
         if (level === 'warn') {
-            self.logger.warn('forwarding error frame', logOptions);
+            logger.warn('forwarding error frame', logOptions);
         } else if (level === 'info') {
-            self.logger.info('forwarding expected error frame', logOptions);
+            logger.info('forwarding expected error frame', logOptions);
         }
     } else if (level === 'error') {
-        self.logger.error('unexpected error while forwarding', logOptions);
+        logger.error('unexpected error while forwarding', logOptions);
     } else if (level === 'warn') {
-        self.logger.warn('error while forwarding', logOptions);
+        logger.warn('error while forwarding', logOptions);
     } else if (level === 'info') {
-        self.logger.info('expected error while forwarding', logOptions);
+        logger.info('expected error while forwarding', logOptions);
     }
-};
+}
 
 function errorLogLevel(err, codeName) {
     switch (codeName) {


### PR DESCRIPTION
- continues the `foo.extendLogInfo(info)` pattern towards more consistent logging
- pulls key parts out of RelayRequest, to be driven by RelayHandler, to survive in the upcoming lazy path
- drops branched closure allocations
- moves closure allocations to constructor, rather than maybe called methods

r @kriskowal 

cc @jwolski: @Raynos tells me that Ringpop's been using this API, and that this change will require an update in its forwarding path.  We don't consider this a public API nor a breaking change, so major won't be bumping... however I will give you a minor bump, it won't be a 2.6.x.  Note also the crucial change from your perspective is https://github.com/uber/tchannel/commit/c8be0373216a6e0813f49f2d42c1b54a0ad33fb9, which I could ultimately leave out of this branch, and punt the peer selection work until a later lazy branch, let me know how you want to handle this.