### PR TITLE
default emitConnectionMetrics to false

### DIFF
--- a/node/channel.js
+++ b/node/channel.js
@@ -137,7 +137,7 @@ function TChannel(options) {
     self.requireCn = self.options.requireCn;
     self.emitConnectionMetrics =
         typeof self.options.emitConnectionMetrics === 'boolean' ?
-        self.options.emitConnectionMetrics : true;
+        self.options.emitConnectionMetrics : false;
     self.choosePeerWithHeap = self.options.choosePeerWithHeap || false;
 
     // required: 'app'

--- a/node/test/connection-stats.js
+++ b/node/test/connection-stats.js
@@ -27,7 +27,10 @@ var allocCluster = require('./lib/alloc-cluster.js');
 var timers = TimeMock(Date.now());
 
 allocCluster.test('emits connection stats with success', {
-    numPeers: 2
+    numPeers: 2,
+    channelOptions: {
+        emitConnectionMetrics: true
+    }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
     var client = cluster.channels[1];
@@ -99,7 +102,10 @@ allocCluster.test('emits connection stats with success', {
 });
 
 allocCluster.test('emits connection stats with failure', {
-    numPeers: 1
+    numPeers: 1,
+    channelOptions: {
+        emitConnectionMetrics: true
+    }
 }, function t(cluster, assert) {
     var client = cluster.channels[0];
     var clientHost = cluster.hosts[0];
@@ -167,7 +173,8 @@ allocCluster.test('emits connection stats with failure', {
 allocCluster.test('emits active connections', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];

--- a/node/test/connection-with-statsd.js
+++ b/node/test/connection-with-statsd.js
@@ -29,7 +29,10 @@ var TChannelStatsd = require('../lib/statsd');
 var timers = TimeMock(Date.now());
 
 allocCluster.test('emits connection stats with success', {
-    numPeers: 2
+    numPeers: 2,
+    channelOptions: {
+        emitConnectionMetrics: true
+    }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
     var client = cluster.channels[1];
@@ -89,7 +92,10 @@ allocCluster.test('emits connection stats with success', {
 });
 
 allocCluster.test('emits connection stats with failure', {
-    numPeers: 1
+    numPeers: 1,
+    channelOptions: {
+        emitConnectionMetrics: true
+    }
 }, function t(cluster, assert) {
     var client = cluster.channels[0];
     var hostKey = 'localhost';
@@ -143,7 +149,8 @@ allocCluster.test('emits connection stats with failure', {
 allocCluster.test('emits active connections', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];

--- a/node/test/request-stats.js
+++ b/node/test/request-stats.js
@@ -30,7 +30,8 @@ allocCluster.test('emits stats', {
         statTags: {
             app: 'client',
             host: os.hostname()
-        }
+        },
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];

--- a/node/test/request-with-statsd.js
+++ b/node/test/request-with-statsd.js
@@ -31,7 +31,8 @@ var timers = TimeMock(Date.now());
 allocCluster.test('emits stats on call success', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -149,7 +150,8 @@ allocCluster.test('emits stats on call success', {
 allocCluster.test('emits stats on p2p call success', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -366,7 +368,8 @@ allocCluster.test('emits stats with no connection metrics', {
 allocCluster.test('emits stats on call failure', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];

--- a/node/test/response-stats.js
+++ b/node/test/response-stats.js
@@ -30,7 +30,8 @@ allocCluster.test('emits response stats with ok', {
         statTags: {
             app: 'server',
             host: os.hostname()
-        }
+        },
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -193,7 +194,8 @@ allocCluster.test('emits response stats with not ok', {
         statTags: {
             app: 'server',
             host: os.hostname()
-        }
+        },
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -357,7 +359,8 @@ allocCluster.test('emits response stats with error', {
         statTags: {
             app: 'server',
             host: os.hostname()
-        }
+        },
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];

--- a/node/test/response-with-statsd.js
+++ b/node/test/response-with-statsd.js
@@ -31,7 +31,8 @@ var timers = TimeMock(Date.now());
 allocCluster.test('emits stats on response ok', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -146,7 +147,8 @@ allocCluster.test('emits stats on response ok', {
 allocCluster.test('emits stats on response not ok', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];
@@ -261,7 +263,8 @@ allocCluster.test('emits stats on response not ok', {
 allocCluster.test('emits stats on response error', {
     numPeers: 2,
     channelOptions: {
-        timers: timers
+        timers: timers,
+        emitConnectionMetrics: true
     }
 }, function t(cluster, assert) {
     var server = cluster.channels[0];


### PR DESCRIPTION
We turn it off in production for performance reasons. Having
it on by default burns 10% of the process CPU with peer
reporting logic.

Until we've optimized connection metrics it should be off
by default.

r: @kriskowal @rf