### PR TITLE
v2/handler: use res.code directly

### DIFF
--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -646,10 +646,9 @@ function sendCallResponseFrame(res, flags, args) {
         return err;
     }
 
-    var code = res.ok ? v2.CallResponse.Codes.OK : v2.CallResponse.Codes.Error;
     var req = res.inreq;
     var resBody = new v2.CallResponse(
-        flags, code, res.tracing, res.headers,
+        flags, res.code, res.tracing, res.headers,
         res.checksum.type, args);
     res.checksum = self._sendCallBodies(
         res.id, resBody, null,


### PR DESCRIPTION
So that we can ever support as modules defining their own non-zero code space.

r @kriskowal @Raynos 