### PR TITLE
go: Add support for setting shard key on calls

### DIFF
--- a/golang/calloptions.go
+++ b/golang/calloptions.go
@@ -52,12 +52,15 @@ func (c *CallOptions) setHeaders(headers transportHeaders) {
 		c = defaultCallOptions
 	}
 
-	format := Raw
-	if c.Format != "" {
-		format = c.Format
-	}
+	headers[ArgScheme] = Raw.String()
+	c.overrideHeaders(headers)
+}
 
-	headers[ArgScheme] = format.String()
+// overrideHeaders sets headers if the call options contains non-default values.
+func (c *CallOptions) overrideHeaders(headers transportHeaders) {
+	if c.Format != "" {
+		headers[ArgScheme] = c.Format.String()
+	}
 	if c.ShardKey != "" {
 		headers[ShardKey] = c.ShardKey
 	}

--- a/golang/calloptions.go
+++ b/golang/calloptions.go
@@ -40,6 +40,9 @@ type CallOptions struct {
 	// Format is arg scheme used for this call, sent in the "as" header.
 	// This header is only set if the Format is set.
 	Format Format
+
+	// ShardKey determines where this call request belongs, used with ringpop applications.
+	ShardKey string
 }
 
 var defaultCallOptions = &CallOptions{}
@@ -55,6 +58,9 @@ func (c *CallOptions) setHeaders(headers transportHeaders) {
 	}
 
 	headers[ArgScheme] = format.String()
+	if c.ShardKey != "" {
+		headers[ShardKey] = c.ShardKey
+	}
 }
 
 // setResponseHeaders copies some headers from the incoming call request to the response.

--- a/golang/context.go
+++ b/golang/context.go
@@ -33,8 +33,9 @@ type contextKey int
 const contextKeyTChannel = 1
 
 type tchannelCtxParams struct {
-	span *Span
-	call IncomingCall
+	span    *Span
+	call    IncomingCall
+	options *CallOptions
 }
 
 // IncomingCall exposes properties for incoming calls through the context.
