### PR TITLE
Larch reservoir sampled logger

### DIFF
--- a/hyperbahn/clients/index.js
+++ b/hyperbahn/clients/index.js
@@ -254,7 +254,7 @@ function bootstrap(cb) {
 
     self.repl.once('listening', listenReady.signal);
     self.repl.start();
-    
+
     if (self.logger.bootstrap) {
         self.logger.bootstrap(listenReady.signal);
     } else {

--- a/hyperbahn/clients/index.js
+++ b/hyperbahn/clients/index.js
@@ -254,8 +254,12 @@ function bootstrap(cb) {
 
     self.repl.once('listening', listenReady.signal);
     self.repl.start();
-
-    self.logger.bootstrap(listenReady.signal);
+    
+    if (self.logger.bootstrap) {
+        self.logger.bootstrap(listenReady.signal);
+    } else {
+        listenReady.signal();
+    }
 
     self._controlServer.listen(self._controlPort, listenReady.signal);
 
@@ -282,7 +286,9 @@ ApplicationClients.prototype.destroy = function destroy() {
     self.repl.close();
     self._controlServer.close();
 
-    self.logger.destroy();
+    if (self.logger.destroy) {
+        self.logger.destroy();
+    }
 };
 
 ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdate() {

--- a/hyperbahn/clients/index.js
+++ b/hyperbahn/clients/index.js
@@ -243,7 +243,7 @@ function bootstrap(cb) {
 
     assert(typeof cb === 'function', 'cb required');
 
-    var listenReady = CountedReadySignal(3);
+    var listenReady = CountedReadySignal(4);
     listenReady(onListen);
 
     self.processReporter.bootstrap();
@@ -254,6 +254,8 @@ function bootstrap(cb) {
 
     self.repl.once('listening', listenReady.signal);
     self.repl.start();
+
+    self.logger.bootstrap(listenReady.signal);
 
     self._controlServer.listen(self._controlPort, listenReady.signal);
 
@@ -279,6 +281,8 @@ ApplicationClients.prototype.destroy = function destroy() {
 
     self.repl.close();
     self._controlServer.close();
+
+    self.logger.destroy();
 };
 
 ApplicationClients.prototype.onRemoteConfigUpdate = function onRemoteConfigUpdate() {

--- a/hyperbahn/clients/logger.js
+++ b/hyperbahn/clients/logger.js
@@ -100,7 +100,8 @@ function createLogger(options) {
     });
 
     var logger = LarchLogger({
-        backends: [larchBackend]
+        backends: [larchBackend],
+        statsd: options.statsd
     });
 
     return logger;

--- a/hyperbahn/clients/logger.js
+++ b/hyperbahn/clients/logger.js
@@ -21,12 +21,12 @@
 'use strict';
 
 var os = require('os');
-var Logtron = require('logtron');
+var Logger = require('logtron');
 var process = require('process');
 
-var Larch = require('../lib/larch/larch');
-var LarchLogtronBackend = require('../lib/larch/logtron-backend');
-var LarchReservoirBackend = require('../lib/larch/reservoir-backend');
+var LarchLogger = require('../lib/larch/larch');
+var LogtronLogBackend = require('../lib/larch/logtron-backend');
+var ReservoirLogBackend = require('../lib/larch/reservoir-backend');
 
 var Levels = {
     TRACE: 10,
@@ -42,7 +42,7 @@ module.exports = createLogger;
 
 // inline createLogger for now because yolo
 function createLogger(options) {
-    var logtronLogger = new Logtron({
+    var logtronLogger = new Logger({
         meta: {
             team: options.team,
             project: options.project,
@@ -80,7 +80,7 @@ function createLogger(options) {
             }
         },
         statsd: options.statsd,
-        backends: Logtron.defaultBackends({
+        backends: Logger.defaultBackends({
             kafka: options.kafka,
             logFile: options.logFile,
             console: options.console,
@@ -95,11 +95,11 @@ function createLogger(options) {
 
     // The backend for larch is a reservoir sampler that logs to a logtron
     // backend which redirects to a Logtron instance
-    var larchBackend = LarchReservoirBackend({
-        backend: LarchLogtronBackend(logtronLogger)
+    var larchBackend = ReservoirLogBackend({
+        backend: LogtronLogBackend(logtronLogger)
     });
 
-    var logger = Larch({
+    var logger = LarchLogger({
         backends: [larchBackend]
     });
 

--- a/hyperbahn/lib/larch/base-backend.js
+++ b/hyperbahn/lib/larch/base-backend.js
@@ -47,7 +47,7 @@ function BaseBackend(options) {
 
     assert(
         typeof self.destroy === 'function',
-        '`bootstrap` method of BaseBackend must be overridden by function'
+        '`destroy` method of BaseBackend must be overridden by function'
     );
 
     assert(

--- a/hyperbahn/lib/larch/base-backend.js
+++ b/hyperbahn/lib/larch/base-backend.js
@@ -23,6 +23,8 @@
 var assert = require('assert');
 var collectParallel = require('collect-parallel/array');
 
+var Errors = require('./errors');
+
 module.exports = BaseBackend;
 
 function BaseBackend(options) {
@@ -67,9 +69,13 @@ BaseBackend.prototype.destroy = function bootstrap(cb) {
 BaseBackend.prototype.logMany = function logMany(records, cb) {
     var self = this;
 
-    collectParallel(records, eachRecord, cb);
+    collectParallel(records, eachRecord, logsDone);
 
     function eachRecord(record, i, recordCb) {
         self.log(record, recordCb);
+    }
+
+    function logsDone(ignored, results) {
+        cb(Errors.resultArrayToError(results, 'larch.log-many.many-errors'));
     }
 };

--- a/hyperbahn/lib/larch/base-backend.js
+++ b/hyperbahn/lib/larch/base-backend.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var collectParallel = require('collect-parallel/array');
+
+module.exports = BaseBackend;
+
+function BaseBackend(options) {
+    if (!(this instanceof BaseBackend)) {
+        return new BaseBackend(options);
+    }
+
+    var self = this;
+
+    assert(
+        typeof self.log === 'function' &&
+        self.log !== BaseBackend.prototype.log,
+        '`log` method of BaseBackend must be overridden by function'
+    );
+
+    assert(
+        typeof self.bootstrap === 'function',
+        '`bootstrap` method of BaseBackend must be overridden by function'
+    );
+
+    assert(
+        typeof self.destroy === 'function',
+        '`bootstrap` method of BaseBackend must be overridden by function'
+    );
+
+    assert(
+        typeof self.logMany === 'function',
+        '`logMany` method of BaseBackend must be overriden by function'
+    );
+}
+
+BaseBackend.prototype.log = function log(record, cb) {};
+
+BaseBackend.prototype.bootstrap = function bootstrap(cb) {
+    cb();
+};
+
+BaseBackend.prototype.destroy = function bootstrap(cb) {
+    cb();
+};
+
+BaseBackend.prototype.logMany = function logMany(records, cb) {
+    var self = this;
+
+    collectParallel(records, eachRecord, cb);
+
+    function eachRecord(record, i, recordCb) {
+        self.log(record, recordCb);
+    }
+};

--- a/hyperbahn/lib/larch/errors.js
+++ b/hyperbahn/lib/larch/errors.js
@@ -41,6 +41,12 @@ function resultArrayToError(items, type, message) {
         }
     }
 
+    return errorArrayToError(errors, type, message);
+}
+
+module.exports.errorArrayToError = errorArrayToError;
+
+function errorArrayToError(errors, type, message) {
     if (errors.length === 0) {
         return null;
     } else if (errors.length === 1) {

--- a/hyperbahn/lib/larch/errors.js
+++ b/hyperbahn/lib/larch/errors.js
@@ -22,11 +22,9 @@
 
 var TypedError = require('error/typed');
 
-module.exports.ManyErrors = ManyErrors;
-
-var ManyErrors = TypedError({
+var ManyErrors = module.exports.ManyErrors = TypedError({
     type: 'many.errors',
-    message: "{count} errors. Example: {example}",
+    message: '{count} errors. Example: {example}',
     count: null,
     example: null,
     errors: null
@@ -45,13 +43,9 @@ function resultArrayToError(items, type, message) {
 
     if (errors.length === 0) {
         return null;
-    }
-
-    else if (errors.length === 1) {
+    } else if (errors.length === 1) {
         return errors[0];
-    }
-
-    else {
+    } else {
         return ManyErrors({
             message: message,
             type: type,

--- a/hyperbahn/lib/larch/errors.js
+++ b/hyperbahn/lib/larch/errors.js
@@ -1,0 +1,41 @@
+var TypedError = require('error/typed');
+
+module.exports.ManyErrors = ManyErrors;
+
+var ManyErrors = TypedError({
+    type: 'many.errors',
+    message: "{count} errors. Example: {example}",
+    count: null,
+    example: null,
+    errors: null
+});
+
+module.exports.resultArrayToError = resultArrayToError;
+
+function resultArrayToError(items, type, message) {
+    var errors = [];
+    var i;
+    for (i = 0; i < items.length; i++) {
+        if (items[i].err) {
+            errors.push(items[i].err);
+        }
+    }
+
+    if (errors.length === 0) {
+        return null;
+    }
+
+    else if (errors.length === 1) {
+        return errors[0];
+    }
+
+    else {
+        return ManyErrors({
+            message: message,
+            type: type,
+            errors: errors,
+            count: errors.length,
+            example: errors[0].message
+        });
+    }
+}

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -69,7 +69,7 @@ function logMultiBackend(level, msg, meta, cb) {
     function writesDone(ignored, results) {
         if (typeof cb === 'function') {
             cb(Errors.resultArrayToError(
-                results, 
+                results,
                 'larch.log-multi-backend.many-errors'
             ));
         }

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -24,7 +24,7 @@ var assert = require('assert');
 var collectParallel = require('collect-parallel/array');
 
 var Record = require('./record');
-var errors = require('./errors');
+var Errors = require('./errors');
 
 module.exports = Larch;
 
@@ -89,7 +89,7 @@ Larch.prototype.bootstrap = function bootstrap(cb) {
     }
 
     function bootstrapsDone(ignored, results) {
-        cb(errors.resultArrayToError(results, 'larch.bootstrap.many-errors'));
+        cb(Errors.resultArrayToError(results, 'larch.bootstrap.many-errors'));
     }
 };
 
@@ -103,7 +103,7 @@ Larch.prototype.destroy = function destroy(cb) {
     }
 
     function destroysDone(ignored, results) {
-        cb(errors.resultArrayToError(results, 'larch.destroy.many-errors'));
+        cb(Errors.resultArrayToError(results, 'larch.destroy.many-errors'));
     }
 };
 

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -89,7 +89,7 @@ Larch.prototype.bootstrap = function bootstrap(cb) {
     }
 
     function bootstrapsDone(ignored, results) {
-        cb(errors.resultArrayToError(results), null);
+        cb(errors.resultArrayToError(results, 'larch.bootstrap.many-errors'));
     }
 };
 
@@ -103,7 +103,7 @@ Larch.prototype.destroy = function destroy(cb) {
     }
 
     function destroysDone(ignored, results) {
-        cb(errors.resultArrayToError(results), null);
+        cb(errors.resultArrayToError(results, 'larch.destroy.many-errors'));
     }
 };
 

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -86,7 +86,9 @@ Larch.prototype.bootstrap = function bootstrap(cb) {
     }
 
     function bootstrapsDone(ignored, results) {
-        cb(Errors.resultArrayToError(results, 'larch.bootstrap.many-errors'));
+        if (typeof cb === 'function') {
+            cb(Errors.resultArrayToError(results, 'larch.bootstrap.many-errors'));
+        }
     }
 };
 
@@ -100,7 +102,9 @@ Larch.prototype.destroy = function destroy(cb) {
     }
 
     function destroysDone(ignored, results) {
-        cb(Errors.resultArrayToError(results, 'larch.destroy.many-errors'));
+        if (typeof cb === 'function') {
+            cb(Errors.resultArrayToError(results, 'larch.destroy.many-errors'));
+        }
     }
 };
 

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -22,7 +22,9 @@
 
 var assert = require('assert');
 var collectParallel = require('collect-parallel/array');
+
 var Levels = require('./levels');
+var Record = require('./record');
 
 module.exports = Larch;
 
@@ -47,16 +49,20 @@ Larch.prototype.logSingleBackend =
 function logSingleBackend(level, msg, meta, cb) {
     var self = this;
 
-    self.backends[0].log(level, msg, meta, cb);
+    var record = new Record(level, msg, meta, null);
+
+    self.backends[0].log(record, cb);
 };
 
 Larch.prototype.logMultiBackend =
 function logMultiBackend(level, msg, meta, cb) {
     var self = this;
 
+    var record = new Record(level, msg, meta, null);
+
     var i;
     for (i = 0; i < self.backends.length; i++) {
-        self.backends[i].log(level, msg, meta, backendDone);
+        self.backends[i].log(record, backendDone);
     }
 
     var done = 0;
@@ -90,29 +96,29 @@ Larch.prototype.destroy = function destroy(cb) {
 };
 
 Larch.prototype.trace = function trace(msg, meta, cb) {
-    this.log(Levels.BY_NAME.trace, msg, meta, cb);
+    this.log('trace', msg, meta, cb);
 };
 
 Larch.prototype.debug = function debug(msg, meta, cb) {
-    this.log(Levels.BY_NAME.debug, msg, meta, cb);
+    this.log('debug', msg, meta, cb);
 };
 
 Larch.prototype.info = function info(msg, meta, cb) {
-    this.log(Levels.BY_NAME.info, msg, meta, cb);
+    this.log('info', msg, meta, cb);
 };
 
 Larch.prototype.access = function access(msg, meta, cb) {
-    this.log(Levels.BY_NAME.access, msg, meta, cb);
+    this.log('access', msg, meta, cb);
 };
 
 Larch.prototype.warn = function warn(msg, meta, cb) {
-    this.log(Levels.BY_NAME.warn, msg, meta, cb);
+    this.log('warn', msg, meta, cb);
 };
 
 Larch.prototype.error = function error(msg, meta, cb) {
-    this.log(Levels.BY_NAME.error, msg, meta, cb);
+    this.log('error', msg, meta, cb);
 };
 
 Larch.prototype.fatal = function fatal(msg, meta, cb) {
-    this.log(Levels.BY_NAME.fatal, msg, meta, cb);
+    this.log('fatal', msg, meta, cb);
 };

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -23,7 +23,6 @@
 var assert = require('assert');
 var collectParallel = require('collect-parallel/array');
 
-var Levels = require('./levels');
 var Record = require('./record');
 
 module.exports = Larch;

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -1,0 +1,118 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var collectParallel = require('collect-parallel/array');
+var Levels = require('./levels');
+
+module.exports = Larch;
+
+function Larch(options) {
+    if (!(this instanceof Larch)) {
+        return new Larch(options);
+    }
+
+    var self = this;
+
+    self.backends = options.backends;
+    assert(Array.isArray(self.backends), 'options.backends must be array');
+
+    if (self.backends.length === 1) {
+        self.log = self.logSingleBackend;
+    } else {
+        self.log = self.logMultiBackend;
+    }
+}
+
+Larch.prototype.logSingleBackend =
+function logSingleBackend(level, msg, meta, cb) {
+    var self = this;
+
+    self.backends[0].log(level, msg, meta, cb);
+};
+
+Larch.prototype.logMultiBackend =
+function logMultiBackend(level, msg, meta, cb) {
+    var self = this;
+
+    var i;
+    for (i = 0; i < self.backends.length; i++) {
+        self.backends[i].log(level, msg, meta, backendDone);
+    }
+
+    var done = 0;
+    function backendDone() {
+        done++;
+
+        if (done === self.backends.length) {
+            cb();
+        }
+    }
+};
+
+Larch.prototype.bootstrap = function bootstrap(cb) {
+    var self = this;
+
+    collectParallel(self.backends, bootstrapBackend, cb);
+
+    function bootstrapBackend(backend, i, backendCb) {
+        backend.bootstrap(backendCb);
+    }
+};
+
+Larch.prototype.destroy = function destroy(cb) {
+    var self = this;
+
+    collectParallel(self.backends, destroyBackend, cb);
+
+    function destroyBackend(backend, i, backendCb) {
+        backend.destroy(backendCb);
+    }
+};
+
+Larch.prototype.trace = function trace(msg, meta, cb) {
+    this.log(Levels.BY_NAME.trace, msg, meta, cb);
+};
+
+Larch.prototype.debug = function debug(msg, meta, cb) {
+    this.log(Levels.BY_NAME.debug, msg, meta, cb);
+};
+
+Larch.prototype.info = function info(msg, meta, cb) {
+    this.log(Levels.BY_NAME.info, msg, meta, cb);
+};
+
+Larch.prototype.access = function access(msg, meta, cb) {
+    this.log(Levels.BY_NAME.access, msg, meta, cb);
+};
+
+Larch.prototype.warn = function warn(msg, meta, cb) {
+    this.log(Levels.BY_NAME.warn, msg, meta, cb);
+};
+
+Larch.prototype.error = function error(msg, meta, cb) {
+    this.log(Levels.BY_NAME.error, msg, meta, cb);
+};
+
+Larch.prototype.fatal = function fatal(msg, meta, cb) {
+    this.log(Levels.BY_NAME.fatal, msg, meta, cb);
+};

--- a/hyperbahn/lib/larch/larch.js
+++ b/hyperbahn/lib/larch/larch.js
@@ -63,7 +63,7 @@ function logMultiBackend(level, msg, meta, cb) {
     function backendDone() {
         done++;
 
-        if (done === self.backends.length) {
+        if (done >= self.backends.length) {
             cb();
         }
     }

--- a/hyperbahn/lib/larch/levels.js
+++ b/hyperbahn/lib/larch/levels.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+module.exports.BY_NAME = {
+    'trace': 10,
+    'debug': 20,
+    'info': 30,
+    'access': 35,
+    'warn': 40,
+    'error': 50,
+    'fatal': 60
+};
+
+module.exports.BY_VALUE = {
+    '10': 'trace',
+    '20': 'debug',
+    '30': 'info',
+    '35': 'access',
+    '40': 'warn',
+    '50': 'error',
+    '60': 'fatal'
+};

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var util = require('util');
+var assert = require('assert');
+
+var BaseBackend = require('./base-backend');
+
+function LogtronBackend(logtron) {
+    if (!(this instanceof LogtronBackend)) {
+        return new LogtronBackend(logtron);
+    }
+
+    var self = this;
+
+    BaseBackend.call(self);
+
+    self.logtron = logtron;
+    assert(
+        typeof self.logtron === 'object' &&
+        typeof self.logtron.writeEntry === 'function',
+        'LogtronBackend expected first argument to be Logtron instance'
+    );
+}
+
+util.inherits(LogtronBackend, BaseBackend);
+
+LogtronBackend.prototype.log = function log(record, cb) {
+    var self = this;
+
+    self.logtron.writeEntry(record, cb);
+};

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -67,6 +67,7 @@ LogtronBackend.prototype.logMany = function logMany(records, cb) {
     var i;
     var done = 0;
     var errors = [];
+
     for (i = 0; i < records.length; i++) {
         self.log(records[i], recordDone);
     }

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -79,7 +79,7 @@ LogtronBackend.prototype.logMany = function logMany(records, cb) {
 
         if (done >= records.length) {
             cb(Errors.errorArrayToError(
-                errors, 
+                errors,
                 'larch.logtron-backend.log-many.many-errors'
             ));
         }

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -77,4 +77,3 @@ LogtronBackend.prototype.logMany = function logMany(records, cb) {
         }
     }
 };
-

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -25,6 +25,8 @@ var assert = require('assert');
 
 var BaseBackend = require('./base-backend');
 
+module.exports = LogtronBackend;
+
 function LogtronBackend(logtron) {
     if (!(this instanceof LogtronBackend)) {
         return new LogtronBackend(logtron);

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -24,6 +24,7 @@ var util = require('util');
 var assert = require('assert');
 var LogtronEntry = require('logtron/entry');
 
+var Errors = require('./errors');
 var BaseBackend = require('./base-backend');
 
 module.exports = LogtronBackend;
@@ -65,15 +66,22 @@ LogtronBackend.prototype.logMany = function logMany(records, cb) {
 
     var i;
     var done = 0;
+    var errors = [];
     for (i = 0; i < records.length; i++) {
         self.log(records[i], recordDone);
     }
 
-    function recordDone() {
+    function recordDone(error) {
         done++;
+        if (error) {
+            errors.push(error);
+        }
 
         if (done >= records.length) {
-            cb();
+            cb(Errors.errorArrayToError(
+                errors, 
+                'larch.logtron-backend.log-many.many-errors'
+            ));
         }
     }
 };

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -52,7 +52,7 @@ LogtronBackend.prototype.log = function log(record, cb) {
 
     var entry = new LogtronEntry(
         record.data.level,
-        record.data.msg,
+        record.data.message,
         record.meta,
         self.logtron.path
     );

--- a/hyperbahn/lib/larch/logtron-backend.js
+++ b/hyperbahn/lib/larch/logtron-backend.js
@@ -22,6 +22,7 @@
 
 var util = require('util');
 var assert = require('assert');
+var LogtronEntry = require('logtron/entry');
 
 var BaseBackend = require('./base-backend');
 
@@ -49,5 +50,31 @@ util.inherits(LogtronBackend, BaseBackend);
 LogtronBackend.prototype.log = function log(record, cb) {
     var self = this;
 
-    self.logtron.writeEntry(record, cb);
+    var entry = new LogtronEntry(
+        record.data.level,
+        record.data.msg,
+        record.meta,
+        self.logtron.path
+    );
+
+    self.logtron.writeEntry(entry, cb);
 };
+
+LogtronBackend.prototype.logMany = function logMany(records, cb) {
+    var self = this;
+
+    var i;
+    var done = 0;
+    for (i = 0; i < records.length; i++) {
+        self.log(records[i], recordDone);
+    }
+
+    function recordDone() {
+        done++;
+
+        if (done >= records.length) {
+            cb();
+        }
+    }
+};
+

--- a/hyperbahn/lib/larch/record.js
+++ b/hyperbahn/lib/larch/record.js
@@ -26,9 +26,9 @@ var stringify = require('json-stringify-safe');
 
 module.exports = Record;
 
-function Record(level, msg, meta, time) {
-    this.meta = (meta === null || meta === void 0) ? null : meta;
-    this.data = new RecordData(level, msg, meta, time);
+function Record(level, message, time) {
+    this.meta = (meta === null || meta === undefined) ? null : meta;
+    this.data = new RecordData(level, message, time);
     this.serialized = null;
     this.hasBeenMerged = false;
 }
@@ -54,14 +54,8 @@ Record.prototype.toJSON = function toJSON() {
     return this.data;
 };
 
-function RecordData(level, msg, meta, time) {
+function RecordData(level, message, time) {
     this.level = level;
-    this.msg = msg;
+    this.message = message;
     this.time = time || new Date().toISOString();
-    this.component = null;
-    this.src = 0;
-    this.v = 0;
-    this.pid = process.pid;
-    this.hostname = os.hostname();
-    this.name = null;
 }

--- a/hyperbahn/lib/larch/record.js
+++ b/hyperbahn/lib/larch/record.js
@@ -22,6 +22,7 @@
 
 var os = require('os');
 var process = require('process');
+var stringify = require('json-stringify-safe');
 
 module.exports = Record;
 
@@ -33,8 +34,8 @@ function Record(level, msg, meta, time) {
 }
 
 Record.prototype.serialize = function serialize() {
-    if (!this.serialized) {
-        this.serialized = JSON.stringify(this.toJSON());
+    if (this.serialized !== null) {
+        this.serialized = stringify(this.toJSON());
     }
 
     return this.serialized;

--- a/hyperbahn/lib/larch/record.js
+++ b/hyperbahn/lib/larch/record.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var os = require('os');
+var process = require('process');
+
+module.exports = Record;
+
+function Record(level, msg, meta, time) {
+    this.meta = (meta === null || meta === void 0) ? null : meta;
+    this.data = new RecordData(level, msg, meta, time);
+    this.serialized = null;
+    this.hasBeenMerged = false;
+}
+
+Record.prototype.serialize = function serialize() {
+    if (!this.serialized) {
+        this.serialized = JSON.stringify(this.toJSON());
+    }
+
+    return this.serialized;
+};
+
+Record.prototype.toJSON = function toJSON() {
+    var i;
+    if (!this.hasBeenMerged) {
+        for (i in this.meta) if (this.meta.hasOwnProperty(i)) {
+            this.data[i] = this.meta[i];
+        }
+
+        this.hasBeenMerged = true;
+    }
+
+    return this.data;
+};
+
+function RecordData(level, msg, meta, time) {
+    this.level = level;
+    this.msg = msg;
+    this.time = time || new Date().toISOString();
+    this.component = null;
+    this.src = 0;
+    this.v = 0;
+    this.pid = process.pid;
+    this.hostname = os.hostname();
+    this.name = null;
+}

--- a/hyperbahn/lib/larch/record.js
+++ b/hyperbahn/lib/larch/record.js
@@ -20,13 +20,11 @@
 
 'use strict';
 
-var os = require('os');
-var process = require('process');
 var stringify = require('json-stringify-safe');
 
 module.exports = Record;
 
-function Record(level, message, time) {
+function Record(level, message, meta, time) {
     this.meta = (meta === null || meta === undefined) ? null : meta;
     this.data = new RecordData(level, message, time);
     this.serialized = null;

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -96,9 +96,9 @@ ReservoirBackend.prototype.flush = function flush(records) {
     var self = this;
 
     var i;
-    for (i in self.dropCount) {
-        self.statsd.gauge('larch.dropped.' + i, self.dropCount[i]);
-        self.dropCount[i] = 0;
+    var keys = Object.keys(self.dropCount);
+    for (i = 0; i < keys.length; i++) {
+        self.statsd.count('larch.dropped.' + keys[i], self.dropCount[keys[i]]);
     }
 
     var copy = records.slice(0);
@@ -123,20 +123,28 @@ ReservoirBackend.prototype.log = function log(record, cb) {
     } else {
         var probability = self.rangeRand(0, self.count);
         if (probability < self.size) {
-            // evict and replace
+            // record drop for the record we're evicting
+            self.recordDrop(self.records[probability].data.level);
+
             self.records[probability] = record;
         } else {
-            // record drop count
-            if (!self.dropCount[record.data.level]) {
-                self.dropCount[record.data.level] == 1;
-            } else {
-                self.dropCount[record.data.level] += 1;
-            }
+            // record drop for record we're dropping
+            self.recordDrop(record.data.level);
         }
     }
 
     if (typeof cb === 'function') {
         cb();
+    }
+};
+
+ReservoirBackend.prototype.recordDrop = function recordDrop(level) {
+    var self = this;
+
+    if (!self.dropCount[level]) {
+        self.dropCount[level] = 1;
+    } else {
+        self.dropCount[level] += 1;
     }
 };
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -100,7 +100,7 @@ ReservoirBackend.prototype.log = function log(record, cb) {
     if (self.records.length < self.size) {
         self.records.push(record);
     } else {
-        var probability = self.rangeRand(1, self.count);
+        var probability = self.rangeRand(1, self.count - 1);
         if (probability < self.records.length) {
             // evict and replace
             self.records[probability] = record;

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -125,12 +125,15 @@ ReservoirBackend.prototype.flush = function flush(records) {
 
     function onLoggingDone(err) {
         // TODO: what to do when flush fails? Generate a log message?
-        var count = 1;
-        if (err.count) {
-            count = err.count;
+        if (err) {
+            var count = 1;
+            if (err.count) {
+                count = err.count;
+            }
+
+            self.statsd.incr('larch.errors', count);
         }
 
-        self.statsd.incr('larch.errors', count);
         self.statsd.timing('larch.flushTime', self.now() - start);
     }
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -79,10 +79,15 @@ function ReservoirBackend(options) {
         'options.timers must be object with setTimeout function'
     );
 
+    self.now = options.now || Date.now;
+    assert(
+        typeof self.now === 'function',
+        'options.now must be function'
+    );
+
     self.timer = null;
     self.count = 0;
     self.records = [];
-    self.errors = [];
     self.dropCount = {};
     self.logCount = {};
 }
@@ -96,16 +101,22 @@ ReservoirBackend.rangeRand = function rand(lo, hi) {
 ReservoirBackend.prototype.flush = function flush(records) {
     var self = this;
 
+    var start = self.now();
+
     var i;
     var keys = Object.keys(self.dropCount);
     for (i = 0; i < keys.length; i++) {
-        self.statsd.count('larch.dropped.' + keys[i], self.dropCount[keys[i]]);
+        self.statsd.increment('larch.dropped.' + keys[i], self.dropCount[keys[i]]);
         self.dropCount[keys[i]] = 0;
+    }
+
+    for (i = 0; i < self.records.length; i++) {
+        self.countLog(self.records[i].data.level);
     }
 
     keys = Object.keys(self.logCount);
     for (i = 0; i < keys.length; i++) {
-        self.statsd.count('larch.logged.' + keys[i], self.logCount[keys[i]]);
+        self.statsd.increment('larch.logged.' + keys[i], self.logCount[keys[i]]);
         self.logCount[keys[i]] = 0;
     }
 
@@ -114,7 +125,13 @@ ReservoirBackend.prototype.flush = function flush(records) {
 
     function onLoggingDone(err) {
         // TODO: what to do when flush fails? Generate a log message?
-        self.errors.push(err);
+        var count = 1;
+        if (err.count) {
+            count = err.count;
+        }
+
+        self.statsd.incr('larch.errors', count);
+        self.statsd.timing('larch.flushTime', self.now() - start);
     }
 
     self.records.length = 0;
@@ -128,13 +145,11 @@ ReservoirBackend.prototype.log = function log(record, cb) {
 
     if (self.records.length < self.size) {
         self.records.push(record);
-        self.countLog(record.data.level);
     } else {
         var probability = self.rangeRand(0, self.count);
         if (probability < self.size) {
             // record drop for the record we're evicting
             self.countDrop(self.records[probability].data.level);
-            self.countLog(record.data.level);
 
             self.records[probability] = record;
         } else {

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -95,7 +95,9 @@ ReservoirBackend.prototype.flush = function flush(records) {
 ReservoirBackend.prototype.log = function log(record, cb) {
     var self = this;
 
-    cb();
+    if (typeof cb === 'function') {
+        cb();
+    }
 
     self.count += 1;
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -81,7 +81,7 @@ function ReservoirBackend(options) {
 
     self.timer = null;
     self.count = 0;
-    self.records = new Array(self.size);
+    self.records = [];
     self.errors = [];
     self.dropCount = {};
 }

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -37,11 +37,18 @@ function ReservoirBackend(options) {
 
     BaseBackend.call(self);
 
-    self.size = options.size || 500;
+    self.backend = options.backend;
+    assert(
+        typeof options.backend === 'object' &&
+        typeof options.backend.logMany === 'function',
+        'options.backend must be object with logMany function'
+    );
+
+    self.size = options.size || 100;
     assert(
         typeof self.size === 'number' &&
-        self.size > 10 && self.size < 1000000000,
-        'options.size must be number 10 > n > 1000000000'
+        self.size >= 5 && self.size < 1000000000,
+        'options.size must be number 5 >= n > 1000000000'
     );
 
     self.rangeRand = options.rangeRand || ReservoirBackend.rangeRand;
@@ -64,13 +71,6 @@ function ReservoirBackend(options) {
         'options.timers must be object with setTimeout function'
     );
 
-    self.backend = options.backend;
-    assert(
-        typeof options.backend === 'object' &&
-        typeof options.backend.logMany === 'function',
-        'options.backend must be object with logMany function'
-    );
-
     self.timer = null;
     self.count = 0;
     self.records = [];
@@ -79,14 +79,18 @@ function ReservoirBackend(options) {
 util.inherits(ReservoirBackend, BaseBackend);
 
 ReservoirBackend.rangeRand = function rand(lo, hi) {
-    return Math.random() * (hi - lo) + lo;
+    return Math.floor(Math.random() * (hi - lo) + lo);
 };
 
 ReservoirBackend.prototype.flush = function flush(records) {
     var self = this;
 
     var copy = records.slice(0);
-    self.backend.logMany(copy);
+    self.backend.logMany(copy, onLoggingDone);
+
+    function onLoggingDone(err) {
+        // TODO: what to do when flush fails? Generate a log message?
+    }
 
     self.records.length = 0;
     self.count = 0;
@@ -100,8 +104,8 @@ ReservoirBackend.prototype.log = function log(record, cb) {
     if (self.records.length < self.size) {
         self.records.push(record);
     } else {
-        var probability = self.rangeRand(1, self.count - 1);
-        if (probability < self.records.length) {
+        var probability = self.rangeRand(0, self.count);
+        if (probability < self.size) {
             // evict and replace
             self.records[probability] = record;
         }
@@ -121,6 +125,11 @@ ReservoirBackend.prototype.destroy = function destroy(cb) {
 
 ReservoirBackend.prototype.bootstrap = function bootstrap(cb) {
     var self = this;
+
+    assert(
+        typeof cb === 'function', 
+        'bootstrap must be called with a callback'
+    );
 
     self.timer = self.timers.setTimeout(onTimer, self.flushInterval);
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -1,0 +1,130 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var timers = require('timers');
+
+var BaseBackend = require('./base-backend');
+
+function ReservoirBackend(options) {
+    if (!(this instanceof ReservoirBackend)) {
+        return new ReservoirBackend(options);
+    }
+
+    var self = this;
+
+    BaseBackend.call(self);
+
+    self.size = options.size || 500;
+    assert(
+        typeof self.size === 'number' &&
+        self.size > 10 && self.size < 1000000000,
+        'options.size must be number 10 > n > 1000000000'
+    );
+
+    self.rangeRand = options.rangeRand || ReservoirBackend.rangeRand;
+    assert(
+        typeof self.rangeRand === 'function',
+        'options.rangeRand must be function'
+    );
+
+    self.flushInterval = options.flushInterval || 50;
+    assert(
+        typeof self.flushInterval === 'number' &&
+        self.flushInterval > 1 && self.flushInterval < 1000000,
+        'options.flushInterval must be number 1 > n > 1000000'
+    );
+
+    self.timers = options.timers || timers;
+    assert(
+        typeof self.timers === 'object' &&
+        typeof self.timers.setTimeout === 'function',
+        'options.timers must be object with setTimeout function'
+    );
+
+    self.backend = options.backend;
+    assert(
+        typeof options.backend === 'object' &&
+        typeof options.backend.logMany === 'function',
+        'options.backend must be object with logMany function'
+    );
+
+    self.timer = null;
+    self.count = 0;
+    self.records = [];
+}
+
+util.inherits(ReservoirBackend, BaseBackend);
+
+ReservoirBackend.rangeRand = function rand(lo, hi) {
+    return Math.random() * (hi - lo) + lo;
+};
+
+ReservoirBackend.prototype.flush = function flush(records) {
+    var self = this;
+
+    var copy = records.slice(0);
+    self.backend.logMany(copy);
+
+    self.records.length = 0;
+    self.count = 0;
+};
+
+ReservoirBackend.prototype.log = function log(record, cb) {
+    var self = this;
+
+    cb();
+
+    self.count += 1;
+
+    if (self.records.length < self.size) {
+        self.records.push(record);
+    } else {
+        var probability = self.rangeRand(1, self.count);
+        if (probability < self.records.length) {
+            // evict and replace
+            self.records[probability] = record;
+        }
+    }
+};
+
+ReservoirBackend.prototype.destroy = function destroy(cb) {
+    var self = this;
+
+    self.timers.clearTimeout(self.timer);
+    self.backend.destroy(cb);
+};
+
+ReservoirBackend.prototype.bootstrap = function bootstrap(cb) {
+    var self = this;
+
+    self.timer = self.timers.setTimeout(onTimer, self.flushInterval);
+
+    function onTimer() {
+        self.flush(self.records);
+
+        self.timer = self.timers.setTimeout(onTimer, self.flushInterval);
+    }
+
+    self.backend.bootstrap(cb);
+};

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -48,8 +48,8 @@ function ReservoirBackend(options) {
     self.statsd = options.statsd || NullStatsd();
     assert(
         typeof self.statsd === 'object' &&
-        typeof self.statsd.count === 'function',
-        'options.statsd must be object with `count` method'
+        typeof self.statsd.gauge === 'function',
+        'options.statsd must be object with `gauge` method'
     );
 
     self.size = options.size || 100;
@@ -97,7 +97,7 @@ ReservoirBackend.prototype.flush = function flush(records) {
 
     var i;
     for (i in self.dropCount) {
-        self.statsd.count('larch.dropped.' + i, self.dropCount[i]);
+        self.statsd.gauge('larch.dropped.' + i, self.dropCount[i]);
         self.dropCount[i] = 0;
     }
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -95,10 +95,6 @@ ReservoirBackend.prototype.flush = function flush(records) {
 ReservoirBackend.prototype.log = function log(record, cb) {
     var self = this;
 
-    if (typeof cb === 'function') {
-        cb();
-    }
-
     self.count += 1;
 
     if (self.records.length < self.size) {
@@ -109,6 +105,10 @@ ReservoirBackend.prototype.log = function log(record, cb) {
             // evict and replace
             self.records[probability] = record;
         }
+    }
+
+    if (typeof cb === 'function') {
+        cb();
     }
 };
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -26,6 +26,8 @@ var timers = require('timers');
 
 var BaseBackend = require('./base-backend');
 
+module.exports = ReservoirBackend;
+
 function ReservoirBackend(options) {
     if (!(this instanceof ReservoirBackend)) {
         return new ReservoirBackend(options);

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -23,6 +23,7 @@
 var assert = require('assert');
 var util = require('util');
 var timers = require('timers');
+var NullStatsd = require('uber-statsd-client/null');
 
 var BaseBackend = require('./base-backend');
 
@@ -39,9 +40,16 @@ function ReservoirBackend(options) {
 
     self.backend = options.backend;
     assert(
-        typeof options.backend === 'object' &&
-        typeof options.backend.logMany === 'function',
-        'options.backend must be object with logMany function'
+        typeof self.backend === 'object' &&
+        typeof self.backend.logMany === 'function',
+        'options.backend must be object with `logMany` method'
+    );
+
+    self.statsd = options.statsd || NullStatsd();
+    assert(
+        typeof self.statsd === 'object' &&
+        typeof self.statsd.count === 'function',
+        'options.statsd must be object with `count` method'
     );
 
     self.size = options.size || 100;
@@ -73,8 +81,9 @@ function ReservoirBackend(options) {
 
     self.timer = null;
     self.count = 0;
-    self.records = new Array(self.size);;
+    self.records = new Array(self.size);
     self.errors = [];
+    self.dropCount = {};
 }
 
 util.inherits(ReservoirBackend, BaseBackend);
@@ -85,6 +94,12 @@ ReservoirBackend.rangeRand = function rand(lo, hi) {
 
 ReservoirBackend.prototype.flush = function flush(records) {
     var self = this;
+
+    var i;
+    for (i in self.dropCount) {
+        self.statsd.count('larch.dropped.' + i, self.dropCount[i]);
+        self.dropCount[i] = 0;
+    }
 
     var copy = records.slice(0);
     self.backend.logMany(copy, onLoggingDone);
@@ -110,6 +125,13 @@ ReservoirBackend.prototype.log = function log(record, cb) {
         if (probability < self.size) {
             // evict and replace
             self.records[probability] = record;
+        } else {
+            // record drop count
+            if (!self.dropCount[record.data.level]) {
+                self.dropCount[record.data.level] == 1;
+            } else {
+                self.dropCount[record.data.level] += 1;
+            }
         }
     }
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -73,7 +73,7 @@ function ReservoirBackend(options) {
 
     self.timer = null;
     self.count = 0;
-    self.records = [];
+    self.records = new Array(self.size);;
     self.errors = [];
 }
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -74,6 +74,7 @@ function ReservoirBackend(options) {
     self.timer = null;
     self.count = 0;
     self.records = [];
+    self.errors = [];
 }
 
 util.inherits(ReservoirBackend, BaseBackend);
@@ -90,6 +91,7 @@ ReservoirBackend.prototype.flush = function flush(records) {
 
     function onLoggingDone(err) {
         // TODO: what to do when flush fails? Generate a log message?
+        self.errors.push(err);
     }
 
     self.records.length = 0;
@@ -127,7 +129,7 @@ ReservoirBackend.prototype.bootstrap = function bootstrap(cb) {
     var self = this;
 
     assert(
-        typeof cb === 'function', 
+        typeof cb === 'function',
         'bootstrap must be called with a callback'
     );
 

--- a/hyperbahn/lib/larch/reservoir-backend.js
+++ b/hyperbahn/lib/larch/reservoir-backend.js
@@ -159,6 +159,8 @@ ReservoirBackend.prototype.countDrop = function countDrop(level) {
 };
 
 ReservoirBackend.prototype.countLog = function countLog(level) {
+    var self = this;
+
     if (!self.logCount[level]) {
         self.logCount[level] = 1;
     } else {

--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -53,6 +53,7 @@
     "format-stack": "4.1.0",
     "istanbul": "^0.3.17",
     "opn": "^0.1.2",
+    "rezult": "^1.0.0",
     "tape": "^3.4.0",
     "uber-licence": "1.5.1",
     "uber-standard": "3.6.5"

--- a/hyperbahn/package.json
+++ b/hyperbahn/package.json
@@ -55,6 +55,7 @@
     "opn": "^0.1.2",
     "rezult": "^1.0.0",
     "tape": "^3.4.0",
+    "time-mock": "^0.1.2",
     "uber-licence": "1.5.1",
     "uber-standard": "3.6.5"
   },

--- a/hyperbahn/test/index.js
+++ b/hyperbahn/test/index.js
@@ -39,3 +39,4 @@ require('./trace.js');
 require('./remote-config-client.js');
 require('./remote-config.js');
 require('./time-series/requesting-a-service-with-spiky-traffic.js');
+require('./larch/');

--- a/hyperbahn/test/larch/errors.js
+++ b/hyperbahn/test/larch/errors.js
@@ -23,7 +23,7 @@
 var Result = require('rezult');
 var test = require('tape');
 
-var Errors = require('../../../lib/larch/errors');
+var Errors = require('../../lib/larch/errors');
 
 test('resultArrayToError with no errors', function t1(assert) {
     var array = [

--- a/hyperbahn/test/larch/errors.js
+++ b/hyperbahn/test/larch/errors.js
@@ -40,7 +40,7 @@ test('resultArrayToError with no errors', function t1(assert) {
 });
 
 test('resultArrayToError with 1 error', function t2(assert) {
-    var didntWorkErr = new Error('didnt work'); 
+    var didntWorkErr = new Error('didnt work');
 
     var array = [
         new Result(null, 'asdf'),
@@ -86,8 +86,8 @@ test('resultArrayToError with all errors', function t4(assert) {
     var err3 = new Error('didnt work');
 
     var array = [
-        new Result(err1), 
-        new Result(err2), 
+        new Result(err1),
+        new Result(err2),
         new Result(err3)
     ];
 

--- a/hyperbahn/test/larch/errors.js
+++ b/hyperbahn/test/larch/errors.js
@@ -1,3 +1,25 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
 var Result = require('rezult');
 var test = require('tape');
 

--- a/hyperbahn/test/larch/index.js
+++ b/hyperbahn/test/larch/index.js
@@ -20,44 +20,4 @@
 
 'use strict';
 
-var TypedError = require('error/typed');
-
-module.exports.ManyErrors = ManyErrors;
-
-var ManyErrors = TypedError({
-    type: 'many.errors',
-    message: "{count} errors. Example: {example}",
-    count: null,
-    example: null,
-    errors: null
-});
-
-module.exports.resultArrayToError = resultArrayToError;
-
-function resultArrayToError(items, type, message) {
-    var errors = [];
-    var i;
-    for (i = 0; i < items.length; i++) {
-        if (items[i].err) {
-            errors.push(items[i].err);
-        }
-    }
-
-    if (errors.length === 0) {
-        return null;
-    }
-
-    else if (errors.length === 1) {
-        return errors[0];
-    }
-
-    else {
-        return ManyErrors({
-            message: message,
-            type: type,
-            errors: errors,
-            count: errors.length,
-            example: errors[0].message
-        });
-    }
-}
+require('./errors');

--- a/hyperbahn/test/larch/larch.js
+++ b/hyperbahn/test/larch/larch.js
@@ -1,0 +1,108 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var util = require('util');
+
+var Larch = require('../../lib/larch/larch');
+var BaseBackend = require('../../lib/larch/base-backend');
+
+function FakeBackend(options) {
+    if (!(this instanceof FakeBackend)) {
+        return new FakeBackend(options);
+    }
+    var self = this;
+
+    self.logs = [];
+}
+
+util.inherits(FakeBackend, BaseBackend);
+
+FakeBackend.prototype.log = function log(record, cb) {
+    var self = this;
+
+    console.log("got here lol");
+
+    self.logs.push(record);
+
+    if (typeof cb === 'function') {
+        cb();
+    }
+};
+
+test('larch with single backend uses logSingleBackend', function t1(assert) {
+    var backend = FakeBackend();
+
+    var logger = Larch({backends: [backend]});
+
+    assert.ok(
+        logger.log === logger.logSingleBackend, 
+        'logger is using logSingleBackend'
+    );
+
+    logger.error('test', {foo: 'bar'});
+
+    var jsonRecord = backend.logs[0].toJSON();
+    delete jsonRecord.time;
+
+    assert.deepEqual(
+        jsonRecord,
+        {foo: 'bar', message: 'test', level: 'error'},
+        'log backend gets message'
+    );
+
+    assert.end();
+});
+
+test('larch with muiltple backends uses logMultiBackend', function t2(assert) {
+    var backend = FakeBackend();
+    var backend2 = FakeBackend();
+
+    var logger = Larch({backends: [backend, backend2]});
+
+    assert.ok(
+        logger.log === logger.logMultiBackend, 
+        'logger is using logSingleBackend'
+    );
+
+    logger.error('test', {foo: 'bar'});
+
+    var jsonRecord = backend.logs[0].toJSON();
+    delete jsonRecord.time;
+
+    assert.deepEqual(
+        jsonRecord,
+        {foo: 'bar', message: 'test', level: 'error'},
+        'log backend gets message'
+    );
+
+    var jsonRecord2 = backend2.logs[0].toJSON();
+    delete jsonRecord2.time;
+
+    assert.deepEqual(
+        jsonRecord2,
+        {foo: 'bar', message: 'test', level: 'error'},
+        'log backend 2 gets message'
+    );
+
+    assert.end();
+});

--- a/hyperbahn/test/larch/larch.js
+++ b/hyperbahn/test/larch/larch.js
@@ -40,8 +40,6 @@ util.inherits(FakeBackend, BaseBackend);
 FakeBackend.prototype.log = function log(record, cb) {
     var self = this;
 
-    console.log("got here lol");
-
     self.logs.push(record);
 
     if (typeof cb === 'function') {
@@ -55,7 +53,7 @@ test('larch with single backend uses logSingleBackend', function t1(assert) {
     var logger = Larch({backends: [backend]});
 
     assert.ok(
-        logger.log === logger.logSingleBackend, 
+        logger.log === logger.logSingleBackend,
         'logger is using logSingleBackend'
     );
 
@@ -80,7 +78,7 @@ test('larch with muiltple backends uses logMultiBackend', function t2(assert) {
     var logger = Larch({backends: [backend, backend2]});
 
     assert.ok(
-        logger.log === logger.logMultiBackend, 
+        logger.log === logger.logMultiBackend,
         'logger is using logSingleBackend'
     );
 

--- a/hyperbahn/test/larch/larch.js
+++ b/hyperbahn/test/larch/larch.js
@@ -21,10 +21,8 @@
 'use strict';
 
 var test = require('tape');
-var util = require('util');
 
 var Larch = require('../../lib/larch/larch');
-var BaseBackend = require('../../lib/larch/base-backend');
 var FakeBackend = require('../lib/fake-backend');
 
 test('larch with single backend uses logSingleBackend', function t1(assert) {

--- a/hyperbahn/test/larch/larch.js
+++ b/hyperbahn/test/larch/larch.js
@@ -25,35 +25,7 @@ var util = require('util');
 
 var Larch = require('../../lib/larch/larch');
 var BaseBackend = require('../../lib/larch/base-backend');
-
-function FakeBackend(options) {
-    if (!(this instanceof FakeBackend)) {
-        return new FakeBackend(options);
-    }
-    this.logs = [];
-    this.bootstrapped = false;
-    this.destroyed = false;
-}
-
-util.inherits(FakeBackend, BaseBackend);
-
-FakeBackend.prototype.log = function log(record, cb) {
-    this.logs.push(record);
-
-    if (typeof cb === 'function') {
-        cb();
-    }
-};
-
-FakeBackend.prototype.bootstrap = function bootstrap(cb) {
-    this.bootstrapped = true;
-    cb();
-};
-
-FakeBackend.prototype.destroy = function destroy(cb) {
-    this.destroyed = true;
-    cb();
-};
+var FakeBackend = require('../lib/fake-backend');
 
 test('larch with single backend uses logSingleBackend', function t1(assert) {
     var backend = FakeBackend();

--- a/hyperbahn/test/larch/reservoir-backend.js
+++ b/hyperbahn/test/larch/reservoir-backend.js
@@ -60,27 +60,27 @@ test('ReservoirBackend correctly limits logs', function t1(assert) {
     assert.ok(backend.logs.length === 5, 'only 5 logs got through to backend');
 
     assert.ok(
-        backend.logs[0].data.message === 'thing failed', 
+        backend.logs[0].data.message === 'thing failed',
         'logs[0] is right'
     );
     assert.ok(
-        backend.logs[1].data.message === 'timed out', 
+        backend.logs[1].data.message === 'timed out',
         'logs[1] is right'
     );
     assert.ok(
-        backend.logs[2].data.message === 'timed out', 
+        backend.logs[2].data.message === 'timed out',
         'logs[2] is right'
     );
     assert.ok(
-        backend.logs[3].data.message === 'timed out', 
+        backend.logs[3].data.message === 'timed out',
         'logs[3] is right'
     );
     assert.ok(
-        backend.logs[4].data.message === 'timed out', 
+        backend.logs[4].data.message === 'timed out',
         'logs[4] is right'
     );
 
     assert.end();
 });
 
-function noop () {}
+function noop() {}

--- a/hyperbahn/test/larch/reservoir-backend.js
+++ b/hyperbahn/test/larch/reservoir-backend.js
@@ -80,6 +80,8 @@ test('ReservoirBackend correctly limits logs', function t1(assert) {
         'logs[4] is right'
     );
 
+    reservoir.destroy(noop);
+
     assert.end();
 });
 

--- a/hyperbahn/test/larch/reservoir-backend.js
+++ b/hyperbahn/test/larch/reservoir-backend.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var Timer = require('time-mock');
+
+var ReservoirBackend = require('../../lib/larch/reservoir-backend');
+var Record = require('../../lib/larch/record');
+
+var FakeBackend = require('../lib/fake-backend');
+
+test('ReservoirBackend correctly limits logs', function t1(assert) {
+    function fakeRangeRand(lo, hi) {
+        return 0;
+    }
+
+    var backend = FakeBackend();
+    var timer = Timer(0);
+
+    var reservoir = ReservoirBackend({
+        backend: backend,
+        size: 5,
+        timers: timer,
+        rangeRand: fakeRangeRand
+    });
+
+    reservoir.bootstrap(noop);
+
+    assert.ok(backend.bootstrapped, 'backend was bootstrapped');
+
+    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.log(new Record('error', 'timed out', {}));
+    reservoir.log(new Record('warn', 'thing failed', {}));
+
+    timer.advance(50);
+
+    assert.ok(reservoir.records.length === 0, 'reservoir was flushed');
+    assert.ok(backend.logs.length === 5, 'only 5 logs got through to backend');
+
+    assert.ok(
+        backend.logs[0].data.message === 'thing failed', 
+        'logs[0] is right'
+    );
+    assert.ok(
+        backend.logs[1].data.message === 'timed out', 
+        'logs[1] is right'
+    );
+    assert.ok(
+        backend.logs[2].data.message === 'timed out', 
+        'logs[2] is right'
+    );
+    assert.ok(
+        backend.logs[3].data.message === 'timed out', 
+        'logs[3] is right'
+    );
+    assert.ok(
+        backend.logs[4].data.message === 'timed out', 
+        'logs[4] is right'
+    );
+
+    assert.end();
+});
+
+function noop () {}

--- a/hyperbahn/test/lib/fake-backend.js
+++ b/hyperbahn/test/lib/fake-backend.js
@@ -54,4 +54,3 @@ FakeBackend.prototype.destroy = function destroy(cb) {
     this.destroyed = true;
     cb();
 };
-

--- a/hyperbahn/test/lib/fake-backend.js
+++ b/hyperbahn/test/lib/fake-backend.js
@@ -20,6 +20,38 @@
 
 'use strict';
 
-require('./errors');
-require('./larch');
-require('./reservoir-backend');
+var util = require('util');
+
+var BaseBackend = require('../../lib/larch/base-backend');
+
+module.exports = FakeBackend;
+
+function FakeBackend(options) {
+    if (!(this instanceof FakeBackend)) {
+        return new FakeBackend(options);
+    }
+    this.logs = [];
+    this.bootstrapped = false;
+    this.destroyed = false;
+}
+
+util.inherits(FakeBackend, BaseBackend);
+
+FakeBackend.prototype.log = function log(record, cb) {
+    this.logs.push(record);
+
+    if (typeof cb === 'function') {
+        cb();
+    }
+};
+
+FakeBackend.prototype.bootstrap = function bootstrap(cb) {
+    this.bootstrapped = true;
+    cb();
+};
+
+FakeBackend.prototype.destroy = function destroy(cb) {
+    this.destroyed = true;
+    cb();
+};
+

--- a/hyperbahn/test/lib/larch/errors.js
+++ b/hyperbahn/test/lib/larch/errors.js
@@ -1,0 +1,83 @@
+var Result = require('rezult');
+var test = require('tape');
+
+var Errors = require('../../../lib/larch/errors');
+
+test('resultArrayToError with no errors', function t1(assert) {
+    var array = [
+        new Result(null, 'foo'),
+        new Result(null, 'bar'),
+        new Result(null, 'baz')
+    ];
+
+    var err = Errors.resultArrayToError(array, 'thing.error');
+
+    assert.ok(err === null, 'returns null');
+
+    assert.end();
+});
+
+test('resultArrayToError with 1 error', function t2(assert) {
+    var didntWorkErr = new Error('didnt work'); 
+
+    var array = [
+        new Result(null, 'asdf'),
+        new Result(didntWorkErr),
+        new Result(null, 'asdfsdsf'),
+        new Result(null, 'jkl')
+    ];
+
+    var err = Errors.resultArrayToError(array, 'thing.error');
+
+    assert.ok(err === didntWorkErr, 'returns the one error');
+
+    assert.end();
+});
+
+test('resultArrayToError with some errors', function t3(assert) {
+    var err1 = new Error('foobar');
+    var err2 = new Error('timeout');
+
+    var array = [
+        new Result(null, 'foo'),
+        new Result(err1),
+        new Result(null, 'bar'),
+        new Result(null, 'foobar'),
+        new Result(err2)
+    ];
+
+    var err = Errors.resultArrayToError(array, 'thing.error');
+
+    assert.ok(err.type === 'thing.error', 'error type is right');
+    assert.ok(err.message === '2 errors. Example: foobar', 'error message is right');
+    assert.ok(err.count === 2, 'error count is right');
+    assert.ok(err.example === 'foobar', 'error example is right');
+    assert.ok(err.errors[0] === err1, 'errors[0] is err1');
+    assert.ok(err.errors[1] === err2, 'errors[1] is err2');
+
+    assert.end();
+});
+
+test('resultArrayToError with all errors', function t4(assert) {
+    var err1 = new Error('foobar');
+    var err2 = new Error('timeout');
+    var err3 = new Error('didnt work');
+
+    var array = [
+        new Result(err1), 
+        new Result(err2), 
+        new Result(err3)
+    ];
+
+    var err = Errors.resultArrayToError(array, 'thing.error');
+
+    assert.ok(err.type === 'thing.error', 'error type is right');
+    assert.ok(err.message === '3 errors. Example: foobar', 'error message is right');
+    assert.ok(err.count === 3, 'error count is right');
+    assert.ok(err.example === 'foobar', 'error example is right');
+    assert.ok(err.errors[0] === err1, 'errors[0] is err1');
+    assert.ok(err.errors[1] === err2, 'errors[1] is err2');
+    assert.ok(err.errors[2] === err3, 'errors[1] is err2');
+
+    assert.end();
+});


### PR DESCRIPTION
@Raynos @jcorbin @kriskowal 

To continue the discussion on the commit:

1. Should we do straight reservoir sampling or do a scored-record sampling approach for the first impl? **For v0 we'll do straight reservoir sampling just to see what affect it has on resource usage when generating a lot of error logs.**
2. Is violation of log ordering a problem? I think its not; the logs will be mis ordered per 50ms chunk and only if there are more than 500 logs in that chunk. 
3. My weird copy serialize optimization in `record.js`. It uses an object with the data that doesn't change and copies the meta fields into it. My benchmarks showed that to be faster, but I could remove the optimization for clarity and instead just copy all fields into a new object.