### PR TITLE
Better req/res logging

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -198,13 +198,9 @@ function onResponseError(err, req) {
         return;
     }
 
-    // TODO: req.extendLogInfo
-    var loggingOptions = req.res.extendLogInfo({
-        error: err,
-        arg1: String(req.arg1),
-        serviceName: req.serviceName,
-        socketRemoteAddr: self.socketRemoteAddr
-    });
+    var loggingOptions = req.extendLogInfo(req.res.extendLogInfo({
+        error: err
+    }));
 
     if (req.res.state === States.Done) {
         var arg2 = isStringOrBuffer(req.res.arg2) ?

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -204,9 +204,7 @@ function onResponseError(err, req) {
         ok: req.res.ok,
         type: req.res.type,
         serviceName: req.serviceName,
-        state: req.res.state === States.Done ? 'Done' :
-            req.res.state === States.Error ? 'Error' :
-            'Unknown',
+        state: States.describe(req.res.state),
         socketRemoteAddr: self.socketRemoteAddr
     };
 

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -198,15 +198,13 @@ function onResponseError(err, req) {
         return;
     }
 
-    var loggingOptions = {
+    // TODO: req.extendLogInfo
+    var loggingOptions = req.res.extendLogInfo({
         error: err,
         arg1: String(req.arg1),
-        ok: req.res.ok,
-        type: req.res.type,
         serviceName: req.serviceName,
-        state: States.describe(req.res.state),
         socketRemoteAddr: self.socketRemoteAddr
-    };
+    });
 
     if (req.res.state === States.Done) {
         var arg2 = isStringOrBuffer(req.res.arg2) ?
@@ -218,9 +216,6 @@ function onResponseError(err, req) {
         loggingOptions.arg2 = String(arg2).slice(0, 50);
         loggingOptions.bufArg3 = arg3.slice(0, 50);
         loggingOptions.arg3 = String(arg3).slice(0, 50);
-    } else if (req.res.state === States.Error) {
-        loggingOptions.codeString = req.res.codeString;
-        loggingOptions.errMessage = req.res.message;
     }
 
     if ((err.type === 'tchannel.response-already-started' ||

--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -193,6 +193,11 @@ TChannelConnectionBase.prototype.onResponseError =
 function onResponseError(err, req) {
     var self = this;
 
+    // don't log if we get further timeout errors for already timed out response
+    if (req.timedOut && errors.classify(err) === 'Timeout') {
+        return;
+    }
+
     var loggingOptions = {
         error: err,
         arg1: String(req.arg1),

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -72,11 +72,14 @@ TChannelInRequest.prototype.type = 'tchannel.incoming-request';
 TChannelInRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
+    info.requestType = self.type;
+    info.requestState = States.describe(self.state);
+
     // TODO: add:
     // - request id?
     // - tracing id?
     // - other?
-    info.inRemoteAddr = self.remoteAddr;
+    info.requestRemoteAddr = self.remoteAddr;
     info.serviceName = self.serviceName;
     if (self.endpoint !== null) {
         info.arg1 = self.endpoint;

--- a/node/in_request.js
+++ b/node/in_request.js
@@ -72,19 +72,20 @@ TChannelInRequest.prototype.type = 'tchannel.incoming-request';
 TChannelInRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
-    info.requestType = self.type;
-    info.requestState = States.describe(self.state);
-
     // TODO: add:
     // - request id?
     // - tracing id?
     // - other?
+
+    info.requestType = self.type;
+    info.requestState = States.describe(self.state);
     info.requestRemoteAddr = self.remoteAddr;
     info.serviceName = self.serviceName;
+
     if (self.endpoint !== null) {
-        info.arg1 = self.endpoint;
+        info.requestArg1 = self.endpoint;
     } else {
-        info.arg1 = String(self.arg1);
+        info.requestArg1 = String(self.arg1);
     }
 
     return info;

--- a/node/in_response.js
+++ b/node/in_response.js
@@ -63,6 +63,16 @@ inherits(TChannelInResponse, EventEmitter);
 
 TChannelInResponse.prototype.type = 'tchannel.incoming-response';
 
+TChannelInResponse.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+
+    info.ok = self.ok;
+    info.type = self.type;
+    info.state = States.describe(self.state);
+
+    return info;
+};
+
 TChannelInResponse.prototype.onFinish = function onFinish(_arg, self) {
     self.state = States.Done;
 };

--- a/node/in_response.js
+++ b/node/in_response.js
@@ -66,9 +66,9 @@ TChannelInResponse.prototype.type = 'tchannel.incoming-response';
 TChannelInResponse.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
-    info.ok = self.ok;
-    info.type = self.type;
-    info.state = States.describe(self.state);
+    info.responseType = self.type;
+    info.responseState = States.describe(self.state);
+    info.responseOk = self.ok;
 
     return info;
 };

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -302,9 +302,11 @@ TChannelOutRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     info.requestRemoteAddr = self.remoteAddr;
     info.serviceName = self.serviceName;
 
-    info.reqRemoteAddr = self.remoteAddr;
-    info.serviceName = self.serviceName;
-    info.outArg1 = String(self.arg1);
+    if (self.endpoint !== null) {
+        info.requestArg1 = self.endpoint;
+    } else {
+        info.requestArg1 = String(self.arg1);
+    }
 
     return info;
 };

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -296,9 +296,16 @@ TChannelOutRequest.prototype.emitError = function emitError(err) {
 
 TChannelOutRequest.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
+
+    info.requestType = self.type;
+    info.requestState = States.describe(self.state);
+    info.requestRemoteAddr = self.remoteAddr;
+    info.serviceName = self.serviceName;
+
     info.reqRemoteAddr = self.remoteAddr;
     info.serviceName = self.serviceName;
     info.outArg1 = String(self.arg1);
+
     return info;
 };
 

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -66,6 +66,16 @@ inherits(TChannelOutResponse, EventEmitter);
 
 TChannelOutResponse.prototype.type = 'tchannel.outgoing-response';
 
+TChannelOutResponse.prototype.extendLogInfo = function extendLogInfo(info) {
+    var self = this;
+
+    info.ok = self.ok;
+    info.type = self.type;
+    info.state = States.describe(self.state);
+
+    return info;
+};
+
 TChannelOutResponse.prototype._sendCallResponse = function _sendCallResponse(args, isLast) {
     var self = this;
     throw errors.UnimplementedMethod({

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -69,9 +69,14 @@ TChannelOutResponse.prototype.type = 'tchannel.outgoing-response';
 TChannelOutResponse.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
-    info.responseOk = self.ok;
     info.responseType = self.type;
     info.responseState = States.describe(self.state);
+    info.responseOk = self.ok;
+    info.responseCode = self.code;
+    info.responseCodeString = self.codeString;
+    info.responseErrorMessage = self.message;
+    info.responseStart = self.start;
+    info.responseEnd = self.end;
 
     return info;
 };
@@ -217,13 +222,10 @@ TChannelOutResponse.prototype.emitFinish = function emitFinish() {
 
     if (self.end) {
         self.logger.warn('out response double emitFinish', self.extendLogInfo({
-            end: self.end,
             now: now,
             serviceName: self.inreq.serviceName,
             cn: self.inreq.headers.cn,
             endpoint: String(self.inreq.arg1),
-            codeString: self.codeString,
-            errorMessage: self.message,
             remoteAddr: self.inreq.connection.socketRemoteAddr
         }));
         return;
@@ -295,10 +297,6 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
             cn: self.inreq.headers.cn,
             endpoint: self.inreq.endpoint,
             remoteAddr: self.inreq.remoteAddr,
-
-            end: self.end,
-            codeString: self.codeString,
-            errorMessage: self.message,
             hasResponse: !!self.arg3
         });
 

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -69,9 +69,9 @@ TChannelOutResponse.prototype.type = 'tchannel.outgoing-response';
 TChannelOutResponse.prototype.extendLogInfo = function extendLogInfo(info) {
     var self = this;
 
-    info.ok = self.ok;
-    info.type = self.type;
-    info.state = States.describe(self.state);
+    info.responseOk = self.ok;
+    info.responseType = self.type;
+    info.responseState = States.describe(self.state);
 
     return info;
 };

--- a/node/out_response.js
+++ b/node/out_response.js
@@ -119,9 +119,7 @@ TChannelOutResponse.prototype.sendParts = function sendParts(parts, isLast) {
             // TODO: log warn
             break;
         default:
-            self.channel.logger.error('TChannelOutResponse is in a wrong state', {
-                state: self.state
-            });
+            self.channel.logger.error('TChannelOutResponse is in a wrong state', self.extendLogInfo({}));
             break;
     }
 };
@@ -218,7 +216,7 @@ TChannelOutResponse.prototype.emitFinish = function emitFinish() {
     var now = self.timers.now();
 
     if (self.end) {
-        self.logger.warn('out response double emitFinish', {
+        self.logger.warn('out response double emitFinish', self.extendLogInfo({
             end: self.end,
             now: now,
             serviceName: self.inreq.serviceName,
@@ -226,11 +224,8 @@ TChannelOutResponse.prototype.emitFinish = function emitFinish() {
             endpoint: String(self.inreq.arg1),
             codeString: self.codeString,
             errorMessage: self.message,
-            remoteAddr: self.inreq.connection.socketRemoteAddr,
-            state: self.state,
-
-            isOk: self.ok
-        });
+            remoteAddr: self.inreq.connection.socketRemoteAddr
+        }));
         return;
     }
 
@@ -280,10 +275,10 @@ TChannelOutResponse.prototype.sendOk = function sendOk(res1, res2) {
 TChannelOutResponse.prototype.sendNotOk = function sendNotOk(res1, res2) {
     var self = this;
     if (self.state === States.Error) {
-        self.logger.error('cannot send application error, already sent error frame', {
+        self.logger.error('cannot send application error, already sent error frame', self.extendLogInfo({
             res1: res1,
             res2: res2
-        });
+        }));
     } else {
         self.setOk(false);
         self.send(res1, res2);
@@ -295,7 +290,7 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
 
     /* send calls after finish() should be swallowed */
     if (self.end) {
-        var logOptions = {
+        var logOptions = self.extendLogInfo({
             serviceName: self.inreq.serviceName,
             cn: self.inreq.headers.cn,
             endpoint: self.inreq.endpoint,
@@ -304,10 +299,8 @@ TChannelOutResponse.prototype.send = function send(res1, res2) {
             end: self.end,
             codeString: self.codeString,
             errorMessage: self.message,
-            isOk: self.ok,
-            hasResponse: !!self.arg3,
-            state: self.state
-        };
+            hasResponse: !!self.arg3
+        });
 
         if (self.inreq && self.inreq.timedOut) {
             self.logger.info('OutResponse.send() after inreq timed out', logOptions);

--- a/node/reqres_states.js
+++ b/node/reqres_states.js
@@ -24,3 +24,22 @@ module.exports.Initial = 0;
 module.exports.Streaming = 1;
 module.exports.Done = 2;
 module.exports.Error = 3;
+
+module.exports.classify = function classify(state) {
+    switch (state) {
+        case module.exports.Initial:
+            return 'Initial';
+        case module.exports.Streaming:
+            return 'Streaming';
+        case module.exports.Done:
+            return 'Done';
+        case module.exports.Error:
+            return 'Error';
+        default:
+            return null;
+    }
+};
+
+module.exports.describe = function describe(state) {
+    return module.exports.classify(state) || 'Unknown(' + state + ')';
+};

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -97,14 +97,13 @@ allocCluster.test('sending OK OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Done');
-        assert.equal(record1.msg,
-            'outgoing response has an error');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record1.msg, 'outgoing response has an error');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Done');
+        assert.equal(record1.meta.responseOk, true);
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, true);
-        assert.equal(record1.meta.ok, true);
 
         assert.end();
     }
@@ -146,14 +145,13 @@ allocCluster.test('sending OK NOT_OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Done');
-        assert.equal(record1.msg,
-            'outgoing response has an error');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record1.msg, 'outgoing response has an error');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Done');
+        assert.equal(record1.meta.responseOk, true);
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, false);
-        assert.equal(record1.meta.ok, true);
 
         assert.end();
     }
@@ -206,10 +204,9 @@ allocCluster.test('sending OK ERROR_FRAME', {
         assert.equal(record1.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err1.message, 'Error: foobar');
 
-        assert.equal(record2.meta.state, 'Done');
-        assert.equal(record2.msg,
-            'outgoing response has an error');
-        assert.equal(record2.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record2.msg, 'outgoing response has an error');
+        assert.equal(record2.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record2.meta.responseState, 'Done');
         assert.ok(record2.meta.arg3.indexOf('foobar') >= 0);
         assert.equal(err2.method, 'sendError');
         assert.equal(err2.type, 'tchannel.response-already-done');
@@ -256,14 +253,13 @@ allocCluster.test('sending NOT_OK OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Done');
-        assert.equal(record1.msg,
-            'outgoing response has an error');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record1.msg, 'outgoing response has an error');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Done');
+        assert.equal(record1.meta.responseOk, false);
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, true);
-        assert.equal(record1.meta.ok, false);
 
         assert.end();
     }
@@ -305,14 +301,13 @@ allocCluster.test('sending NOT_OK NOT_OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Done');
-        assert.equal(record1.msg,
-            'outgoing response has an error');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record1.msg, 'outgoing response has an error');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Done');
+        assert.equal(record1.meta.responseOk, false);
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, false);
-        assert.equal(record1.meta.ok, false);
 
         assert.end();
     }
@@ -365,10 +360,9 @@ allocCluster.test('sending NOT_OK ERROR_FRAME', {
         assert.equal(record1.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err1.message, 'Error: foobar');
 
-        assert.equal(record2.meta.state, 'Done');
-        assert.equal(record2.msg,
-            'outgoing response has an error');
-        assert.equal(record2.meta.arg1, 'DoubleResponse::method');
+        assert.equal(record2.msg, 'outgoing response has an error');
+        assert.equal(record2.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record2.meta.responseState, 'Done');
         assert.ok(record2.meta.arg3.indexOf('foobar') >= 0);
         assert.equal(err2.method, 'sendError');
         assert.equal(err2.type, 'tchannel.response-already-done');
@@ -425,12 +419,11 @@ allocCluster.test('sending ERROR_FRAME OK', {
         assert.equal(record1.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err1.message, 'Error: foobar');
 
-        assert.equal(record2.msg,
-            'outgoing response has an error');
-        assert.equal(record2.meta.state, 'Error');
-        assert.equal(record2.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record2.meta.codeString, 'UnexpectedError');
-        assert.equal(record2.meta.errMessage, 'Unexpected Error');
+        assert.equal(record2.msg, 'outgoing response has an error');
+        assert.equal(record2.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record2.meta.responseState, 'Error');
+        assert.equal(record2.meta.responseCodeString, 'UnexpectedError');
+        assert.equal(record2.meta.responseErrorMessage, 'Unexpected Error');
         assert.equal(err2.method, 'setOk');
         assert.equal(err2.ok, true);
         assert.equal(err2.type, 'tchannel.response-already-started');
@@ -485,12 +478,11 @@ allocCluster.test('sending ERROR_FRAME NOT_OK', {
         assert.equal(record1.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err1.message, 'Error: foobar');
 
-        assert.equal(record2.msg,
-            'outgoing response has an error');
-        assert.equal(record2.meta.state, 'Error');
-        assert.equal(record2.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record2.meta.codeString, 'UnexpectedError');
-        assert.equal(record2.meta.errMessage, 'Unexpected Error');
+        assert.equal(record2.msg, 'outgoing response has an error');
+        assert.equal(record2.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record2.meta.responseState, 'Error');
+        assert.equal(record2.meta.responseCodeString, 'UnexpectedError');
+        assert.equal(record2.meta.responseErrorMessage, 'Unexpected Error');
         assert.equal(err2.method, 'setOk');
         assert.equal(err2.ok, false);
         assert.equal(err2.type, 'tchannel.response-already-started');
@@ -552,12 +544,11 @@ allocCluster.test('sending ERROR_FRAME ERROR_FRAME', {
         assert.equal(record2.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err2.message, 'Error: foobar');
 
-        assert.equal(record3.meta.state, 'Error');
-        assert.equal(record3.msg,
-            'outgoing response has an error');
-        assert.equal(record3.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record3.meta.codeString, 'UnexpectedError');
-        assert.equal(record3.meta.errMessage, 'Unexpected Error');
+        assert.equal(record3.msg, 'outgoing response has an error');
+        assert.equal(record3.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record3.meta.responseState, 'Error');
+        assert.equal(record3.meta.responseCodeString, 'UnexpectedError');
+        assert.equal(record3.meta.responseErrorMessage, 'Unexpected Error');
         assert.equal(err3.method, 'sendError');
         assert.equal(err3.type, 'tchannel.response-already-done');
         assert.equal(err3.codeString, 'UnexpectedError');
@@ -603,12 +594,11 @@ allocCluster.test('sending INTERNAL_TIMEOUT OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Error');
-        assert.equal(record1.msg,
-            'error for timed out outgoing response');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record1.meta.ok, true);
-        assert.equal(record1.meta.codeString, 'Timeout');
+        assert.equal(record1.msg, 'error for timed out outgoing response');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Error');
+        assert.equal(record1.meta.responseOk, true);
+        assert.equal(record1.meta.responseCodeString, 'Timeout');
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, true);
@@ -653,12 +643,11 @@ allocCluster.test('sending INTERNAL_TIMEOUT NOT_OK', {
 
         var err1 = record1.meta.error;
 
-        assert.equal(record1.meta.state, 'Error');
-        assert.equal(record1.msg,
-            'error for timed out outgoing response');
-        assert.equal(record1.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record1.meta.ok, true);
-        assert.equal(record1.meta.codeString, 'Timeout');
+        assert.equal(record1.msg, 'error for timed out outgoing response');
+        assert.equal(record1.meta.requestArg1, 'DoubleResponse::method');
+        assert.equal(record1.meta.responseState, 'Error');
+        assert.equal(record1.meta.responseOk, true);
+        assert.equal(record1.meta.responseCodeString, 'Timeout');
         assert.equal(err1.method, 'setOk');
         assert.equal(err1.type, 'tchannel.response-already-started');
         assert.equal(err1.ok, false);
@@ -714,12 +703,12 @@ allocCluster.test('sending INTERNAL_TIMEOUT ERROR_FRAME', {
         assert.equal(record1.meta.endpoint, 'DoubleResponse::method');
         assert.equal(err1.message, 'Error: foobar');
 
-        assert.equal(record2.meta.state, 'Error');
-        assert.equal(record2.msg,
-            'error for timed out outgoing response');
-        assert.equal(record2.meta.arg1, 'DoubleResponse::method');
-        assert.equal(record2.meta.ok, true);
-        assert.equal(record2.meta.codeString, 'Timeout');
+        assert.equal(record2.msg, 'error for timed out outgoing response');
+        assert.equal(record2.meta.responseState, 'Error');
+        assert.equal(record2.meta.responseOk, true);
+        assert.equal(record2.meta.responseCodeString, 'Timeout');
+        assert.equal(record2.meta.requestArg1, 'DoubleResponse::method');
+
         assert.equal(err2.method, 'sendError');
         assert.equal(err2.type, 'tchannel.response-already-done');
         assert.equal(err2.codeString, 'UnexpectedError');


### PR DESCRIPTION
- more consistent log fields
- don't log about response timeout errors on already timed out requests