### PR TITLE
TChannel: fix subtle edge case for listening sub channels

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -323,7 +323,8 @@ TChannel.prototype.onServerSocketConnection = function onServerSocketConnection(
     }
 
     var socketRemoteAddr = sock.remoteAddress + ':' + sock.remotePort;
-    var conn = new TChannelConnection(self, sock, 'in', socketRemoteAddr);
+    var chan = self.topChannel || self;
+    var conn = new TChannelConnection(chan, sock, 'in', socketRemoteAddr);
 
     conn.errorEvent.on(onConnectionError);
 


### PR DESCRIPTION
Found while working on #1239:
- we have an assumption / invariant that conn.channel is the root channel
- this is guaranteed for outgoing ones, since peer.channel has this invariant, and peers create outgoing connections
- however channels create incoming connections, and weren't making the same guarantee

So for consistency, do this; I'll need this in #1239 since only the root channel will have the cached "should all connections be handled lazily" bool, not any of the sub channels.

r @kriskowal @Raynos 