### PR TITLE
Fix lbpool encoding

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -259,7 +259,8 @@ TChannelHTTP.prototype.forwardToHTTP = function forwardToHTTP(tchannel, options,
 
 TChannelHTTP.prototype._forwardToLBPool = function _forwardToLBPool(options, inreq, outres, callback) {
     var self = this;
-
+    if (!options) { options = {}; }
+    options.encoding = null;
     var data = inreq.bodyStream || inreq.bodyArg; // lb_pool likes polymorphism
     self.lbpool.request(options, data, onResponse);
 


### PR DESCRIPTION
Messed up git on #1225, so send again
r: @joshua @ShanniLi @kriskowal 
cc: @davewhat @vipulaneja 
lbpool by default use utf8 as encoding, which is not valid when a binary response is present.

https://github.com/Voxer/lb_pool/blob/6f53c5c4ad8b6e0dd6899fb9a9f35b710c8300de/pool_endpoint_request.js#L137