### PR TITLE
Add non-streaming option for forwardToTChannel in as-http

### DIFF
--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperbahn",
-  "version": "cd",
+  "version": "2.7.7",
   "description": "Service Discovery and Routing",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperbahn",
-  "version": "2.7.7",
+  "version": "cd",
   "description": "Service Discovery and Routing",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -127,7 +127,7 @@ TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback
         }
         function arg2Ready(err, arg2) {
             if (err) {
-                callback(err, null, null);
+                callback(err, null, null, null);
             } else {
                 readArg2(tres, arg2);
             }
@@ -143,7 +143,7 @@ TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback
             var fromBufferErr = errors.HTTPReqArg2fromoBufferError(arg2res.err, {
                 arg2: arg2
             });
-            callback(fromBufferErr, null, null);
+            callback(fromBufferErr, null, null, null);
         } else if (tres.streamed) {
             callback(null, arg2res.value, tres.arg3, null);
         } else {

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var assert = require('assert');
 var bufrw = require('bufrw');
 var http = require('http');
 var extend = require('xtend');

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -202,6 +202,12 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
     var options = tchannel.requestOptions(extendInto({
         hasNoParent: true
     }, requestOptions));
+
+    if (!options.streamed) {
+        var treq = tchannel.request(options);
+        return self.sendRequest(treq, hreq, forwarded);
+    }
+
     var peer = tchannel.peers.choosePeer(null);
     if (!peer) {
         self._sendHTTPError(hres, errors.NoPeerAvailable());

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -99,10 +99,11 @@ TChannelHTTP.prototype.sendRequest = function send(treq, hreq, options, callback
     getRawBody(hreq, {
         length: hreq.headers['content-length'],
         limit: '1mb'
-      }, onRawBody);
+    }, onRawBody);
 
     function onRawBody(err, body) {
         if (err) {
+            callback(err, null, null, null);
             return err;
         }
         return treq.send(arg1, arg2, body, onResponse);

--- a/node/as/http.js
+++ b/node/as/http.js
@@ -198,9 +198,6 @@ TChannelHTTP.prototype.setHandler = function register(tchannel, handler) {
 TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, hreq, hres, requestOptions, callback) {
     var self = this;
     self.logger = self.logger || tchannel.logger;
-    // TODO: no retrying due to:
-    // - streamed bypasses TChannelRequest
-    // - driving peer selection manually therefore
     // TODO: more http state machine integration
 
     var options = tchannel.requestOptions(extendInto({

--- a/node/package.json
+++ b/node/package.json
@@ -33,6 +33,7 @@
     "hexer": "^1.4.5",
     "json-stringify-safe": "^5.0.0",
     "lru-cache": "^2.6.4",
+    "raw-body": "^2.1.2",
     "ready-signal": "^1.1.1",
     "run-parallel": "^1.1.0",
     "run-series": "^1.1.2",

--- a/node/test/as-http.js
+++ b/node/test/as-http.js
@@ -31,7 +31,7 @@ var TChannelHTTP = require('../as/http.js');
 var allocCluster = require('./lib/alloc-cluster.js');
 var LBPool = require('lb_pool').Pool;
 
-allocHTTPTest('as/http can bridge a service using node http', {
+allocHTTPTest('as/http can bridge a service using node http (streaming)', {
     onServiceRequest: handleTestHTTPRequest
 }, function t(cluster, assert) {
 
@@ -106,7 +106,7 @@ allocHTTPTest('as/http can bridge a service using node http', {
     ], assert.end);
 });
 
-allocHTTPTest('as/http can bridge a service using lbpool', {
+allocHTTPTest('as/http can bridge a service using lbpool (non-streaming)', {
     onServiceRequest: handleTestHTTPRequest,
     enableLBPool: true
 }, function t(cluster, assert) {
@@ -342,7 +342,7 @@ function allocHTTPBridge(opts) {
             cluster.egressChan,
             hreq,
             hres,
-            {},
+            {streamed: !opts.enableLBPool},
             onEgressComplete);
     }
 


### PR DESCRIPTION
As discussed, leave options - streamed to forwardToTChannel caller instead of force streaming, so that tchannel can retry by turning off request streaming.
r: @Raynos @jcorbin @ShanniLi 
cc: @vipulaneja 