### PR TITLE
go: Add StatsReporter and StatsTags to Registrar interface

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -235,6 +235,9 @@ type Registrar interface {
 	// Logger returns the logger for this Registrar.
 	Logger() Logger
 
+	// StatsReporter returns the stats reporter for this Registrar.
+	StatsReporter() StatsReporter
+
 	// Peers returns the peer list for this Registrar.
 	Peers() *PeerList
 }
@@ -346,6 +349,11 @@ func (ch *Channel) Ping(ctx context.Context, hostPort string) error {
 // Logger returns the logger for this channel.
 func (ch *Channel) Logger() Logger {
 	return ch.log
+}
+
+// StatsReporter returns the stats reporter for this channel.
+func (ch *Channel) StatsReporter() StatsReporter {
+	return ch.statsReporter
 }
 
 // ServiceName returns the serviceName that this channel was created for.

--- a/golang/channel.go
+++ b/golang/channel.go
@@ -235,8 +235,11 @@ type Registrar interface {
 	// Logger returns the logger for this Registrar.
 	Logger() Logger
 
-	// StatsReporter returns the stats reporter for this Registrar.
+	// StatsReporter returns the stats reporter for this Registrar
 	StatsReporter() StatsReporter
+
+	// StatsTags returns the tags that should be used.
+	StatsTags() map[string]string
 
 	// Peers returns the peer list for this Registrar.
 	Peers() *PeerList
@@ -354,6 +357,16 @@ func (ch *Channel) Logger() Logger {
 // StatsReporter returns the stats reporter for this channel.
 func (ch *Channel) StatsReporter() StatsReporter {
 	return ch.statsReporter
+}
+
+// StatsTags returns the common tags that should be used when reporting stats.
+// It returns a new map for each call.
+func (ch *Channel) StatsTags() map[string]string {
+	m := make(map[string]string)
+	for k, v := range ch.commonStatsTags {
+		m[k] = v
+	}
+	return m
 }
 
 // ServiceName returns the serviceName that this channel was created for.

--- a/golang/channel_test.go
+++ b/golang/channel_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func toMap(fields LogFields) map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, f := range fields {
+		m[f.Key] = f.Value
+	}
+	return m
+}
+
+func TestLoggers(t *testing.T) {
+	ch, err := NewChannel("svc", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	peerInfo := ch.PeerInfo()
+	fields := toMap(ch.Logger().Fields())
+	assert.Equal(t, peerInfo.ServiceName, fields["service"])
+
+	sc := ch.GetSubChannel("subch")
+	fields = toMap(sc.Logger().Fields())
+	assert.Equal(t, peerInfo.ServiceName, fields["service"])
+	assert.Equal(t, "subch", fields["subchannel"])
+}
+
+func TestStats(t *testing.T) {
+	ch, err := NewChannel("svc", &ChannelOptions{
+		Logger: NewLogger(ioutil.Discard),
+	})
+	require.NoError(t, err, "NewChannel failed")
+
+	hostname, err := os.Hostname()
+	require.NoError(t, err, "Hostname failed")
+
+	peerInfo := ch.PeerInfo()
+	tags := ch.StatsTags()
+	assert.NotNil(t, ch.StatsReporter(), "StatsReporter missing")
+	assert.Equal(t, peerInfo.ProcessName, tags["app"], "app tag")
+	assert.Equal(t, peerInfo.ServiceName, tags["service"], "service tag")
+	assert.Equal(t, hostname, tags["host"], "hostname tag")
+
+	sc := ch.GetSubChannel("subch")
+	subTags := sc.StatsTags()
+	assert.NotNil(t, sc.StatsReporter(), "StatsReporter missing")
+	for k, v := range tags {
+		assert.Equal(t, v, subTags[k], "subchannel missing tag %v", k)
+	}
+	assert.Equal(t, "subch", subTags["subchannel"], "subchannel tag missing")
+}

--- a/golang/subchannel.go
+++ b/golang/subchannel.go
@@ -36,6 +36,7 @@ type SubChannel struct {
 	peers              *PeerList
 	handlers           *handlerMap
 	logger             Logger
+	statsReporter      StatsReporter
 }
 
 // Map of subchannel and the corresponding service
@@ -47,11 +48,12 @@ type subChannelMap struct {
 func newSubChannel(serviceName string, ch *Channel) *SubChannel {
 	logger := ch.Logger().WithFields(LogField{"subchannel", serviceName})
 	return &SubChannel{
-		serviceName: serviceName,
-		peers:       ch.peers,
-		topChannel:  ch,
-		handlers:    &handlerMap{},
-		logger:      logger,
+		serviceName:   serviceName,
+		peers:         ch.peers,
+		topChannel:    ch,
+		handlers:      &handlerMap{},
+		logger:        logger,
+		statsReporter: ch.StatsReporter(),
 	}
 }
 
@@ -83,6 +85,11 @@ func (c *SubChannel) Register(h Handler, operationName string) {
 // Logger returns the logger for this subchannel.
 func (c *SubChannel) Logger() Logger {
 	return c.logger
+}
+
+// StatsReporter returns the StatsReporter for this subchannel.
+func (c *SubChannel) StatsReporter() StatsReporter {
+	return c.statsReporter
 }
 
 // Find if a handler for the given service+operation pair exists

--- a/golang/subchannel.go
+++ b/golang/subchannel.go
@@ -87,9 +87,16 @@ func (c *SubChannel) Logger() Logger {
 	return c.logger
 }
 
-// StatsReporter returns the StatsReporter for this subchannel.
+// StatsReporter returns the stats reporter for this subchannel.
 func (c *SubChannel) StatsReporter() StatsReporter {
-	return c.statsReporter
+	return c.topChannel.StatsReporter()
+}
+
+// StatsTags returns the stats tags for this subchannel.
+func (c *SubChannel) StatsTags() map[string]string {
+	tags := c.topChannel.StatsTags()
+	tags["subchannel"] = c.serviceName
+	return tags
 }
 
 // Find if a handler for the given service+operation pair exists


### PR DESCRIPTION
This will allow subpackages (e.g. hyperbahn, thrift, trace) to report stats using the same tags as the tchannel package.

cc @junchaowu 