@@ -88,6 +89,13 @@ func CurrentCall(ctx context.Context) IncomingCall {
 func CurrentSpan(ctx context.Context) *Span {
 	if params := getTChannelParams(ctx); params != nil {
 		return params.span
+	}
+	return nil
+}
+
+func currentCallOptions(ctx context.Context) *CallOptions {
+	if params := getTChannelParams(ctx); params != nil {
+		return params.options
 	}
 	return nil
 }

--- a/golang/context_builder.go
+++ b/golang/context_builder.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// ContextBuilder stores all TChannel-specific parameters that will
+// be stored inside of a context.
+type ContextBuilder struct {
+	// If Timeout is zero, Build will default to defaultTimeout.
+	Timeout time.Duration
+
+	// Headers are application headers that json/thrift will encode into arg2.
+	Headers map[string]string
+
+	// CallOptions are TChannel call options for the specific call.
+	CallOptions CallOptions
+
+	// Hidden fields: we do not want users outside of tchannel to set these.
+	incomingCall IncomingCall
+	span         *Span
+}
+
+// NewContextBuilder returns a builder that can be used to create a Context.
+func NewContextBuilder(timeout time.Duration) *ContextBuilder {
+	return &ContextBuilder{
+		Timeout: timeout,
+	}
+}
+
+// SetTimeout sets the timeout for the Context.
+func (cb *ContextBuilder) SetTimeout(timeout time.Duration) *ContextBuilder {
+	cb.Timeout = timeout
+	return cb
+}
+
+// AddHeader adds a single application header to the Context.
+func (cb *ContextBuilder) AddHeader(key, value string) *ContextBuilder {
+	if cb.Headers == nil {
+		cb.Headers = map[string]string{key: value}
+	} else {
+		cb.Headers[key] = value
+	}
+	return cb
+}
+
+// SetHeaders sets the application headers for this Context.
+func (cb *ContextBuilder) SetHeaders(headers map[string]string) *ContextBuilder {
+	cb.Headers = headers
+	return cb
+}
+
+// SetShardKey sets the ShardKey call option ("sk" transport header).
+func (cb *ContextBuilder) SetShardKey(sk string) *ContextBuilder {
+	cb.CallOptions.ShardKey = sk
+	return cb
+}
+
+// SetFormat sets the Format call option ("as" transport header).
+func (cb *ContextBuilder) SetFormat(f Format) *ContextBuilder {
+	cb.CallOptions.Format = f
+	return cb
+}
+
+// SetIncomingCallForTest sets an IncomingCall in the context.
+// This should only be used in unit tests.
+func (cb *ContextBuilder) SetIncomingCallForTest(call IncomingCall) *ContextBuilder {
+	return cb.setIncomingCall(call)
+}
+
+// SetSpanForTest sets a tracing span in the context.
+// This should only be used in unit tests.
+func (cb *ContextBuilder) SetSpanForTest(span *Span) *ContextBuilder {
+	return cb.setSpan(span)
+}
+
+func (cb *ContextBuilder) setSpan(span *Span) *ContextBuilder {
+	cb.span = span
+	return cb
+}
+
+func (cb *ContextBuilder) setIncomingCall(call IncomingCall) *ContextBuilder {
+	cb.incomingCall = call
+	return cb
+}
+
+// Build returns a ContextWithHeaders that can be used to make calls.
+func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
+	timeout := cb.Timeout
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	params := &tchannelCtxParams{
+		span: cb.span,
+		call: cb.incomingCall,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx = context.WithValue(ctx, contextKeyTChannel, params)
+	return WrapWithHeaders(ctx, cb.Headers), cancel
+}

--- a/golang/context_builder.go
+++ b/golang/context_builder.go
@@ -36,7 +36,7 @@ type ContextBuilder struct {
 	Headers map[string]string
 
 	// CallOptions are TChannel call options for the specific call.
-	CallOptions CallOptions
+	CallOptions *CallOptions
 
 	// Hidden fields: we do not want users outside of tchannel to set these.
 	incomingCall IncomingCall
@@ -74,12 +74,18 @@ func (cb *ContextBuilder) SetHeaders(headers map[string]string) *ContextBuilder 
 
 // SetShardKey sets the ShardKey call option ("sk" transport header).
 func (cb *ContextBuilder) SetShardKey(sk string) *ContextBuilder {
+	if cb.CallOptions == nil {
+		cb.CallOptions = new(CallOptions)
+	}
 	cb.CallOptions.ShardKey = sk
 	return cb
 }
 
 // SetFormat sets the Format call option ("as" transport header).
 func (cb *ContextBuilder) SetFormat(f Format) *ContextBuilder {
+	if cb.CallOptions == nil {
+		cb.CallOptions = new(CallOptions)
+	}
 	cb.CallOptions.Format = f
 	return cb
 }
@@ -114,8 +120,9 @@ func (cb *ContextBuilder) Build() (ContextWithHeaders, context.CancelFunc) {
 	}
 
 	params := &tchannelCtxParams{
-		span: cb.span,
-		call: cb.incomingCall,
+		options: cb.CallOptions,
+		span:    cb.span,
+		call:    cb.incomingCall,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/golang/context_test.go
+++ b/golang/context_test.go
@@ -1,5 +1,4 @@
 // Copyright (c) 2015 Uber Technologies, Inc.
-
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -18,29 +17,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tchannel
+package tchannel_test
 
 import (
 	"testing"
 	"time"
 
+	. "github.com/uber/tchannel/golang"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel/golang/testutils"
 )
 
-type mockIncomingCall struct {
-	callerName string
-}
-
-func (m *mockIncomingCall) CallerName() string {
-	return m.callerName
-}
-
-var (
-	cn = "hello"
-)
+var cn = "hello"
 
 func TestWrapContextForTest(t *testing.T) {
-	call := &mockIncomingCall{callerName: cn}
+	call := testutils.NewIncomingCall(cn)
 	ctx, cancel := NewContext(time.Second)
 	defer cancel()
 	actual := WrapContextForTest(ctx, call)

--- a/golang/context_test.go
+++ b/golang/context_test.go
@@ -45,7 +45,7 @@ func TestWrapContextForTest(t *testing.T) {
 func TestShardKeyPropagates(t *testing.T) {
 	WithVerifiedServer(t, nil, func(ch *Channel, hostPort string) {
 		peerInfo := ch.PeerInfo()
-		registerFunc(t, ch, "test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+		testutils.RegisterFunc(t, ch, "test", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			return &raw.Res{
 				Arg3: []byte(CurrentCall(ctx).ShardKey()),
 			}, nil

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -224,6 +224,11 @@ func (call *InboundCall) CallerName() string {
 	return call.headers[CallerName]
 }
 
+// ShardKey returns the shard key from the ShardKey transport header.
+func (call *InboundCall) ShardKey() string {
+	return call.headers[ShardKey]
+}
+
 // Reads the entire operation name (arg1) from the request stream.
 func (call *InboundCall) readOperation() error {
 	var arg1 []byte

--- a/golang/inbound_test.go
+++ b/golang/inbound_test.go
@@ -43,7 +43,7 @@ func TestActiveCallReq(t *testing.T) {
 		gotCall := make(chan struct{})
 		unblock := make(chan struct{})
 
-		registerFunc(t, ch, "blocked", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
+		testutils.RegisterFunc(t, ch, "blocked", func(ctx context.Context, args *raw.Args) (*raw.Res, error) {
 			gotCall <- struct{}{}
 			<-unblock
 			return &raw.Res{}, nil

--- a/golang/messages.go
+++ b/golang/messages.go
@@ -151,6 +151,9 @@ const (
 	// likely to fail in the same way if they were to fail.
 	FailureDomain TransportHeaderName = "fd"
 
+	// ShardKey header value is used by ringpop to deliver calls to a specific tchannel instance.
+	ShardKey TransportHeaderName = "sk"
+
 	// RetryFlags header specifies whether retry policies.
 	RetryFlags TransportHeaderName = "re"
 

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -66,6 +66,12 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		return nil, ErrConnectionClosed
 	}
 
+	if opts := currentCallOptions(ctx); opts != nil {
+		// TODO(prashant): Figure out whether we want callOptions as BeginCall argument
+		// and as a Context value.
+		callOptions = opts
+	}
+
 	headers := transportHeaders{
 		CallerName: c.localPeerInfo.ServiceName,
 	}

--- a/golang/outbound.go
+++ b/golang/outbound.go
@@ -66,16 +66,13 @@ func (c *Connection) beginCall(ctx context.Context, serviceName string, callOpti
 		return nil, ErrConnectionClosed
 	}
 
-	if opts := currentCallOptions(ctx); opts != nil {
-		// TODO(prashant): Figure out whether we want callOptions as BeginCall argument
-		// and as a Context value.
-		callOptions = opts
-	}
-
 	headers := transportHeaders{
 		CallerName: c.localPeerInfo.ServiceName,
 	}
 	callOptions.setHeaders(headers)
+	if opts := currentCallOptions(ctx); opts != nil {
+		opts.overrideHeaders(headers)
+	}
 
 	call := new(OutboundCall)
 	call.mex = mex

--- a/golang/testutils/call.go
+++ b/golang/testutils/call.go
@@ -26,16 +26,26 @@ import "github.com/uber/tchannel/golang"
 // ensure it's only compiled with tests.
 
 // FakeIncomingCall implements IncomingCall interface.
+// Note: the F suffix for the fields is to clash with the method name.
 type FakeIncomingCall struct {
-	callerName string
+	// CallerNameF is the calling service's name.
+	CallerNameF string
+
+	// ShardKeyF is the intended destination for this call.
+	ShardKeyF string
 }
 
 // CallerName returns the caller name as specified in the fake call.
 func (f *FakeIncomingCall) CallerName() string {
-	return f.callerName
+	return f.CallerNameF
+}
+
+// ShardKey returns the shard key as specified in the fake call.
+func (f *FakeIncomingCall) ShardKey() string {
+	return f.ShardKeyF
 }
 
 // NewIncomingCall creates an incoming call for tests.
 func NewIncomingCall(callerName string) tchannel.IncomingCall {
-	return &FakeIncomingCall{callerName: callerName}
+	return &FakeIncomingCall{CallerNameF: callerName}
 }

--- a/golang/thrift/thrift_test.go
+++ b/golang/thrift/thrift_test.go
@@ -28,13 +28,13 @@ import (
 
 	// Test is in a separate package to avoid circular dependencies.
 
-	"github.com/uber/tchannel/golang/testutils"
 	. "github.com/uber/tchannel/golang/thrift"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	tchannel "github.com/uber/tchannel/golang"
+	"github.com/uber/tchannel/golang/testutils"
 	gen "github.com/uber/tchannel/golang/thrift/gen-go/test"
 	"github.com/uber/tchannel/golang/thrift/mocks"
 )

--- a/golang/tracing.go
+++ b/golang/tracing.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/uber/tchannel/golang/typed"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -105,13 +104,4 @@ func (s Span) NewChildSpan() *Span {
 		childSpan.spanID = uint64(traceRng.Int63())
 	}
 	return childSpan
-}
-
-// CurrentSpan returns the Span value for the provided Context
-func CurrentSpan(ctx context.Context) *Span {
-	if span := ctx.Value(contextKeyTracing); span != nil {
-		return span.(*Span)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This change refactors how contexts are built and where TChannel parameters are stored. We use a single context Value to store all TChannel parameters to avoid creating redundant contexts and avoiding O(n) lookup (where n is the number rof values).

There is still WIP to figure out how best to deal with CallOptions, as now we have two methods:
 - directly when doing BeginCall
 - as part of the Context