### PR TITLE
Hyperbahn client should only destroy in HardFail mode

### DIFF
--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -160,6 +160,9 @@ function HyperbahnClient(options) {
         self.advertisementTimeoutTime = advertisementTimeout || 5000;
     } else {
         self.advertisementTimeoutTime = 0;
+        self.logger.info('HyperbahnClient advertisement timeout disabled', {
+            service: self.serviceName
+        });
     }
 }
 

--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -159,7 +159,7 @@ function HyperbahnClient(options) {
     if (self.hardFail) {
         self.advertisementTimeoutTime = advertisementTimeout || 5000;
     } else {
-        self.advertisementTimeoutTime = advertisementTimeout;
+        self.advertisementTimeoutTime = 0;
     }
 }
 
@@ -240,9 +240,7 @@ HyperbahnClient.prototype.advertisementFailure =
 function advertisementFailure(err) {
     var self = this;
 
-    if (self.hardFail) {
-        self.destroy();
-    }
+    self.destroy();
     self.emit('error', err);
 
     if (self.statsd) {
@@ -306,10 +304,6 @@ function advertise(opts) {
             },
             self.advertisementTimeoutTime
         );
-    } else {
-        self.logger.info('HyperbahnClient advertisement timeout disabled', {
-            service: self.serviceName
-        });
     }
 
     self.attemptCounter++;

--- a/node/hyperbahn/index.js
+++ b/node/hyperbahn/index.js
@@ -240,7 +240,9 @@ HyperbahnClient.prototype.advertisementFailure =
 function advertisementFailure(err) {
     var self = this;
 
-    self.destroy();
+    if (self.hardFail) {
+        self.destroy();
+    }
     self.emit('error', err);
 
     if (self.statsd) {


### PR DESCRIPTION
When advertisement timeout or other failures happens, hyperbahn client will destroy itself even it's not in HardFail mode. And if advertise is called again, it will trigger AlreadyDestroyed error and return, so hyperbahn client will never be able to get to advertised state again.

r: @ShanniLi @Raynos @vipulaneja 