### PR TITLE
Add lazy support to v2/{call,cont,header,checksum,error_response}

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,7 @@
     "url": "git@github.com:uber/tchannel"
   },
   "dependencies": {
-    "bufrw": "^0.9.24",
+    "bufrw": "^0.9.25",
     "crc": "^3.2.1",
     "debug-logtron": "5.0.0",
     "error": "^7.0.1",

--- a/node/test/v2/lazy_frame.js
+++ b/node/test/v2/lazy_frame.js
@@ -25,8 +25,7 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 
 var TestBody = require('./lib/test_body.js');
-var Frame = require('../../v2/frame.js');
-var LazyFrame = require('../../v2/lazy_frame.js');
+var v2 = require('../../v2/index.js');
 
 var Bytes = [
     0x00, 0x15,             // size: 2
@@ -38,20 +37,20 @@ var Bytes = [
 
     0x04, 0x64, 0x6f, 0x67, 0x65 // junk bytes
 ];
-var lazyFrame = new LazyFrame(
+var lazyFrame = new v2.LazyFrame(
     0x15, 0x03, 0x01,
     new Buffer(Bytes)
 );
-lazyFrame.bodyRW = Frame.Types[0x03].RW;
+lazyFrame.bodyRW = v2.Frame.Types[0x03].RW;
 
-test('LazyFrame.RW: read/write', testRW.cases(LazyFrame.RW, [
+test('LazyFrame.RW: read/write', testRW.cases(v2.LazyFrame.RW, [
     [
         lazyFrame, Bytes
     ]
 ]));
 
 TestBody.testWith('LazyFrame.readBody', function t(assert) {
-    var frame = LazyFrame.RW.readFrom(new Buffer([
+    var frame = v2.LazyFrame.RW.readFrom(new Buffer([
         0x00, 0x15,             // size: 2
         0x00,                   // type: 1
         0x00,                   // reserved:1
@@ -75,7 +74,7 @@ TestBody.testWith('LazyFrame.readBody', function t(assert) {
 });
 
 TestBody.testWith('LazyFrame.setId', function t(assert) {
-    var frame = LazyFrame.RW.readFrom(new Buffer([
+    var frame = v2.LazyFrame.RW.readFrom(new Buffer([
         0x00, 0x15,             // size: 2
         0x00,                   // type: 1
         0x00,                   // reserved:1
@@ -93,7 +92,7 @@ TestBody.testWith('LazyFrame.setId', function t(assert) {
     assert.equal(frame.id, 0x04);
 
     var buffer = new Buffer(frame.size);
-    LazyFrame.RW.writeInto(frame, buffer, 0);
+    v2.LazyFrame.RW.writeInto(frame, buffer, 0);
 
     assert.deepEqual(
         buffer,

--- a/node/test/v2/lazy_frame.js
+++ b/node/test/v2/lazy_frame.js
@@ -161,6 +161,10 @@ test('CallRequest.RW.lazy', function t(assert) {
         v2.CallRequest.RW.lazy.readService(lazyFrame),
         frame.body.service,
         'CallRequest.RW.lazy.readService');
+    assertReadRes(
+        v2.CallRequest.RW.lazy.readArg1(lazyFrame),
+        Buffer(frame.body.args[0]),
+        'CallRequest.RW.lazy.readArg1');
     assert.equal(
         v2.CallRequest.RW.lazy.isFrameTerminal(lazyFrame),
         !(frame.body.flags & v2.CallFlags.Fragment),

--- a/node/test/v2/lazy_frame.js
+++ b/node/test/v2/lazy_frame.js
@@ -239,3 +239,39 @@ test('CallResponse.RW.lazy', function t(assert) {
         assert.deepEqual(res.value, value, 'expected value from ' + desc);
     }
 });
+
+test('CallRequestCont.RW.lazy', function t(assert) {
+    var frame = new v2.Frame(24,    // frame id
+        new v2.CallRequestCont(     // frame body
+            42,                     // flags
+            v2.Checksum.Types.None, // csum
+            ["key", "turn"]         // args
+        )
+    );
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+
+    // validate basic lazy frame properties
+    assert.equal(lazyFrame.id, frame.id, 'expected frame id');
+    assert.equal(lazyFrame.type, frame.type, 'expected frame type');
+    assert.deepEqual(lazyFrame.buffer.parent, buf.parent,
+        'frame carries a slice into the original read buffer');
+
+    // validate lazy reading
+    assertReadRes(
+        v2.CallRequestCont.RW.lazy.readFlags(lazyFrame),
+        frame.body.flags,
+        'CallRequestCont.RW.lazy.readFlags');
+    assert.equal(
+        v2.CallRequestCont.RW.lazy.isFrameTerminal(lazyFrame),
+        !(frame.body.flags & v2.CallFlags.Fragment),
+        'CallRequestCont.RW.lazy.isFrameTerminal');
+
+    assert.end();
+
+    function assertReadRes(res, value, desc) {
+        assert.ifError(res.err, 'no error from ' + desc);
+        assert.deepEqual(res.value, value, 'expected value from ' + desc);
+    }
+});

--- a/node/test/v2/lazy_frame.js
+++ b/node/test/v2/lazy_frame.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var Buffer = require('buffer').Buffer;
+var bufrw = require('bufrw');
 var test = require('tape');
 var testRW = require('bufrw/test_rw');
 
@@ -109,4 +110,76 @@ TestBody.testWith('LazyFrame.setId', function t(assert) {
     );
 
     assert.end();
+});
+
+test('CallRequest.RW.lazy', function t(assert) {
+    var spanId = Buffer([0x02, 0x04, 0x06, 0x08, 0x0a, 0x0c, 0x0e, 0x10]);
+    var parentId = Buffer([0x01, 0x03, 0x05, 0x07, 0x09, 0x0b, 0x0d, 0x0f]);
+    var traceId = Buffer([0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d, 0x15]);
+    var tracing = new v2.Tracing(
+        spanId, parentId, traceId
+    );
+
+    var frame = new v2.Frame(24,    // frame id
+        new v2.CallRequest(         // frame body
+            42,                     // flags
+            99,                     // ttl
+            tracing,                // tracing
+            "castle",               // service
+            {                       // headers
+                "cn": "mario",      // headers.cn
+                "as": "plumber"     // headers.as
+            },                      //
+            v2.Checksum.Types.None, // csum
+            ["door", "key", "turn"] // args
+        )
+    );
+    var buf = bufrw.toBuffer(v2.Frame.RW, frame);
+
+    var lazyFrame = bufrw.fromBuffer(v2.LazyFrame.RW, buf);
+
+    // validate basic lazy frame properties
+    assert.equal(lazyFrame.id, frame.id, 'expected frame id');
+    assert.equal(lazyFrame.type, frame.type, 'expected frame type');
+    assert.deepEqual(lazyFrame.buffer.parent, buf.parent,
+        'frame carries a slice into the original read buffer');
+
+    // validate call req lazy reading
+    assertReadRes(
+        v2.CallRequest.RW.lazy.readFlags(lazyFrame),
+        frame.body.flags,
+        'CallRequest.RW.lazy.readFlags');
+    assertReadRes(
+        v2.CallRequest.RW.lazy.readTTL(lazyFrame),
+        frame.body.ttl,
+        'CallRequest.RW.lazy.readTTL');
+    assertReadRes(
+        v2.CallRequest.RW.lazy.readTracing(lazyFrame),
+        tracing,
+        'CallRequest.RW.lazy.readTracing');
+    assertReadRes(
+        v2.CallRequest.RW.lazy.readService(lazyFrame),
+        frame.body.service,
+        'CallRequest.RW.lazy.readService');
+    assert.equal(
+        v2.CallRequest.RW.lazy.isFrameTerminal(lazyFrame),
+        !(frame.body.flags & v2.CallFlags.Fragment),
+        'CallRequest.RW.lazy.isFrameTerminal');
+
+    // validate call req lazy writing
+    var newTTL = frame.body.ttl - 15;
+    assert.ifError(
+        v2.CallRequest.RW.lazy.writeTTL(newTTL, lazyFrame).err,
+        'no error from v2.CallRequest.RW.lazy.writeTTL');
+    var newFrame = bufrw.fromBuffer(v2.Frame.RW, lazyFrame.buffer);
+    assert.equal(
+        newFrame.body.ttl, newTTL,
+        'expected new TTL to round trip through eager frame');
+
+    assert.end();
+
+    function assertReadRes(res, value, desc) {
+        assert.ifError(res.err, 'no error from ' + desc);
+        assert.deepEqual(res.value, value, 'expected value from ' + desc);
+    }
 });

--- a/node/v2/call.js
+++ b/node/v2/call.js
@@ -252,6 +252,29 @@ CallResponse.TypeCode = 0x04;
 CallResponse.Codes = ResponseCodes;
 CallResponse.RW = bufrw.Base(callResLength, readCallResFrom, writeCallResInto);
 
+CallResponse.RW.lazy = {};
+
+CallResponse.RW.lazy.flagsOffset = Frame.Overhead;
+CallResponse.RW.lazy.readFlags = function readFlags(frame) {
+    // flags:1
+    return bufrw.UInt8.readFrom(frame.buffer, CallResponse.RW.lazy.flagsOffset);
+};
+
+CallResponse.RW.lazy.codeOffset = CallResponse.RW.lazy.flagsOffset + 1;
+// TODO: readCode?
+
+CallResponse.RW.lazy.tracingOffset = CallResponse.RW.lazy.codeOffset + 1;
+CallResponse.RW.lazy.readTracing = function lazyReadTracing(frame) {
+    // tracing:24 traceflags:1
+    return Tracing.RW.readFrom(frame.buffer, CallResponse.RW.lazy.tracingOffset);
+};
+
+CallResponse.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
+    var flags = CallResponse.RW.lazy.readFlags(frame);
+    var frag = flags & CallFlags.Fragment;
+    return !frag;
+};
+
 function callResLength(body) {
     var res;
     var length = 0;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -124,6 +124,20 @@ CallResponseCont.TypeCode = 0x14;
 CallResponseCont.Cont = CallResponseCont;
 CallResponseCont.RW = bufrw.Base(callResContLength, readCallResContFrom, writeCallResContInto);
 
+CallResponseCont.RW.lazy = {};
+
+CallResponseCont.RW.lazy.flagsOffset = Frame.Overhead;
+CallResponseCont.RW.lazy.readFlags = function readFlags(frame) {
+    // flags:1
+    return bufrw.UInt8.readFrom(frame.buffer, CallResponseCont.RW.lazy.flagsOffset);
+};
+
+CallResponseCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
+    var flags = CallResponseCont.RW.lazy.readFlags(frame);
+    var frag = flags & CallFlags.Fragment;
+    return !frag;
+};
+
 function callResContLength(body) {
     var res;
     var length = 0;

--- a/node/v2/cont.js
+++ b/node/v2/cont.js
@@ -23,6 +23,8 @@
 var bufrw = require('bufrw');
 var Checksum = require('./checksum');
 var ArgsRW = require('./args');
+var Frame = require('./frame');
+var CallFlags = require('./call_flags');
 var argsrw = ArgsRW();
 
 // flags:1 csumtype:1 (csum:4){0,1} (arg~2)+
@@ -38,6 +40,20 @@ function CallRequestCont(flags, csum, args) {
 CallRequestCont.TypeCode = 0x13;
 CallRequestCont.Cont = CallRequestCont;
 CallRequestCont.RW = bufrw.Base(callReqContLength, readCallReqContFrom, writeCallReqContInto);
+
+CallRequestCont.RW.lazy = {};
+
+CallRequestCont.RW.lazy.flagsOffset = Frame.Overhead;
+CallRequestCont.RW.lazy.readFlags = function readFlags(frame) {
+    // flags:1
+    return bufrw.UInt8.readFrom(frame.buffer, CallRequestCont.RW.lazy.flagsOffset);
+};
+
+CallRequestCont.RW.lazy.isFrameTerminal = function isFrameTerminal(frame) {
+    var flags = CallRequestCont.RW.lazy.readFlags(frame);
+    var frag = flags & CallFlags.Fragment;
+    return !frag;
+};
 
 function callReqContLength(body) {
     var res;

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -167,4 +167,10 @@ ErrorResponse.RW = bufrw.Struct(ErrorResponse, [
     }}},
 ]);
 
+ErrorResponse.RW.lazy = {};
+
+ErrorResponse.RW.lazy.isFrameTerminal = function isFrameTerminal() {
+    return true;
+};
+
 module.exports = ErrorResponse;

--- a/node/v2/header.js
+++ b/node/v2/header.js
@@ -192,6 +192,30 @@ HeaderRW.prototype.readFrom = function readFrom(buffer, offset) {
     return bufrw.ReadResult.just(offset, headers);
 };
 
+HeaderRW.prototype.lazySkip = function lazySkip(frame, offset) {
+    var self = this;
+
+    // TODO: conspire with Call(Request,Response) to memoize headers start/end
+    // offsets, maybe even start of each key?
+
+    var res = self.countrw.readFrom(frame.buffer, offset);
+    if (res.err) return res;
+    offset = res.offset;
+    var n = res.value;
+
+    for (var i = 0; i < n; i++) {
+        res = self.keyrw.sizerw.readFrom(frame.buffer, offset);
+        if (res.err) return res;
+        offset = res.offset + res.value;
+
+        res = self.valrw.sizerw.readFrom(frame.buffer, offset);
+        if (res.err) return res;
+        offset = res.offset + res.value;
+    }
+
+    return bufrw.ReadResult.just(offset, null);
+};
+
 module.exports = HeaderRW;
 
 // nh:1 (hk~1 hv~1){nh}


### PR DESCRIPTION
Add lazy RW support to key v2 parts.

r @kriskowal @rf 