### PR TITLE
Misc cleanups ahead of #1270

### DIFF
--- a/node/connection_base.js
+++ b/node/connection_base.js
@@ -241,7 +241,7 @@ TChannelConnectionBase.prototype.onReqDone = function onReqDone(req) {
     if (inreq !== req && !req.timedOut) {
         self.logger.warn('mismatched onReqDone callback', {
             hostPort: self.channel.hostPort,
-            hasInReq: inreq !== undefined,
+            hasInReq: !!inreq,
             id: req.id
         });
     }

--- a/node/operations.js
+++ b/node/operations.js
@@ -232,11 +232,11 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
     }
 
     var tombstone = new OperationTombstone(self, id, self.timers.now(), req);
-    req.operations = null;
     self.requests.out[id] = tombstone;
-    self.pending.out--;
-
     tombstone.timeHeapHandle = self.connection.channel.timeHeap.update(tombstone, tombstone.time);
+
+    req.operations = null;
+    self.pending.out--;
 
     return req;
 };

--- a/node/operations.js
+++ b/node/operations.js
@@ -231,13 +231,12 @@ Operations.prototype.popOutReq = function popOutReq(id, context) {
         });
     }
 
-    var now = self.timers.now();
-    var tombstone = new OperationTombstone(self, id, now, req);
+    var tombstone = new OperationTombstone(self, id, self.timers.now(), req);
     req.operations = null;
     self.requests.out[id] = tombstone;
     self.pending.out--;
 
-    tombstone.timeHeapHandle = self.connection.channel.timeHeap.update(tombstone, now);
+    tombstone.timeHeapHandle = self.connection.channel.timeHeap.update(tombstone, tombstone.time);
 
     return req;
 };

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -192,21 +192,6 @@ function emitResponseStat(res) {
     }
 };
 
-function emitOutboundCallsSuccess(request) {
-    request.channel.emitFastStat(request.channel.buildStat(
-        'tchannel.outbound.calls.success',
-        'counter',
-        1,
-        new stat.OutboundCallsSuccessTags(
-            request.serviceName,
-            request.headers.cn,
-            request.endpoint
-        )
-    ));
-}
-
-
-
 TChannelOutRequest.prototype.emitPerAttemptResponseStat =
 function emitPerAttemptResponseStat(res) {
     var self = this;
@@ -229,7 +214,6 @@ function emitPerAttemptResponseStat(res) {
         emitOutboundCallsSuccess(self);
     }
 };
-
 
 TChannelOutRequest.prototype.emitPerAttemptLatency =
 function emitPerAttemptLatency() {
@@ -463,7 +447,7 @@ function emitOutboundCallsSent() {
 };
 
 TChannelOutRequest.prototype.hookupStreamCallback =
-function hookupCallback(callback) {
+function hookupStreamCallback(callback) {
     var self = this;
     var called = false;
 
@@ -485,8 +469,10 @@ function hookupCallback(callback) {
     return self;
 };
 
-TChannelOutRequest.prototype.hookupCallback = function hookupCallback(callback) {
+TChannelOutRequest.prototype.hookupCallback =
+function hookupCallback(callback) {
     var self = this;
+
     if (callback.canStream) {
         return self.hookupStreamCallback(callback);
     }
@@ -558,3 +544,16 @@ TChannelOutRequest.prototype.onTimeout = function onTimeout(now) {
         }));
     }
 };
+
+function emitOutboundCallsSuccess(request) {
+    request.channel.emitFastStat(request.channel.buildStat(
+        'tchannel.outbound.calls.success',
+        'counter',
+        1,
+        new stat.OutboundCallsSuccessTags(
+            request.serviceName,
+            request.headers.cn,
+            request.endpoint
+        )
+    ));
+}

--- a/node/out_request.js
+++ b/node/out_request.js
@@ -407,6 +407,10 @@ TChannelOutRequest.prototype.sendArg1 = function sendArg1(arg1) {
 TChannelOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     var self = this;
 
+    if (callback) {
+        self.hookupCallback(callback);
+    }
+
     self.sendArg1(arg1);
 
     if (self.span) {
@@ -416,10 +420,6 @@ TChannelOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
 
     if (self.logical === false && self.retryCount === 0) {
         self.emitOutboundCallsSent();
-    }
-
-    if (callback) {
-        self.hookupCallback(callback);
     }
 
     self.arg2 = arg2;

--- a/node/streaming_out_request.js
+++ b/node/streaming_out_request.js
@@ -70,12 +70,11 @@ StreamingOutRequest.prototype.sendArg1 = function sendArg1(arg1) {
 StreamingOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
     var self = this;
 
-    self.sendArg1(arg1);
-
     if (callback) {
         self.hookupCallback(callback);
     }
 
+    self.sendArg1(arg1);
     self.arg2.end(arg2);
     self.arg3.end(arg3);
 
@@ -85,12 +84,11 @@ StreamingOutRequest.prototype.send = function send(arg1, arg2, arg3, callback) {
 StreamingOutRequest.prototype.sendStreams = function sendStreams(arg1, arg2, arg3, callback) {
     var self = this;
 
-    self.sendArg1(arg1);
-
     if (callback) {
         self.hookupStreamCallback(callback);
     }
 
+    self.sendArg1(arg1);
     pipelineStreams([arg2, arg3], [self.arg2, self.arg3]);
 
     return self;

--- a/node/test/lib/alloc-cluster.js
+++ b/node/test/lib/alloc-cluster.js
@@ -189,7 +189,9 @@ function clusterTester(opts, t) {
         opts.assert = assert;
         allocCluster(opts).ready(function clusterReady(cluster) {
             assert.once('end', function testEnded() {
-                cluster.assertEmptyState(assert);
+                if (!opts.skipEmptyCheck) {
+                    cluster.assertEmptyState(assert);
+                }
                 cluster.destroy();
             });
             t(cluster, assert);


### PR DESCRIPTION
Assorted improvements and minor changes ahead of #1270:
- hookup callbacks first in streaming out req
- fix a small issue with the "mismatched onReqDone callback" log fields
- allow allocCluster auto empty assertion to be disabled (so that test case can do its own call with a manually crafted expectation)
- other misc cleanups