### PR TITLE
Use thriftrw

### DIFF
--- a/node/docs/as-thrift.md
+++ b/node/docs/as-thrift.md
@@ -86,6 +86,8 @@ send call requests and register call request handlers
 It can be passed options.
 
  - required `opts.source` The thrift idl as a string
+ - `opts.strict` defaults to true. When set to false you opt out
+    of strict IDL parsing.
  - `opts.logParseFailures` logParseFailures defaults to true. When
     it is set to true we will log parse failures to the logger using
     `logger.warn()`. If you do not want these log statements you

--- a/node/package.json
+++ b/node/package.json
@@ -40,7 +40,7 @@
     "safe-json-parse": "^4.0.0",
     "sse4_crc32": "3.2.0",
     "tape-cluster": "2.1.0",
-    "thriftify": "1.0.0-alpha14",
+    "thriftrw": "^2.1.1",
     "uber-statsd-client": "1.3.2",
     "xtend": "^4.0.0"
   },

--- a/node/tcollector/reporter.js
+++ b/node/tcollector/reporter.js
@@ -53,7 +53,8 @@ function TCollectorTraceReporter(options) {
     }
 
     self.tchannelThrift = new self.channel.TChannelAsThrift({
-        source: tcollectorSpec
+        source: tcollectorSpec,
+        strict: false
     });
 }
 

--- a/node/test/anechoic-chamber.thrift
+++ b/node/test/anechoic-chamber.thrift
@@ -30,9 +30,9 @@ exception NoEchoTypedError {
 }
 
 service Chamber {
-    i32 echo(0: required i32 value) throws (
+    i32 echo(1: required i32 value) throws (
         1: NoEchoError noEcho
         2: NoEchoTypedError noEchoTyped
     )
-    i32 echo_big(0: required list<string> value)
+    i32 echo_big(1: required list<string> value)
 }

--- a/node/test/as-thrift.js
+++ b/node/test/as-thrift.js
@@ -129,9 +129,10 @@ allocCluster.test('send and receive a not ok', {
         assert.ifError(err);
 
         assert.ok(!res.ok);
+
         assert.equal(res.body.value, 10);
         assert.equal(res.body.message, 'No echo');
-        assert.equal(res.body.type, 'tchannel.hydrated-error.default-type');
+        assert.equal(res.body.type, undefined);
 
         assert.end();
     });
@@ -155,6 +156,7 @@ allocCluster.test('send and receive a typed not ok', {
         assert.ifError(err);
 
         assert.ok(!res.ok);
+
         assert.equal(res.body.value, 10);
         assert.equal(res.body.message, 'No echo typed error');
         assert.equal(res.body.type, 'server.no-echo');
@@ -331,10 +333,9 @@ allocCluster.test('logger set correctly in send and register functions', {
     });
 });
 
-allocCluster.test('send without required fields', {
+allocCluster.test('send with invalid types', {
     numPeers: 2
 }, function t(cluster, assert) {
-
     makeTChannelThriftServer(cluster, {
         okResponse: true
     });
@@ -359,10 +360,11 @@ allocCluster.test('send without required fields', {
             'tchannel-thrift-handler.parse-error.body-failed: ' +
                 'Could not parse body (arg3) argument.\n' +
                 'Expected Thrift encoded arg3 for endpoint Chamber::echo.\n' +
-                'Got \u000b\u0000\u0000\u0000\u0000\u0000\u0003lol ' +
+                'Got \u000b\u0000\u0001\u0000\u0000\u0000\u0003lol ' +
                 'instead of Thrift.\n' +
                 'Parsing error was: ' +
-                'AStruct::reify expects field 0 typeid 8; received 11.\n'
+                'unexpected typeid 11 (STRING) for field "value" ' +
+                'with id 1 on echo_args; expected 8 (I32).\n'
         );
 
         assert.equal(res, undefined);

--- a/node/test/bad-anechoic-chamber.thrift
+++ b/node/test/bad-anechoic-chamber.thrift
@@ -30,7 +30,7 @@ exception NoEchoTypedError {
 }
 
 service Chamber {
-    i32 echo(0: required string value) throws (
+    i32 echo(1: required string value) throws (
         1: NoEchoError noEcho
         2: NoEchoTypedError noEchoTyped
     )

--- a/node/test/double-response.js
+++ b/node/test/double-response.js
@@ -27,15 +27,15 @@ var TChannelAsThrift = require('../as/thrift.js');
 
 var throft = [
     'struct DoubleResult {',
-    '    1: string value',
+    '    1: required string value',
     '}',
     '',
     'exception DoubleError {',
-    '    1: string message',
+    '    1: required string message',
     '}',
     '',
     'service DoubleResponse {',
-    '    DoubleResult method(0: string value) throws (',
+    '    DoubleResult method(1: string value) throws (',
     '        1: DoubleError error',
     '    )',
     '}'

--- a/node/test/tcollector-reporter.js
+++ b/node/test/tcollector-reporter.js
@@ -20,22 +20,27 @@
 
 'use strict';
 
-var thriftify = require('thriftify');
 var path = require('path');
 var test = require('tape');
 var fs = require('fs');
 var Buffer = require('buffer').Buffer;
 var timers = require('timers');
+var thriftrw = require('thriftrw');
 
 var allocCluster = require('./lib/alloc-cluster');
 
 var TCollectorReporter = require('../tcollector/reporter');
 
-var tcollectorSpec =
-    fs.readFileSync(path.join(__dirname, '..', 'tcollector', 'tcollector.thrift'), 'utf8');
+var tcollectorSpec = fs.readFileSync(
+    path.join(__dirname, '..', 'tcollector', 'tcollector.thrift'),
+    'utf8'
+);
 
 test('test of thriftify spec', function t1(assert) {
-    var thriftSpec = thriftify.newSpec(path.join(__dirname, '..', 'tcollector', 'tcollector.thrift'));
+    var thriftSpec = new thriftrw.Thrift({
+        source: tcollectorSpec,
+        strict: false
+    });
 
     var argsType = thriftSpec.getType('TCollector::submit_args');
 
@@ -95,11 +100,11 @@ test('test of thriftify spec', function t1(assert) {
         ]
     }};
 
-    var res = argsType.toBuffer(span);
+    var res = argsType.toBufferResult(span);
 
     assert.ifErr(res.err);
 
-    var res2 = argsType.fromBuffer(res.value);
+    var res2 = argsType.fromBufferResult(res.value);
 
     assert.ifErr(res2.err);
 
@@ -204,7 +209,8 @@ allocCluster.test('functional test', {
     });
 
     var thrift = new serverTChannel.TChannelAsThrift({
-        source: tcollectorSpec
+        source: tcollectorSpec,
+        strict: false
     });
 
     thrift.register(


### PR DESCRIPTION
This PR replaces thriftify with thriftrw.

There is no interface change other then an addition
of a `strict` boolean.

Technically this is a breaking change as we now support
a stricter subset of Thrift IDL files and enforce
the required field.

However thrift is marked as unstable in the documentation
so we will just bump minor.

r: @jcorbin @kriskowal @rf