### PR TITLE
Verify that busy frames can be smoothed over

### DIFF
--- a/hyperbahn/app.js
+++ b/hyperbahn/app.js
@@ -103,7 +103,6 @@ Application.prototype.bootstrap = function bootstrap(cb) {
 
     setupEndpoints(self.clients, self.services);
 
-    self.hookupSignals();
     self.clients.bootstrap(onClientsReady);
 
     function onClientsReady(err) {

--- a/hyperbahn/server.js
+++ b/hyperbahn/server.js
@@ -57,6 +57,7 @@ function main(opts) {
 
     // attach before throwing exception
     process.on('uncaughtException', app.clients.onError);
+    app.hookupSignals();
 
     app.bootstrapAndListen(function onAppReady(err) {
         if (err) {

--- a/hyperbahn/test/lib/time-series-cluster.js
+++ b/hyperbahn/test/lib/time-series-cluster.js
@@ -138,7 +138,7 @@ TimeSeriesCluster.prototype.setupClusterOptions =
 function setupClusterOptions(opts) {
     var self = this;
 
-    self.clusterOptions = opts.cluster || {};
+    self.clusterOptions = opts.clusterOptions || {};
     if (!self.clusterOptions.size) {
         self.clusterOptions.size = 10;
     }

--- a/hyperbahn/test/lib/time-series-cluster.js
+++ b/hyperbahn/test/lib/time-series-cluster.js
@@ -85,7 +85,7 @@ module.exports = TimeSeriesCluster;
 */
 function TimeSeriesCluster(opts) {
     /* eslint max-statements: [2, 40] */
-    /* eslint max-complexity: [2, 20] */
+    /* eslint complexity: [2, 20] */
     if (!(this instanceof TimeSeriesCluster)) {
         return new TimeSeriesCluster(opts);
     }

--- a/hyperbahn/test/lib/time-series-cluster.js
+++ b/hyperbahn/test/lib/time-series-cluster.js
@@ -151,7 +151,6 @@ function setupClusterOptions(opts) {
     if (!('rateLimiting.enabled' in self.clusterOptions.remoteConfig)) {
         self.clusterOptions.remoteConfig['rateLimiting.enabled'] = false;
     }
-    self.clusterOptions.namedRemotes = self.namedRemotes;
     if (!('hyperbahn.circuits' in self.clusterOptions.remoteConfig)) {
         self.clusterOptions.remoteConfig['hyperbahn.circuits'] = {
             period: 100,
@@ -161,6 +160,14 @@ function setupClusterOptions(opts) {
             enabled: false
         };
     }
+    if (!('kValue.services' in self.clusterOptions.remoteConfig)) {
+        // Force fully connected client
+        self.clusterOptions.remoteConfig['kValue.services'] = {
+            'time-series-client': self.clusterOptions.size * 3
+        };
+    }
+
+    self.clusterOptions.namedRemotes = self.namedRemotes;
 };
 
 TimeSeriesCluster.prototype.bootstrap = function bootstrap(cb) {

--- a/hyperbahn/test/lib/time-series-cluster.js
+++ b/hyperbahn/test/lib/time-series-cluster.js
@@ -85,6 +85,7 @@ module.exports = TimeSeriesCluster;
 */
 function TimeSeriesCluster(opts) {
     /* eslint max-statements: [2, 40] */
+    /* eslint max-complexity: [2, 20] */
     if (!(this instanceof TimeSeriesCluster)) {
         return new TimeSeriesCluster(opts);
     }

--- a/hyperbahn/test/lib/time-series-cluster.js
+++ b/hyperbahn/test/lib/time-series-cluster.js
@@ -208,6 +208,20 @@ TimeSeriesCluster.prototype.bootstrap = function bootstrap(cb) {
     }
 };
 
+TimeSeriesCluster.prototype.printBatches = function printBatches() {
+    var self = this;
+
+    var count = 0;
+    self.batchClient.on('batch-updated', function onUpdate(meta) {
+        count++;
+
+        if (count % 10 === 0) {
+            /* eslint no-console:0 */
+            console.log('batch updated', meta);
+        }
+    });
+};
+
 TimeSeriesCluster.prototype.sendRequests = function sendRequests(cb) {
     var self = this;
 

--- a/hyperbahn/test/time-series/constant-low-volume-48kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-48kb-traffic.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var console = require('console');
 var Buffer = require('buffer').Buffer;
 
 var TimeSeriesCluster = require('../lib/time-series-cluster.js');

--- a/hyperbahn/test/time-series/constant-low-volume-48kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-48kb-traffic.js
@@ -49,15 +49,7 @@ TimeSeriesCluster.test('constant low volume 48kb traffic', {
     cluster.logger.whitelist('warn', 'forwarding error frame');
     cluster.logger.whitelist('warn', 'mismatched conn.onReqDone');
 
-    var count = 0;
-    cluster.batchClient.on('batch-updated', function onUpdate(meta) {
-        count++;
-
-        if (count % 10 === 0) {
-            /* eslint no-console:0 */
-            console.log('batch updated', meta);
-        }
-    });
+    cluster.printBatches();
 
     cluster.sendRequests(onResults);
 

--- a/hyperbahn/test/time-series/constant-low-volume-4kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-4kb-traffic.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var console = require('console');
 var Buffer = require('buffer').Buffer;
 
 var TimeSeriesCluster = require('../lib/time-series-cluster.js');

--- a/hyperbahn/test/time-series/constant-low-volume-4kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-4kb-traffic.js
@@ -49,15 +49,7 @@ TimeSeriesCluster.test('constant low volume 4kb traffic', {
     cluster.logger.whitelist('warn', 'forwarding error frame');
     cluster.logger.whitelist('warn', 'mismatched conn.onReqDone');
 
-    var count = 0;
-    cluster.batchClient.on('batch-updated', function onUpdate(meta) {
-        count++;
-
-        if (count % 10 === 0) {
-            /* eslint no-console:0 */
-            console.log('batch updated', meta);
-        }
-    });
+    cluster.printBatches();
 
     cluster.sendRequests(onResults);
 

--- a/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var console = require('console');
 var Buffer = require('buffer').Buffer;
 
 var TimeSeriesCluster = require('../lib/time-series-cluster.js');

--- a/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
@@ -33,7 +33,7 @@ var REQUEST_BODY_CHUNKS = [
     new Buffer(REQUEST_BODY)
 ];
 
-TimeSeriesCluster.test('constant low volume 512kb traffic', {
+TimeSeriesCluster.test('constant low volume 512KiB traffic', {
     clusterOptions: {},
     buckets: [
         25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25

--- a/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
+++ b/hyperbahn/test/time-series/constant-low-volume-512kb-traffic.js
@@ -55,15 +55,7 @@ TimeSeriesCluster.test('constant low volume 512kb traffic', {
     cluster.logger.whitelist('warn', 'forwarding error frame');
     cluster.logger.whitelist('warn', 'mismatched conn.onReqDone');
 
-    var count = 0;
-    cluster.batchClient.on('batch-updated', function onUpdate(meta) {
-        count++;
-
-        if (count % 10 === 0) {
-            /* eslint no-console:0 */
-            console.log('batch updated', meta);
-        }
-    });
+    cluster.printBatches();
 
     // cluster.sendRequests(onResults);
     cluster.sendStreamingRequests(onResults);

--- a/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
+++ b/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
@@ -42,7 +42,7 @@ TimeSeriesCluster.test('control test for time-series of timeout requests', {
 
     clientInstances: 1,
     clientBatchDelay: 100,
-    numBatchesInBucket: 25,
+    numBatchesInBucket: 10,
     clientRequestsPerBatch: 25,
     clientRequestsPerBatchForFirstBucket: 10
 }, function t(cluster, assert) {
@@ -59,7 +59,7 @@ TimeSeriesCluster.test('control test for time-series of timeout requests', {
 
     // Set rate on a single Hyperbahn worker
     cluster._cluster.apps[4].clients
-        .serviceProxy.rateLimiter.updateTotalLimit(50);
+        .serviceProxy.rateLimiter.updateTotalLimit(10);
 
     // cluster.printBatches();
 
@@ -80,12 +80,12 @@ TimeSeriesCluster.test('control test for time-series of timeout requests', {
 
         var logLines = cluster.logger.items();
         var rateLimits = logLines.filter(isRateLimit);
-        assert.ok(rateLimits.length >= 50,
-            'expect at least 50 attempts to be rate limited');
+        assert.ok(rateLimits.length >= 25,
+            'expect at least 25 attempts to be rate limited');
 
         assert.ok(rateLimits.every(function checkLog(r) {
-            return r.fields.rpsLimit === 50;
-        }), 'rate limit should be 50');
+            return r.fields.rpsLimit === 10;
+        }), 'rate limit should be 10');
 
         assert.end();
     }

--- a/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
+++ b/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
@@ -20,8 +20,35 @@
 
 'use strict';
 
+var console = require('console');
+
 var TimeSeriesCluster = require('../lib/time-series-cluster.js');
 
+// 14 is a magic number for zero errors + >25 rate limits.
+var OVERLOADED_WORKER_RATELIMIT = 14;
+
+/* End to end test to ensure that retries on Busy work as expected.
+
+    The semantics we want is that when a single Hyperbahn worker
+    is busy an edge client will use retries to "maneouver" around
+    that worker and get 100% success rate.
+
+    We create a TimeSeriesCluster with:
+
+     - 10 hyperbahn worker nodes
+     - rate limiting set to 200 per worker.
+     - We split the test run into 4 buckets
+     - We want one client to have deterministic peer selection
+     - We want 250 req/s split between 10 workers
+     - We manually set the first bucket to 100 req/s to warm
+        up the entire cluster
+
+    Once our test finishes we expect:
+
+     - All requests to succeed
+     - To get at least 2% of requests to be rate limited
+
+*/
 TimeSeriesCluster.test('testing worker with low rate limit', {
     clusterOptions: {
         size: 10,
@@ -36,7 +63,7 @@ TimeSeriesCluster.test('testing worker with low rate limit', {
     buckets: [
         25, 25, 25, 25
     ],
-    clientTimeout: 100,
+    clientTimeout: 500,
     endpointToRequest: 'echo-endpoint',
     requestBody: TimeSeriesCluster.buildString(10),
 
@@ -68,6 +95,8 @@ TimeSeriesCluster.test('testing worker with low rate limit', {
     function onResults(err, results) {
         assert.ifError(err);
 
+        // Ignore first bucket as it's the warmup bucket
+        // which is a statistical outlier for this test.
         for (var i = 1; i < cluster.buckets.length; i++) {
             cluster.assertRange(assert, {
                 value: results[i].errorCount,
@@ -76,21 +105,35 @@ TimeSeriesCluster.test('testing worker with low rate limit', {
                 description: ' error rate ',
                 index: i
             });
+
+            if (results[i].errorCount > 0) {
+                /* eslint no-console: 0 */
+                console.log('# results', results[i]);
+            }
         }
 
         var logLines = cluster.logger.items();
+
+        // We made 250 req/s for 4 seconds. We expect at least
+        // 1 requests out of a 1000 to be rate limited by
+        // worker[4]
         var rateLimits = logLines.filter(isRateLimit);
-        assert.ok(rateLimits.length >= 25,
-            'expect at least 25 attempts to be rate limited');
+        assert.ok(rateLimits.length >= 1,
+            'expect at least 1 attempts to be rate limited ' +
+            'but is: ' + rateLimits.length);
 
         assert.ok(rateLimits.every(function checkLog(r) {
-            return r.fields.rpsLimit === 10;
-        }), 'rate limit should be 10');
+            if (r.meta.rpsLimit !== OVERLOADED_WORKER_RATELIMIT) {
+                console.log('wat', r.meta);
+            }
+
+            return r.meta.rpsLimit === OVERLOADED_WORKER_RATELIMIT;
+        }), 'rate limit should be ' + OVERLOADED_WORKER_RATELIMIT);
 
         assert.end();
     }
 });
 
 function isRateLimit(logRecord) {
-    return logRecord.fields.msg === 'hyperbahn node is rate-limited by the total rps limit';
+    return logRecord.msg === 'hyperbahn node is rate-limited by the total rps limit';
 }

--- a/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
+++ b/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var TimeSeriesCluster = require('../lib/time-series-cluster.js');
+
+TimeSeriesCluster.test('control test for time-series of timeout requests', {
+    clusterOptions: {
+        size: 10,
+        remoteConfig: {
+            'rateLimiting.enabled': true,
+            'rateLimiting.totalRpsLimit': 200,
+            'rateLimiting.rpsLimitForServiceName': {
+                'time-series-server': 800
+            }
+        }
+    },
+    buckets: [
+        25, 25, 25, 25
+    ],
+    clientTimeout: 100,
+    endpointToRequest: 'echo-endpoint',
+    requestBody: TimeSeriesCluster.buildString(10),
+
+    clientInstances: 1,
+    clientBatchDelay: 100,
+    numBatchesInBucket: 25,
+    clientRequestsPerBatch: 25,
+    clientRequestsPerBatchForFirstBucket: 10
+}, function t(cluster, assert) {
+    cluster.logger.whitelist('info', 'error for timed out outgoing response');
+    cluster.logger.whitelist('info', 'forwarding expected error frame');
+    cluster.logger.whitelist('info', 'expected error while forwarding');
+    cluster.logger.whitelist('info', 'OutResponse.send() after inreq timed out');
+    cluster.logger.whitelist('warn', 'forwarding error frame');
+    cluster.logger.whitelist('warn', 'mismatched conn.onReqDone');
+    cluster.logger.whitelist('info', 'ignoring outresponse.send on a closed connection');
+    cluster.logger.whitelist('info', 'ignoring outresponse.sendError on a closed connection');
+    cluster.logger.whitelist('info', 'popOutReq received for unknown or lost id');
+    cluster.logger.whitelist('info', 'hyperbahn node is rate-limited by the total rps limit');
+
+    // Set rate on a single Hyperbahn worker
+    cluster._cluster.apps[4].clients
+        .serviceProxy.rateLimiter.updateTotalLimit(50);
+
+    // cluster.printBatches();
+
+    cluster.sendRequests(onResults);
+
+    function onResults(err, results) {
+        assert.ifError(err);
+
+        for (var i = 1; i < cluster.buckets.length; i++) {
+            cluster.assertRange(assert, {
+                value: results[i].errorCount,
+                min: 0,
+                max: 0,
+                description: ' error rate ',
+                index: i
+            });
+        }
+
+        var logLines = cluster.logger.items();
+        var rateLimits = logLines.filter(isRateLimit);
+        assert.ok(rateLimits.length >= 50,
+            'expect at least 50 attempts to be rate limited');
+
+        assert.ok(rateLimits.every(function checkLog(r) {
+            return r.fields.rpsLimit === 50;
+        }), 'rate limit should be 50');
+
+        assert.end();
+    }
+});
+
+function isRateLimit(logRecord) {
+    return logRecord.fields.msg === 'hyperbahn node is rate-limited by the total rps limit';
+}

--- a/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
+++ b/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
@@ -84,12 +84,13 @@ TimeSeriesCluster.test('testing worker with low rate limit', {
     cluster.logger.whitelist('info', 'popOutReq received for unknown or lost id');
     cluster.logger.whitelist('info', 'hyperbahn node is rate-limited by the total rps limit');
 
+    var apps = cluster._cluster.getExitNodes('time-series-server');
+
     // Set rate on a single Hyperbahn worker
-    cluster._cluster.apps[4].clients
-        .serviceProxy.rateLimiter.updateTotalLimit(10);
+    apps[0].clients .serviceProxy
+        .rateLimiter.updateTotalLimit(OVERLOADED_WORKER_RATELIMIT);
 
     // cluster.printBatches();
-
     cluster.sendRequests(onResults);
 
     function onResults(err, results) {

--- a/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
+++ b/hyperbahn/test/time-series/making-requests-with-a-single-busy-hyperbahn-worker.js
@@ -22,7 +22,7 @@
 
 var TimeSeriesCluster = require('../lib/time-series-cluster.js');
 
-TimeSeriesCluster.test('control test for time-series of timeout requests', {
+TimeSeriesCluster.test('testing worker with low rate limit', {
     clusterOptions: {
         size: 10,
         remoteConfig: {

--- a/hyperbahn/test/time-series/requesting-a-service-with-spiky-traffic.js
+++ b/hyperbahn/test/time-series/requesting-a-service-with-spiky-traffic.js
@@ -102,7 +102,8 @@ TimeSeriesCluster.test('control test for time-series of timeout requests', {
                 value: results[i].errorCount,
                 min: MIN_ERRORS[i],
                 max: MAX_ERRORS[i],
-                name: cluster.buckets[i]
+                index: i,
+                description: ' reqs with timeout of ' + cluster.buckets[i]
             });
         }
 


### PR DESCRIPTION
This uses the TimeSeriesCluster to create a test case that
generates 25 req/s per HyperbahnWorker.

We set the rateLimit to 10 req/s for one out of 10 Hyperbahn
workers and then assert that zero requests fail due to retries.

We also assert that the rate limiter actually kicked in.

r: @kriskowal @rf

cc @anson627 This proofs that retries on Busy solve our problem.
We still need to debug why xlate didn't do retries.