### PR TITLE
Frontend lazy handling support 

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -69,7 +69,8 @@ function TChannelConnection(channel, socket, direction, socketRemoteAddr) {
         requireCn: self.channel.requireCn,
         tracer: self.tracer,
         processName: self.options.processName,
-        connection: self
+        connection: self,
+        handleCallLazily: handleCallLazily
     };
 
     // jshint forin:true
@@ -80,6 +81,10 @@ function TChannelConnection(channel, socket, direction, socketRemoteAddr) {
     self.setupSocket();
     self.setupHandler();
     self.start();
+
+    function handleCallLazily(frame) {
+        return self.handleCallLazily(frame);
+    }
 }
 inherits(TChannelConnection, TChannelConnectionBase);
 

--- a/node/service-name-handler.js
+++ b/node/service-name-handler.js
@@ -42,6 +42,30 @@ function TChannelServiceNameHandler(options) {
 
 TChannelServiceNameHandler.prototype.type = 'tchannel.service-name-handler';
 
+TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, reqFrame) {
+    var self = this;
+
+    var res = reqFrame.bodyRW.lazy.readService(reqFrame);
+    if (res.err) {
+        // TODO: some way to indicate error directly
+        return false;
+    }
+
+    var serviceName = res.value;
+    if (!serviceName) {
+        // TODO: some way to indicate error directly
+        return false;
+    }
+
+    var chan = self.channel.subChannels[serviceName];
+
+    if (chan && chan.handler.handleLazily) {
+        return chan.handler.handleLazily(conn, reqFrame);
+    } else {
+        return false;
+    }
+};
+
 TChannelServiceNameHandler.prototype.handleRequest = function handleRequest(req, buildRes) {
     var self = this;
 

--- a/node/service-name-handler.js
+++ b/node/service-name-handler.js
@@ -47,13 +47,21 @@ TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, 
 
     var res = reqFrame.bodyRW.lazy.readService(reqFrame);
     if (res.err) {
-        // TODO: some way to indicate error directly
+        // TODO: stat?
+        self.channel.logger.warn('failed to lazy read frame serviceName', conn.extendLogInfo({
+            error: res.err
+        }));
+        // TODO: protocol error instead?
+        self._sendLazyErrorFrame(conn, reqFrame, 'BadRequest', 'failed to read serviceName');
         return false;
     }
 
     var serviceName = res.value;
     if (!serviceName) {
-        // TODO: some way to indicate error directly
+        // TODO: reqFrame.extendLogInfo would be nice, especially if it added
+        // things like callerName and arg1
+        self.channel.logger.warn('missing service name in lazy frame', conn.extendLogInfo({}));
+        self._sendLazyErrorFrame(conn, reqFrame, 'BadRequest', 'missing serviceName');
         return false;
     }
 
@@ -64,6 +72,19 @@ TChannelServiceNameHandler.prototype.handleLazily = function handleLazily(conn, 
     } else {
         return false;
     }
+};
+
+TChannelServiceNameHandler.prototype._sendLazyErrorFrame =
+function _sendLazyErrorFrame(conn, reqFrame, codeString, message) {
+    var fakeR = {
+        id: reqFrame.id,
+        tracing: null
+    };
+    var res = reqFrame.bodyRW.lazy.readService(reqFrame);
+    if (!res.err) {
+        fakeR.tracing = res.value;
+    }
+    conn.handler.sendErrorFrame(fakeR, codeString, message);
 };
 
 TChannelServiceNameHandler.prototype.handleRequest = function handleRequest(req, buildRes) {

--- a/node/test/index.js
+++ b/node/test/index.js
@@ -69,6 +69,7 @@ require('./balance_peer_requests.js');
 require('./tcollector-reporter.js');
 require('./pool-of-servers.js');
 require('./no_frag_arg1.js');
+require('./lazy_handler.js');
 require('./lazy_conn_handler.js');
 require('./chan_drain.js');
 


### PR DESCRIPTION
Building on the work of #1239:
- allow operations to handle frames lazily (for ongoing established calls)
- allow channel to handle frames lazily (for new incoming calls)

r @kriskowal @Raynos 