### PR TITLE
WIP: Naive relay

### DIFF
--- a/hyperbahn/benchmarks/Makefile
+++ b/hyperbahn/benchmarks/Makefile
@@ -3,7 +3,7 @@ torch-relay-bench:
 		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
 
 take_relay:
-	node index.js --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
+	node index.js --useNaive --relay --noEndpointOverhead -o relay-$$(git rev-parse --short HEAD).json \
 		-- --relay --skipPing -m 3 -s 4096,16384 -p 1000,10000,20000
 	ln -sf relay-$$(git rev-parse --short HEAD).json relay-$$(basename $$(git symbolic-ref HEAD)).json
 

--- a/hyperbahn/benchmarks/Makefile
+++ b/hyperbahn/benchmarks/Makefile
@@ -1,5 +1,5 @@
 torch-relay-bench:
-	node index.js --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
+	node index.js --noEndpointOverhead --useNaive --relay --torch relay --torchFile ./flame.raw --torchTime 10 \
 		-- --relay --skipPing -s 4096,16384 -p 1000,10000,20000
 
 take_relay:

--- a/hyperbahn/benchmarks/index.js
+++ b/hyperbahn/benchmarks/index.js
@@ -48,6 +48,23 @@ function HyperbahnBenchmarkRunner(opts) {
 util.inherits(HyperbahnBenchmarkRunner, BenchmarkRunner);
 
 HyperbahnBenchmarkRunner.prototype.spawnNaiveRelayServer =
+function spawnNaiveRelayServer() {
+    var self = this;
+
+    var relays = '127.0.0.1:' + self.ports.serverPort;
+
+    var naiveRelayProc = self.run(naiveRelay, [
+        '--relays', relays,
+        '--instances', String(self.instanceCount),
+        '--port', String(self.ports.relayServerPort),
+        '--host', '127.0.0.1'
+    ]);
+    self.relayProcs.push(naiveRelayProc);
+    naiveRelayProc.stdout.pipe(process.stderr);
+    naiveRelayProc.stderr.pipe(process.stderr);
+};
+
+HyperbahnBenchmarkRunner.prototype.spawnNaiveCRelayServer =
 function spawnNaiveCRelayServer() {
     var self = this;
 

--- a/hyperbahn/benchmarks/index.js
+++ b/hyperbahn/benchmarks/index.js
@@ -49,10 +49,13 @@ HyperbahnBenchmarkRunner.prototype.spawnNaiveRelayServer =
 function spawnNaiveRelayServer() {
     var self = this;
 
+    var relays = '127.0.0.1:' + self.ports.serverPort;
+
     var naiveRelayProc = self.run(naiveRelay, [
-        '--destination', String(self.ports.serverPort),
+        '--relays', relays,
         '--instances', String(self.instanceCount),
-        '--port', String(self.ports.relayServerPort)
+        '--port', String(self.ports.relayServerPort),
+        '--host', '127.0.0.1'
     ]);
     self.relayProcs.push(naiveRelayProc);
     naiveRelayProc.stdout.pipe(process.stderr);

--- a/hyperbahn/benchmarks/index.js
+++ b/hyperbahn/benchmarks/index.js
@@ -29,7 +29,7 @@ var path = require('path');
 var BenchmarkRunner = require('tchannel/benchmarks/');
 
 var bahn = path.join(__dirname, 'hyperbahn-worker.js');
-var naiveRelay = path.join(__dirname, 'naive-relay.js');
+var naiveRelay = path.join(__dirname, '..', 'naive-relay', 'worker.js');
 
 var cNaiveRelay = '/home/raynos/uber/naive-relay-c/relay.out';
 
@@ -53,11 +53,11 @@ function spawnNaiveRelayServer() {
 
     var relays = '127.0.0.1:' + self.ports.serverPort;
 
+    // '--instances', String(self.instanceCount),
     var naiveRelayProc = self.run(naiveRelay, [
-        '--relays', relays,
-        '--instances', String(self.instanceCount),
-        '--port', String(self.ports.relayServerPort),
-        '--host', '127.0.0.1'
+        String(self.ports.relayServerPort),
+        '127.0.0.1',
+        relays
     ]);
     self.relayProcs.push(naiveRelayProc);
     naiveRelayProc.stdout.pipe(process.stderr);

--- a/hyperbahn/benchmarks/naive-relay.js
+++ b/hyperbahn/benchmarks/naive-relay.js
@@ -32,4 +32,8 @@ function main(argv) {
         relays: argv.relays
     });
     relay.listen(argv.port, argv.host || myLocalIp());
+
+    if (argv.printRPS) {
+        relay.printRPS();
+    }
 }

--- a/hyperbahn/benchmarks/naive-relay.js
+++ b/hyperbahn/benchmarks/naive-relay.js
@@ -4,31 +4,32 @@
 
     Takes frames in; Mutates the id; forwards.
 
-    Accepting one TCP socket in; Hardcoded to send to a destination
+    Accepting one TCP socket in; Hardcoded to send to a relays
 
     This program is bounded by a single TCP socket
 
-    node naive-relay.js --destination [num] --port [num]
+    node naive-relay.js --relays [hps] --port [num]
 */
 
 var parseArgs = require('minimist');
 var assert = require('assert');
 var process = require('process');
+var myLocalIp = require('my-local-ip');
 
 var NaiveRelay = require('../naive-relay/relay.js');
 
 if (require.main === module) {
-    var argv = parseArgs(process.argv.slice(2));
+    var args = parseArgs(process.argv.slice(2));
     process.title = 'nodejs-benchmarks-naive_relay';
-    main(argv);
+    main(args);
 }
 
 function main(argv) {
-    assert(argv.destination, '--destination required');
+    assert(argv.relays, '--relays required');
     assert(argv.port, '--port required');
 
     var relay = NaiveRelay({
-        destination: argv.destination
+        relays: argv.relays
     });
-    relay.listen(argv.port);
+    relay.listen(argv.port, argv.host || myLocalIp());
 }

--- a/hyperbahn/benchmarks/naive-relay.js
+++ b/hyperbahn/benchmarks/naive-relay.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/* Semantics:
+
+    Takes frames in; Mutates the id; forwards.
+
+    Accepting one TCP socket in; Hardcoded to send to a destination
+
+    This program is bounded by a single TCP socket
+
+    node naive-relay.js --destination [num] --port [num]
+*/
+
+var parseArgs = require('minimist');
+var assert = require('assert');
+var process = require('process');
+
+var NaiveRelay = require('../naive-relay/relay.js');
+
+if (require.main === module) {
+    var argv = parseArgs(process.argv.slice(2));
+    process.title = 'nodejs-benchmarks-naive_relay';
+    main(argv);
+}
+
+function main(argv) {
+    assert(argv.destination, '--destination required');
+    assert(argv.port, '--port required');
+
+    var relay = NaiveRelay({
+        destination: argv.destination
+    });
+    relay.listen(argv.port);
+}

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -152,10 +152,10 @@ RelayConnection.prototype.writeFrame = function writeFrame(frame) {
 RelayConnection.prototype.writeToSocket = function writeToSocket(buffer) {
     var self = this;
 
-    if (self.pendingWrite) {
-        self.writeQueue.push(buffer);
-        return;
-    }
+    // if (self.pendingWrite) {
+    //     self.writeQueue.push(buffer);
+    //     return;
+    // }
 
     if (!self.connected) {
         throw new Error('lol noob');
@@ -186,9 +186,9 @@ function afterWrite(status, socket, writeReq) {
     }
 
     conn.pendingWrite = false;
-    if (conn.writeQueue.length) {
-        conn.writeToSocket(conn.writeQueue.shift());
-    }
+    // if (conn.writeQueue.length) {
+    //     conn.writeToSocket(conn.writeQueue.shift());
+    // }
 }
 
 RelayConnection.prototype.handleInitRequest =

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -33,12 +33,6 @@ function RelayConnection(socket, relay, direction) {
     self.initialized = false;
     self.frameQueue = [];
     self.direction = direction;
-
-    self.parser.onFrameBuffer = onFrameBuffer;
-
-    function onFrameBuffer(frameBuffer) {
-        self.onFrameBuffer(frameBuffer);
-    }
 }
 
 RelayConnection.prototype.readStart = function readStart() {
@@ -72,14 +66,14 @@ function onSocketBuffer(socketBuffer) {
     var self = this;
 
     self.parser.write(socketBuffer);
-};
 
-RelayConnection.prototype.onFrameBuffer =
-function onFrameBuffer(frameBuffer) {
-    var self = this;
-
-    var frame = LazyFrame.alloc(self, frameBuffer);
-    self.relay.handleFrame(frame);
+    // console.log('draining parser');
+    while (self.parser.hasFrameBuffers()) {
+        var frameBuffer = self.parser.getFrameBuffer();
+        var frame = LazyFrame.alloc(self, frameBuffer);
+        self.relay.handleFrame(frame);
+    }
+    // console.log('parser drained');
 };
 
 RelayConnection.prototype.allocateId = function allocateId() {

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -44,14 +44,26 @@ function RelayConnection(socket, relay, direction) {
 RelayConnection.prototype.readStart = function readStart() {
     var self = this;
 
-    self.socket.on('data', onData);
+    self.socket.on('readable', onReadable);
 
     if (self.direction === 'out') {
         self.sendInitRequest();
     }
 
-    function onData(socketBuffer) {
-        self.onSocketBuffer(socketBuffer);
+    function onReadable() {
+        self.onSocketReadable();
+    }
+};
+
+RelayConnection.prototype.onSocketReadable =
+function onSocketReadable() {
+    var self = this;
+
+    var chunk;
+
+    /* eslint yoda: 0*/
+    while (null !== (chunk = self.socket.read())) {
+        self.onSocketBuffer(chunk);
     }
 };
 

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Buffer = require('buffer').Buffer;
-var process = require('process');
 
 var FrameParser = require('./parser.js');
 var LazyFrame = require('./lazy-frame.js');

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -67,13 +67,11 @@ function onSocketBuffer(socketBuffer) {
 
     self.parser.write(socketBuffer);
 
-    // console.log('draining parser');
     while (self.parser.hasFrameBuffers()) {
         var frameBuffer = self.parser.getFrameBuffer();
         var frame = LazyFrame.alloc(self, frameBuffer);
         self.relay.handleFrame(frame);
     }
-    // console.log('parser drained');
 };
 
 RelayConnection.prototype.allocateId = function allocateId() {

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -78,7 +78,7 @@ RelayConnection.prototype.onFrameBuffer =
 function onFrameBuffer(frameBuffer) {
     var self = this;
 
-    var frame = new LazyFrame(self, frameBuffer);
+    var frame = LazyFrame.alloc(self, frameBuffer);
     self.relay.handleFrame(frame);
 };
 

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -8,11 +8,6 @@ var LazyFrame = require('./lazy-frame.js');
 
 var GUID = 1;
 
-// var magicCounters = {
-//     out: 0,
-//     in: 0
-// };
-
 module.exports = RelayConnection;
 
 function RelayConnection(socket, relay, direction) {
@@ -24,6 +19,7 @@ function RelayConnection(socket, relay, direction) {
 
     self.socket = socket;
     self.relay = relay;
+    self.socket.owner = self;
 
     self.parser = new FrameParser(self, onFrameBuffer);
     self.idCounter = 1;
@@ -32,40 +28,101 @@ function RelayConnection(socket, relay, direction) {
 
     self.initialized = false;
     self.frameQueue = [];
+    self.writeQueue = [];
     self.direction = direction;
+
+    self.pendingWrite = false;
+    self.connected = false;
+}
+
+RelayConnection.prototype.accept = function accept() {
+    var self = this;
+
+    self.connected = true;
+    self.readStart();
 }
 
 RelayConnection.prototype.readStart = function readStart() {
     var self = this;
 
-    self.socket.on('readable', onReadable);
-
-    if (self.direction === 'out') {
-        self.sendInitRequest();
-    }
-
-    function onReadable() {
-        self.onSocketReadable();
+    self.socket.onread = onRead;
+    var err = self.socket.readStart();
+    if (err) {
+        console.error('could not readStart lul', err);
+        return;
     }
 };
 
-RelayConnection.prototype.onSocketReadable =
-function onSocketReadable() {
+RelayConnection.prototype.connect = function connect(hostPort) {
     var self = this;
 
-    var chunk;
-
-    /* eslint yoda: 0*/
-    while (null !== (chunk = self.socket.read())) {
-        self.onSocketBuffer(chunk);
+    var parts = hostPort.split(':');
+    var connectReq = self.socket.connect(parts[0], parts[1])
+    if (connectReq === null) {
+        console.error('could not connect', process._errno);
+        return;
     }
+
+    connectReq.oncomplete = afterConnect;
+};
+
+function afterConnect(err, socket, req, readable, writable) {
+    var conn = socket.owner;
+
+    if (err) {
+        console.error('lol connect', err);
+        return;
+    }
+
+    if (!readable || !writable) {
+        console.error('bad socket :(');
+        return;
+    }
+
+    conn.connected = true;
+    conn.readStart();
+
+    if (conn.direction === 'out') {
+        // console.log('sendInitRequest');
+        conn.sendInitRequest();
+    }
+}
+
+function onRead(buffer, offset, length) {
+    if (buffer) {
+        var conn = this.owner;
+        // console.log('gotn socket buffer', {
+        //     guid: conn.guid,
+        //     bufStr: buffer.slice(offset, offset + length).toString('utf8')
+        // });
+        conn.onSocketRead(buffer, offset, offset + length);
+    } else if (process._errno == 'EOF') {
+        // console.log('got EOF LOLOLOLOLOLOL');
+        // socket close (TODO lololol)
+        return;
+    } else {
+        console.error('read failed', process._errno);
+        return;
+    }
+}
+
+RelayConnection.prototype.onSocketRead =
+function onSocketRead(buffer, offset, length) {
+    var self = this;
+
+    if (length === 0) {
+        // could have no bytes
+        return;
+    }
+
+    self.onSocketBuffer(buffer, offset, length);
 };
 
 RelayConnection.prototype.onSocketBuffer =
-function onSocketBuffer(socketBuffer) {
+function onSocketBuffer(socketBuffer, start, length) {
     var self = this;
 
-    self.parser.write(socketBuffer);
+    self.parser.write(socketBuffer, start, length);
 };
 
 RelayConnection.prototype.onFrameBuffer =
@@ -86,11 +143,53 @@ RelayConnection.prototype.writeFrame = function writeFrame(frame) {
     var self = this;
 
     if (self.initialized) {
-        self.socket.write(frame.frameBuffer);
+        self.writeToSocket(frame.frameBuffer);
     } else {
         self.frameQueue.push(frame.frameBuffer);
     }
 };
+
+RelayConnection.prototype.writeToSocket = function writeToSocket(buffer) {
+    var self = this;
+
+    if (self.pendingWrite) {
+        self.writeQueue.push(buffer);
+        return;
+    }
+
+    if (!self.connected) {
+        throw new Error('lol noob');
+    }
+
+    self.pendingWrite = true;
+
+    // console.log('writing to socket', self.guid);
+    var writeReq = self.socket.writeBuffer(buffer);
+    if (!writeReq) {
+        console.error('did not get writeReq');
+        return;
+    }
+
+    writeReq.oncomplete = afterWrite;
+};
+
+function afterWrite(status, socket, writeReq) {
+    var conn = socket.owner;
+
+    if (status) {
+        console.error('write failed', status);
+        return;
+    }
+
+    if (conn.afterWriteCallback) {
+        conn.afterWriteCallback();
+    }
+
+    conn.pendingWrite = false;
+    if (conn.writeQueue.length) {
+        conn.writeToSocket(conn.writeQueue.shift());
+    }
+}
 
 RelayConnection.prototype.handleInitRequest =
 function handleInitRequest(reqFrame) {
@@ -101,8 +200,6 @@ function handleInitRequest(reqFrame) {
 
     reqFrame.readId();
     self.sendInitResponse(reqFrame);
-
-    self.flushPending();
 };
 
 RelayConnection.prototype.sendInitResponse =
@@ -123,8 +220,16 @@ function sendInitResponse(reqFrame) {
         buffer, offset, self.relay.hostPort
     );
 
-    self.socket.write(buffer);
+    self.afterWriteCallback = onWrite;
+    self.writeToSocket(buffer);
 };
+
+function onWrite() {
+    var self = this;
+
+    self.afterWriteCallback = null;
+    self.flushPending();
+}
 
 RelayConnection.prototype.sendInitRequest =
 function sendInitRequest() {
@@ -144,7 +249,7 @@ function sendInitRequest() {
         buffer, offset, self.relay.hostPort
     );
 
-    self.socket.write(buffer);
+    self.writeToSocket(buffer);
 };
 
 RelayConnection.prototype.handleInitResponse =
@@ -161,11 +266,13 @@ RelayConnection.prototype.flushPending =
 function flushPending() {
     var self = this;
 
+    self.initialized = true;
+    // console.log('flushing frames', self.frameQueue.length);
+
     for (var i = 0; i < self.frameQueue.length; i++) {
-        self.socket.write(self.frameQueue[i]);
+        self.writeToSocket(self.frameQueue[i]);
     }
 
-    self.initialized = true;
     self.frameQueue.length = 0;
 };
 

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -1,0 +1,238 @@
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+var process = require('process');
+
+var FrameParser = require('./parser.js');
+var LazyFrame = require('./lazy-frame.js');
+
+var GUID = 1;
+
+// var magicCounters = {
+//     out: 0,
+//     in: 0
+// };
+
+module.exports = RelayConnection;
+
+function RelayConnection(socket, relay, direction) {
+    if (!(this instanceof RelayConnection)) {
+        return new RelayConnection(socket, relay, direction);
+    }
+
+    var self = this;
+
+    self.socket = socket;
+    self.relay = relay;
+
+    self.parser = new FrameParser();
+    self.idCounter = 1;
+    self.guid = String(GUID++) + '~';
+
+    self.initialized = false;
+    self.frameQueue = [];
+    self.direction = direction;
+
+    self.parser.onFrameBuffer = onFrameBuffer;
+
+    function onFrameBuffer(frameBuffer) {
+        self.onFrameBuffer(frameBuffer);
+    }
+}
+
+RelayConnection.prototype.readStart = function readStart() {
+    var self = this;
+
+    self.socket.on('data', onData);
+
+    if (self.direction === 'out') {
+        self.sendInitRequest();
+    }
+
+    function onData(socketBuffer) {
+        self.onSocketBuffer(socketBuffer);
+    }
+};
+
+RelayConnection.prototype.onSocketBuffer =
+function onSocketBuffer(socketBuffer) {
+    var self = this;
+
+    self.parser.write(socketBuffer);
+};
+
+RelayConnection.prototype.onFrameBuffer =
+function onFrameBuffer(frameBuffer) {
+    var self = this;
+
+    var frame = new LazyFrame(self, frameBuffer);
+    self.relay.handleFrame(frame);
+};
+
+RelayConnection.prototype.allocateId = function allocateId() {
+    var self = this;
+
+    return self.idCounter++;
+};
+
+RelayConnection.prototype.writeFrame = function writeFrame(frame) {
+    var self = this;
+
+    if (self.initialized) {
+        self.socket.write(frame.frameBuffer);
+    } else {
+        self.frameQueue.push(frame.frameBuffer);
+    }
+};
+
+RelayConnection.prototype.handleInitRequest =
+function handleInitRequest(reqFrame) {
+    var self = this;
+
+    // magicCounters.in++;
+    // console.log('handleInitRequest', magicCounters.in);
+
+    reqFrame.readId();
+    self.sendInitResponse(reqFrame);
+
+    self.flushPending();
+};
+
+RelayConnection.prototype.sendInitResponse =
+function sendInitResponse(reqFrame) {
+    var self = this;
+
+    // magicCounters.in--;
+    // console.log('handleInitResponse', magicCounters.in);
+
+    var bufferLength = initFrameSize(self.relay.hostPort);
+    var buffer = new Buffer(bufferLength);
+    var offset = 0;
+
+    offset = writeFrameHeader(
+        buffer, offset, bufferLength, 0x02, reqFrame.oldId
+    );
+    offset = writeInitBody(
+        buffer, offset, self.relay.hostPort
+    );
+
+    self.socket.write(buffer);
+};
+
+RelayConnection.prototype.sendInitRequest =
+function sendInitRequest() {
+    var self = this;
+
+    // magicCounters.out++;
+    // console.log('sendInitRequest', magicCounters.out);
+
+    var bufferLength = initFrameSize(self.relay.hostPort);
+    var buffer = new Buffer(bufferLength);
+    var offset = 0;
+
+    offset = writeFrameHeader(
+        buffer, offset, bufferLength, 0x01, self.allocateId()
+    );
+    offset = writeInitBody(
+        buffer, offset, self.relay.hostPort
+    );
+
+    self.socket.write(buffer);
+};
+
+RelayConnection.prototype.handleInitResponse =
+function handleInitResponse() {
+    var self = this;
+
+    // magicCounters.out--;
+    // console.log('handleInitResponse', magicCounters.out);
+
+    self.flushPending();
+};
+
+RelayConnection.prototype.flushPending =
+function flushPending() {
+    var self = this;
+
+    for (var i = 0; i < self.frameQueue.length; i++) {
+        self.socket.write(self.frameQueue[i]);
+    }
+
+    self.initialized = true;
+    self.frameQueue.length = 0;
+};
+
+function initFrameSize(hostPort) {
+    // frameHeader:16 version:2 nh:2 hkl:2 hk:hkl hvl:2 hb:hvl
+    var bufferLength =
+        16 + // frameHeader:166
+        2 + // version:2
+        2 + // nh:2
+        2 + 'host_port'.length + // hostPortKey
+        2 + hostPort.length + // hostPortValue
+        2 + 'process_name'.length + // processNameKey
+        2 + process.title.length; // processNameValue
+
+    return bufferLength;
+}
+
+function writeInitBody(buffer, offset, hostPort) {
+    // Version
+    buffer.writeUInt16BE(2, offset);
+    offset += 2;
+    // number of headers
+    buffer.writeUInt16BE(2, offset);
+    offset += 2;
+
+    // key length
+    buffer.writeUInt16BE('host_port'.length, offset);
+    offset += 2;
+    // key value
+    buffer.write('host_port', offset, 'host_port'.length, 'utf8');
+    offset += 'host_port'.length;
+
+    // value length
+    buffer.writeUInt16BE(hostPort.length, offset);
+    offset += 2;
+    // value value
+    buffer.write(hostPort, offset, hostPort.length, 'utf8');
+    offset += hostPort.length;
+
+    // key length
+    buffer.writeUInt16BE('process_name'.length, offset);
+    offset += 2;
+    // key value
+    buffer.write('process_name', offset, 'process_name'.length, 'utf8');
+    offset += 'process_name'.length;
+
+    // value length
+    buffer.writeUInt16BE(process.title.length, offset);
+    offset += 2;
+    // value value
+    buffer.write(process.title, offset, process.title.length, 'utf8');
+    offset += process.title.length;
+
+    return offset;
+}
+
+function writeFrameHeader(buffer, offset, size, type, id) {
+    // size
+    buffer.writeUInt16BE(size, offset);
+    offset += 2;
+
+    // type
+    buffer.writeInt8(type, offset);
+    offset += 1;
+
+    // reserved
+    offset += 1;
+
+    // id
+    buffer.writeUInt32BE(id, offset);
+    offset += 4;
+
+    // reserved
+    offset += 8;
+
+    return offset;
+}

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -28,6 +28,7 @@ function RelayConnection(socket, relay, direction) {
     self.parser = new FrameParser();
     self.idCounter = 1;
     self.guid = String(GUID++) + '~';
+    self.outRequestMapping = Object.create(null);
 
     self.initialized = false;
     self.frameQueue = [];

--- a/hyperbahn/naive-relay/connection.js
+++ b/hyperbahn/naive-relay/connection.js
@@ -296,35 +296,35 @@ function initFrameSize(hostPort) {
 
 function writeInitBody(buffer, offset, hostPort) {
     // Version
-    buffer.writeUInt16BE(2, offset);
+    buffer.writeUInt16BE(2, offset, true);
     offset += 2;
     // number of headers
-    buffer.writeUInt16BE(2, offset);
+    buffer.writeUInt16BE(2, offset, true);
     offset += 2;
 
     // key length
-    buffer.writeUInt16BE('host_port'.length, offset);
+    buffer.writeUInt16BE('host_port'.length, offset, true);
     offset += 2;
     // key value
     buffer.write('host_port', offset, 'host_port'.length, 'utf8');
     offset += 'host_port'.length;
 
     // value length
-    buffer.writeUInt16BE(hostPort.length, offset);
+    buffer.writeUInt16BE(hostPort.length, offset, true);
     offset += 2;
     // value value
     buffer.write(hostPort, offset, hostPort.length, 'utf8');
     offset += hostPort.length;
 
     // key length
-    buffer.writeUInt16BE('process_name'.length, offset);
+    buffer.writeUInt16BE('process_name'.length, offset, true);
     offset += 2;
     // key value
     buffer.write('process_name', offset, 'process_name'.length, 'utf8');
     offset += 'process_name'.length;
 
     // value length
-    buffer.writeUInt16BE(process.title.length, offset);
+    buffer.writeUInt16BE(process.title.length, offset, true);
     offset += 2;
     // value value
     buffer.write(process.title, offset, process.title.length, 'utf8');
@@ -335,18 +335,18 @@ function writeInitBody(buffer, offset, hostPort) {
 
 function writeFrameHeader(buffer, offset, size, type, id) {
     // size
-    buffer.writeUInt16BE(size, offset);
+    buffer.writeUInt16BE(size, offset, true);
     offset += 2;
 
     // type
-    buffer.writeInt8(type, offset);
+    buffer.writeInt8(type, offset, true);
     offset += 1;
 
     // reserved
     offset += 1;
 
     // id
-    buffer.writeUInt32BE(id, offset);
+    buffer.writeUInt32BE(id, offset, true);
     offset += 4;
 
     // reserved

--- a/hyperbahn/naive-relay/lazy-frame.js
+++ b/hyperbahn/naive-relay/lazy-frame.js
@@ -3,13 +3,44 @@
 var ID_OFFSET = 4;
 var TYPE_OFFSET = 2;
 
+LazyFrame.freeList = new Array(1000);
+for (var i = 0; i < 1000; i++) {
+    LazyFrame.freeList.push(new LazyFrame());
+}
+
+LazyFrame.alloc = allocLazyFrame;
+LazyFrame.free = freeLazyFrame;
+
 module.exports = LazyFrame;
 
-function LazyFrame(sourceConnection, frameBuffer) {
+function allocLazyFrame(sourceConnection, frameBuffer) {
+    if (LazyFrame.freeList.length === 0) {
+        var frame = new LazyFrame();
+    } else {
+        frame = LazyFrame.freeList.pop();
+    }
+
+    frame.sourceConnection = sourceConnection;
+    frame.frameBuffer = frameBuffer;
+
+    return frame;
+}
+
+function freeLazyFrame(frame) {
+    frame.sourceConnection = null;
+    frame.frameBuffer = null;
+    frame.oldId = null;
+    frame.newId = null;
+    frame.frameType = null;
+
+    LazyFrame.freeList.push(frame);
+}
+
+function LazyFrame() {
     var self = this;
 
-    self.sourceConnection = sourceConnection;
-    self.frameBuffer = frameBuffer;
+    self.sourceConnection = null;
+    self.frameBuffer = null;
 
     self.oldId = null;
     self.newId = null;

--- a/hyperbahn/naive-relay/lazy-frame.js
+++ b/hyperbahn/naive-relay/lazy-frame.js
@@ -3,7 +3,7 @@
 var ID_OFFSET = 4;
 var TYPE_OFFSET = 2;
 
-LazyFrame.freeList = new Array(1000);
+LazyFrame.freeList = [];
 for (var i = 0; i < 1000; i++) {
     LazyFrame.freeList.push(new LazyFrame());
 }
@@ -14,8 +14,10 @@ LazyFrame.free = freeLazyFrame;
 module.exports = LazyFrame;
 
 function allocLazyFrame(sourceConnection, frameBuffer) {
+    var frame;
+
     if (LazyFrame.freeList.length === 0) {
-        var frame = new LazyFrame();
+        frame = new LazyFrame();
     } else {
         frame = LazyFrame.freeList.pop();
     }

--- a/hyperbahn/naive-relay/lazy-frame.js
+++ b/hyperbahn/naive-relay/lazy-frame.js
@@ -56,7 +56,7 @@ LazyFrame.prototype.readId = function readId() {
         return self.oldId;
     }
 
-    self.oldId = self.frameBuffer.readUInt32BE(ID_OFFSET);
+    self.oldId = self.frameBuffer.readUInt32BE(ID_OFFSET, true);
     return self.oldId;
 };
 
@@ -67,14 +67,14 @@ LazyFrame.prototype.readFrameType = function readFrameType() {
         return self.frameType;
     }
 
-    self.frameType = self.frameBuffer.readUInt8(TYPE_OFFSET);
+    self.frameType = self.frameBuffer.readUInt8(TYPE_OFFSET, true);
     return self.frameType;
 };
 
 LazyFrame.prototype.writeId = function writeId(newId) {
     var self = this;
 
-    self.frameBuffer.writeUInt32BE(newId, ID_OFFSET);
+    self.frameBuffer.writeUInt32BE(newId, ID_OFFSET, true);
 
     self.newId = newId;
     return self.newId;

--- a/hyperbahn/naive-relay/lazy-frame.js
+++ b/hyperbahn/naive-relay/lazy-frame.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var ID_OFFSET = 4;
+var TYPE_OFFSET = 2;
+
+module.exports = LazyFrame;
+
+function LazyFrame(sourceConnection, frameBuffer) {
+    var self = this;
+
+    self.sourceConnection = sourceConnection;
+    self.frameBuffer = frameBuffer;
+
+    self.oldId = null;
+    self.newId = null;
+    self.frameType = null;
+}
+
+LazyFrame.prototype.readId = function readId() {
+    var self = this;
+
+    if (self.oldId !== null) {
+        return self.oldId;
+    }
+
+    self.oldId = self.frameBuffer.readUInt32BE(ID_OFFSET);
+    return self.oldId;
+};
+
+LazyFrame.prototype.readFrameType = function readFrameType() {
+    var self = this;
+
+    if (self.frameType !== null) {
+        return self.frameType;
+    }
+
+    self.frameType = self.frameBuffer.readUInt8(TYPE_OFFSET);
+    return self.frameType;
+};
+
+LazyFrame.prototype.writeId = function writeId(newId) {
+    var self = this;
+
+    self.frameBuffer.writeUInt32BE(newId, ID_OFFSET);
+
+    self.newId = newId;
+    return self.newId;
+};

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -7,17 +7,19 @@ var SIZE_BYTE_LENGTH = 2;
 
 module.exports = FrameParser;
 
-function FrameParser() {
+function FrameParser(context, onFrameBuffer) {
     if (!(this instanceof FrameParser)) {
-        return new FrameParser();
+        return new FrameParser(context, onFrameBuffer);
     }
 
     var self = this;
 
     self.remainder = [];
-    self.frameBuffers = [];
     self.remainderLength = 0;
     self.frameLength = 0;
+
+    self._context = context;
+    self._onFrameBuffer = onFrameBuffer;
 }
 
 FrameParser.prototype.write =
@@ -62,23 +64,6 @@ function write(networkBuffer) {
     }
 };
 
-FrameParser.prototype.hasFrameBuffers =
-function hasFrameBuffers() {
-    var self = this;
-
-    return self.frameBuffers.length !== 0;
-};
-
-FrameParser.prototype.getFrameBuffer =
-function getFrameBuffer() {
-    var self = this;
-
-    assert(self.frameBuffers.length > 0, 'frameBuffers must not be empty');
-
-    var last = self.frameBuffers.pop();
-    return last;
-};
-
 FrameParser.prototype._addRemainder =
 function _addRemainder(networkBuffer, start, end) {
     var self = this;
@@ -108,7 +93,7 @@ function _pushFrameBuffer(networkBuffer, start, end) {
         self.remainderLength = 0;
     }
 
-    self.frameBuffers.push(frameBuffer);
+    self._onFrameBuffer(self._context, frameBuffer);
     self.frameLength = 0;
 };
 

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -50,7 +50,9 @@ FrameParser.prototype.write = function write(buffer) {
     }
 
     var startOfBuffer = 0;
+    var fauxStartOfBuffer = 0;
     var bufferLength = buffer.length;
+    var totalBufferLength = buffer.length;
 
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
@@ -61,11 +63,12 @@ FrameParser.prototype.write = function write(buffer) {
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
-        if (endOfBuffer === bufferLength) {
+        if (fauxStartOfBuffer + endOfBuffer === totalBufferLength) {
             return;
         }
 
         buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
+        fauxStartOfBuffer += endOfBuffer;
         bufferLength = bufferLength - endOfBuffer;
         totalLength = bufferLength;
         self.frameLength = readFrameSize(buffer, startOfBuffer);

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -49,10 +49,12 @@ FrameParser.prototype.write = function write(buffer) {
         return;
     }
 
+    var startOfBuffer = 0;
+
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
 
-        var lastBuffer = buffer.slice(0, endOfBuffer);
+        var lastBuffer = buffer.slice(startOfBuffer, endOfBuffer);
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
@@ -62,7 +64,7 @@ FrameParser.prototype.write = function write(buffer) {
 
         buffer = buffer.slice(endOfBuffer, buffer.length);
         totalLength = buffer.length;
-        self.frameLength = readFrameSize(buffer, 0);
+        self.frameLength = readFrameSize(buffer, startOfBuffer);
     }
 
     if (buffer.length) {

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -52,7 +52,7 @@ function write(networkBuffer) {
             return;
         }
 
-        bufferOffset += amountToRead;
+        bufferOffset = endOfBuffer;
         maximumBufferLength = totalBufferLength - bufferOffset;
         self._readFrameLength(networkBuffer, bufferOffset);
     }
@@ -92,14 +92,20 @@ function _addRemainder(networkBuffer, start, end) {
 FrameParser.prototype._concatRemainder =
 function _concatRemainder(networkBuffer, start, end) {
     var self = this;
+    var frameBuffer;
 
     if (self.remainderLength === 0) {
-        return networkBuffer;
+        if (start === 0 && end === networkBuffer.length) {
+            return networkBuffer;
+        }
+
+        frameBuffer = networkBuffer.slice(start, end);
+        return frameBuffer;
     }
 
     self._addRemainder(networkBuffer, start, end);
 
-    var frameBuffer = Buffer.concat(self.remainder, self.remainderLength);
+    frameBuffer = Buffer.concat(self.remainder, self.remainderLength);
 
     self.remainder.length = 0;
     self.remainderLength = 0;
@@ -111,7 +117,7 @@ FrameParser.prototype._pushFrameBuffer =
 function _pushFrameBuffer(networkBuffer, start, end) {
     var self = this;
 
-    var frameBuffer = self.concatRemainder(networkBuffer, start, end);
+    var frameBuffer = self._concatRemainder(networkBuffer, start, end);
 
     self.frameBuffers.push(frameBuffer);
     self.frameLength = 0;

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -121,7 +121,12 @@ function _readInitialFrameLength(networkBuffer) {
     } else if (self.remainderLength === 1) {
         self.frameLength = self.remainder[0][0] << 8 | networkBuffer[0];
     } else if (self.remainderLength >= 2) {
-        self.frameLength = self.remainder[0].readUInt16BE(0);
+        var firstLen = self.remainder[0].length;
+        if (firstLen === 1) {
+            self.frameLength = self.remainder[0][0] << 8 | self.remainder[1][0];
+        } else {
+            self.frameLength = self.remainder[0].readUInt16BE(0);
+        }
     }
 };
 

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -53,20 +53,20 @@ FrameParser.prototype.write = function write(buffer) {
     var startOfBuffer = 0;
 
     while (self.frameLength <= totalLength) {
-        var endOfBuffer = self.frameLength - self.remainderLength;
+        var amountToRead = self.frameLength - self.remainderLength;
 
         var lastBuffer = buffer.slice(
-            startOfBuffer, startOfBuffer + endOfBuffer
+            startOfBuffer, startOfBuffer + amountToRead
         );
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
-        if (startOfBuffer + endOfBuffer === totalBufferLength) {
+        if (startOfBuffer + amountToRead === totalBufferLength) {
             return;
         }
 
-        // buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
-        startOfBuffer = startOfBuffer + endOfBuffer;
+        // buffer = buffer.slice(startOfBuffer + amountToRead, bufferLength);
+        startOfBuffer = startOfBuffer + amountToRead;
         totalLength = totalBufferLength - (startOfBuffer);
         self.frameLength = readFrameSize(buffer, startOfBuffer);
     }

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -31,7 +31,8 @@ FrameParser.prototype.write = function write(buffer) {
         });
     }
 
-    var totalLength = self.remainderLength + buffer.length;
+    var totalBufferLength = buffer.length;
+    var totalLength = self.remainderLength + totalBufferLength;
 
     if (self.frameLength === totalLength) {
         self.onFrameBuffer(self.concatRemainder(buffer));
@@ -49,32 +50,30 @@ FrameParser.prototype.write = function write(buffer) {
         return;
     }
 
-    // var startOfBuffer = 0;
-    var fauxStartOfBuffer = 0;
-    var totalBufferLength = buffer.length;
+    var startOfBuffer = 0;
 
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
 
         var lastBuffer = buffer.slice(
-            fauxStartOfBuffer, fauxStartOfBuffer + endOfBuffer
+            startOfBuffer, startOfBuffer + endOfBuffer
         );
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
-        if (fauxStartOfBuffer + endOfBuffer === totalBufferLength) {
+        if (startOfBuffer + endOfBuffer === totalBufferLength) {
             return;
         }
 
         // buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
-        fauxStartOfBuffer = fauxStartOfBuffer + endOfBuffer;
-        totalLength = totalBufferLength - (fauxStartOfBuffer);
-        self.frameLength = readFrameSize(buffer, fauxStartOfBuffer);
+        startOfBuffer = startOfBuffer + endOfBuffer;
+        totalLength = totalBufferLength - (startOfBuffer);
+        self.frameLength = readFrameSize(buffer, startOfBuffer);
     }
 
-    if (fauxStartOfBuffer < totalBufferLength) {
+    if (startOfBuffer < totalBufferLength) {
         self.addRemainder(buffer.slice(
-            fauxStartOfBuffer, totalBufferLength
+            startOfBuffer, totalBufferLength
         ));
     }
 };

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -42,23 +42,37 @@ FrameParser.prototype.scanStart = function scanStart(buffer) {
         });
     }
 
-    if (self.frameLength < buffer.length) {
-        var frameBuffer = buffer.slice(0, self.frameLength);
-        var rest = buffer.slice(self.frameLength, buffer.length);
-
-        self.flush(frameBuffer);
-        self.scanStart(rest);
-    } else if (self.frameLength === buffer.length) {
+    if (self.frameLength === buffer.length) {
         self.flush(buffer);
-    } else if (self.frameLength > buffer.length) {
+        return;
+    }
+
+    if (self.frameLength > buffer.length) {
         // console.log('addRemainder in scanStart', {
         //     bufferLength: buffer.length,
         //     frameLength: self.frameLength
         // });
 
         self.addRemainder(buffer);
-    } else {
-        throw new Error('not possible');
+        return;
+    }
+
+    while (self.frameLength <= buffer.length) {
+        var len = self.frameLength;
+
+        var frameBuffer = buffer.slice(0, len);
+        self.flush(frameBuffer);
+
+        if (len === buffer.length) {
+            return;
+        }
+
+        buffer = buffer.slice(len, buffer.length);
+        self.frameLength = readFrameSize(buffer, 0);
+    }
+
+    if (buffer.length) {
+        self.addRemainder(buffer);
     }
 };
 

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -55,7 +55,9 @@ FrameParser.prototype.write = function write(buffer) {
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
 
-        var lastBuffer = buffer.slice(startOfBuffer, endOfBuffer);
+        var lastBuffer = buffer.slice(
+            startOfBuffer, startOfBuffer + endOfBuffer
+        );
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
@@ -63,7 +65,7 @@ FrameParser.prototype.write = function write(buffer) {
             return;
         }
 
-        buffer = buffer.slice(endOfBuffer, bufferLength);
+        buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
         bufferLength = bufferLength - endOfBuffer;
         totalLength = bufferLength;
         self.frameLength = readFrameSize(buffer, startOfBuffer);

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -1,0 +1,123 @@
+'use strict';
+
+var Buffer = require('buffer').Buffer;
+
+module.exports = FrameParser;
+
+function FrameParser(connection) {
+    if (!(this instanceof FrameParser)) {
+        return new FrameParser(connection);
+    }
+
+    var self = this;
+
+    self.onFrameBuffer = null;
+
+    self.remainder = [];
+    self.remainderLength = 0;
+    self.frameLength = null;
+}
+
+FrameParser.prototype.write = function write(buffer) {
+    var self = this;
+
+    // If not parsing yet.
+    if (self.remainder.length === 0) {
+        // console.log('FrameParser scanStart');
+        self.scanStart(buffer);
+    } else {
+        // console.log('FrameParser scanRest');
+        self.scanRest(buffer);
+    }
+};
+
+FrameParser.prototype.scanStart = function scanStart(buffer) {
+    var self = this;
+
+    self.frameLength = readFrameSize(buffer, 0);
+
+    if (self.frameLength <= 16) {
+        console.error('got really small frame', {
+            frameLength: self.frameLength
+        });
+    }
+
+    if (self.frameLength < buffer.length) {
+        var frameBuffer = buffer.slice(0, self.frameLength);
+        var rest = buffer.slice(self.frameLength, buffer.length);
+
+        self.flush(frameBuffer);
+        self.scanStart(rest);
+    } else if (self.frameLength === buffer.length) {
+        self.flush(buffer);
+    } else if (self.frameLength > buffer.length) {
+        // console.log('addRemainder in scanStart', {
+        //     bufferLength: buffer.length,
+        //     frameLength: self.frameLength
+        // });
+
+        self.addRemainder(buffer);
+    } else {
+        throw new Error('not possible');
+    }
+};
+
+FrameParser.prototype.scanRest = function scanRest(buffer) {
+    var self = this;
+
+    var totalLength = self.remainderLength + buffer.length;
+
+    // console.log('scanRest', {
+    //     totalLength: totalLength,
+    //     frameLength: self.frameLength,
+    //     remainderLength: self.remainderLength,
+    //     bufferLength: buffer.length
+    // });
+
+    if (self.frameLength < totalLength) {
+        var endOfBuffer = self.frameLength - self.remainderLength;
+
+        var lastBuffer = buffer.slice(0, endOfBuffer);
+        self.flush(self.concatRemainder(lastBuffer));
+
+        var rest = buffer.slice(endOfBuffer, buffer.length);
+        self.scanStart(rest);
+    } else if (self.frameLength === totalLength) {
+        self.flush(self.concatRemainder(buffer));
+    } else if (self.frameLength > totalLength) {
+        self.addRemainder(buffer);
+    } else {
+        throw new Error('not possible');
+    }
+};
+
+FrameParser.prototype.flush = function flush(buffer) {
+    var self = this;
+
+    self.onFrameBuffer(buffer);
+    self.frameLength = null;
+};
+
+FrameParser.prototype.addRemainder =
+function addRemainder(buffer) {
+    var self = this;
+
+    self.remainder.push(buffer);
+    self.remainderLength += buffer.length;
+};
+
+FrameParser.prototype.concatRemainder =
+function concatRemainder(buffer) {
+    var self = this;
+
+    self.addRemainder(buffer);
+    var buf = Buffer.concat(self.remainder, self.remainderLength);
+    self.remainder.length = 0;
+    self.remainderLength = 0;
+
+    return buf;
+};
+
+function readFrameSize(buffer, offset) {
+    return buffer.readUInt16BE(offset + 0);
+}

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -21,12 +21,6 @@ function FrameParser(connection) {
 FrameParser.prototype.write = function write(buffer) {
     var self = this;
 
-    self.scanStart(buffer);
-};
-
-FrameParser.prototype.scanStart = function scanStart(buffer) {
-    var self = this;
-
     if (!self.frameLength) {
         self.frameLength = readFrameSize(buffer, 0);
     }

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -40,7 +40,8 @@ FrameParser.prototype.scanStart = function scanStart(buffer) {
     var totalLength = self.remainderLength + buffer.length;
 
     if (self.frameLength === totalLength) {
-        self.flush(self.concatRemainder(buffer));
+        self.onFrameBuffer(self.concatRemainder(buffer));
+        self.frameLength = null;
         return;
     }
 
@@ -58,7 +59,8 @@ FrameParser.prototype.scanStart = function scanStart(buffer) {
         var endOfBuffer = self.frameLength - self.remainderLength;
 
         var lastBuffer = buffer.slice(0, endOfBuffer);
-        self.flush(self.concatRemainder(lastBuffer));
+        self.onFrameBuffer(self.concatRemainder(lastBuffer));
+        self.frameLength = null;
 
         if (endOfBuffer === buffer.length) {
             return;
@@ -72,13 +74,6 @@ FrameParser.prototype.scanStart = function scanStart(buffer) {
     if (buffer.length) {
         self.addRemainder(buffer);
     }
-};
-
-FrameParser.prototype.flush = function flush(buffer) {
-    var self = this;
-
-    self.onFrameBuffer(buffer);
-    self.frameLength = null;
 };
 
 FrameParser.prototype.addRemainder =

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -37,7 +37,7 @@ function write(networkBuffer, start, end) {
 
     var maximumBytesAvailable = self.remainderOffset + networkBufferLength;
     if (maximumBytesAvailable < SIZE_BYTE_LENGTH) {
-        self._addRemainder(networkBuffer, startOfBuffer, networkBufferLength);
+        self._addRemainder(networkBuffer, startOfBuffer, endOfNetworkBuffer);
         return;
     }
 
@@ -46,7 +46,7 @@ function write(networkBuffer, start, end) {
     }
 
     if (self.frameLength > maximumBytesAvailable) {
-        self._addRemainder(networkBuffer, startOfBuffer, networkBufferLength);
+        self._addRemainder(networkBuffer, startOfBuffer, endOfNetworkBuffer);
         return;
     }
 

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -49,16 +49,15 @@ FrameParser.prototype.write = function write(buffer) {
         return;
     }
 
-    var startOfBuffer = 0;
+    // var startOfBuffer = 0;
     var fauxStartOfBuffer = 0;
-    var bufferLength = buffer.length;
     var totalBufferLength = buffer.length;
 
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
 
         var lastBuffer = buffer.slice(
-            startOfBuffer, startOfBuffer + endOfBuffer
+            fauxStartOfBuffer, fauxStartOfBuffer + endOfBuffer
         );
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
@@ -67,15 +66,16 @@ FrameParser.prototype.write = function write(buffer) {
             return;
         }
 
-        buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
-        fauxStartOfBuffer += endOfBuffer;
-        bufferLength = bufferLength - endOfBuffer;
-        totalLength = bufferLength;
-        self.frameLength = readFrameSize(buffer, startOfBuffer);
+        // buffer = buffer.slice(startOfBuffer + endOfBuffer, bufferLength);
+        fauxStartOfBuffer = fauxStartOfBuffer + endOfBuffer;
+        totalLength = totalBufferLength - (fauxStartOfBuffer);
+        self.frameLength = readFrameSize(buffer, fauxStartOfBuffer);
     }
 
-    if (buffer.length) {
-        self.addRemainder(buffer);
+    if (fauxStartOfBuffer < totalBufferLength) {
+        self.addRemainder(buffer.slice(
+            fauxStartOfBuffer, totalBufferLength
+        ));
     }
 };
 

--- a/hyperbahn/naive-relay/parser.js
+++ b/hyperbahn/naive-relay/parser.js
@@ -50,6 +50,7 @@ FrameParser.prototype.write = function write(buffer) {
     }
 
     var startOfBuffer = 0;
+    var bufferLength = buffer.length;
 
     while (self.frameLength <= totalLength) {
         var endOfBuffer = self.frameLength - self.remainderLength;
@@ -58,12 +59,13 @@ FrameParser.prototype.write = function write(buffer) {
         self.onFrameBuffer(self.concatRemainder(lastBuffer));
         self.frameLength = null;
 
-        if (endOfBuffer === buffer.length) {
+        if (endOfBuffer === bufferLength) {
             return;
         }
 
-        buffer = buffer.slice(endOfBuffer, buffer.length);
-        totalLength = buffer.length;
+        buffer = buffer.slice(endOfBuffer, bufferLength);
+        bufferLength = bufferLength - endOfBuffer;
+        totalLength = bufferLength;
         self.frameLength = readFrameSize(buffer, startOfBuffer);
     }
 

--- a/hyperbahn/naive-relay/print-latencies.js
+++ b/hyperbahn/naive-relay/print-latencies.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var metrics = require('metrics');
+var assert = require('assert');
+var fs = require('fs');
+
+main(process.argv);
+
+function main(argv) {
+    assert(argv[2], 'requires file argument');
+
+    var file = argv[2];
+
+    var contents = fs.readFileSync(file, 'utf8');
+    var numbers = getNumbers(contents);
+
+    var histo = new metrics.Histogram()
+    for (var i = 0; i < numbers.length; i++) {
+        histo.update(numbers[i]);
+    }
+
+    console.log(histo.printObj());
+}
+
+function getNumbers(contents) {
+    var lines = contents.split('\n');
+
+    var results = [];
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var numbers = line.split(' ');
+        for (var j = 0; j < numbers.length; j++) {
+            results.push(parseInt(numbers[j], 10));
+        }
+    }
+
+    return results;
+}

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -148,8 +148,10 @@ function forwardCallRequest(frame) {
     var outId = destConn.allocateId();
     frame.writeId(outId);
 
+    var dictKey = String(outId);
+
     // var frameKey = destConn.guid + String(outId);
-    destConn.outRequestMapping[outId] = frame;
+    destConn.outRequestMapping[dictKey] = frame;
 
     destConn.writeFrame(frame);
 };
@@ -158,9 +160,11 @@ NaiveRelay.prototype.forwardCallResponse =
 function forwardCallResponse(frame) {
     var frameId = frame.readId();
 
+    var dictKey = String(frameId);
+
     // var frameKey = frame.sourceConnection.guid + String(frameId);
-    var reqFrame = frame.sourceConnection.outRequestMapping[frameId];
-    delete frame.sourceConnection.outRequestMapping[frameId];
+    var reqFrame = frame.sourceConnection.outRequestMapping[dictKey];
+    delete frame.sourceConnection.outRequestMapping[dictKey];
 
     if (!reqFrame) {
         console.error('unknown frame', {

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -148,10 +148,8 @@ function forwardCallRequest(frame) {
     var outId = destConn.allocateId();
     frame.writeId(outId);
 
-    var dictKey = String(outId);
-
     // var frameKey = destConn.guid + String(outId);
-    destConn.outRequestMapping[dictKey] = frame;
+    destConn.outRequestMapping[outId] = frame;
 
     destConn.writeFrame(frame);
 };
@@ -160,11 +158,9 @@ NaiveRelay.prototype.forwardCallResponse =
 function forwardCallResponse(frame) {
     var frameId = frame.readId();
 
-    var dictKey = String(frameId);
-
     // var frameKey = frame.sourceConnection.guid + String(frameId);
-    var reqFrame = frame.sourceConnection.outRequestMapping[dictKey];
-    delete frame.sourceConnection.outRequestMapping[dictKey];
+    var reqFrame = frame.sourceConnection.outRequestMapping[frameId];
+    delete frame.sourceConnection.outRequestMapping[frameId];
 
     if (!reqFrame) {
         console.error('unknown frame', {

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -18,7 +18,7 @@ function NaiveRelay(opts) {
     self.destinations = opts.relays;
     self.server = net.createServer(onSocket);
 
-    self.outRequestMapping = Object.create(null);
+    // self.outRequestMapping = Object.create(null);
     self.connections = null;
     self.hostPort = null;
 
@@ -148,21 +148,19 @@ function forwardCallRequest(frame) {
     var outId = destConn.allocateId();
     frame.writeId(outId);
 
-    var frameKey = destConn.guid + String(outId);
-    self.outRequestMapping[frameKey] = frame;
+    // var frameKey = destConn.guid + String(outId);
+    destConn.outRequestMapping[outId] = frame;
 
     destConn.writeFrame(frame);
 };
 
 NaiveRelay.prototype.forwardCallResponse =
 function forwardCallResponse(frame) {
-    var self = this;
-
     var frameId = frame.readId();
 
-    var frameKey = frame.sourceConnection.guid + String(frameId);
-    var reqFrame = self.outRequestMapping[frameKey];
-    delete self.outRequestMapping[frameKey];
+    // var frameKey = frame.sourceConnection.guid + String(frameId);
+    var reqFrame = frame.sourceConnection.outRequestMapping[frameId];
+    delete frame.sourceConnection.outRequestMapping[frameId];
 
     if (!reqFrame) {
         console.error('unknown frame', {

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -4,6 +4,7 @@ var net = require('net');
 var console = require('console');
 var setTimeout = require('timers').setTimeout;
 
+var LazyFrame = require('./lazy-frame.js');
 var RelayConnection = require('./connection.js');
 
 module.exports = NaiveRelay;
@@ -95,10 +96,12 @@ NaiveRelay.prototype.handleFrame = function handleFrame(frame) {
     switch (frameType) {
         case 0x01:
             self.handleInitRequest(frame);
+            LazyFrame.free(frame);
             break;
 
         case 0x02:
             self.handleInitResponse(frame);
+            LazyFrame.free(frame);
             break;
 
         case 0x03:
@@ -176,6 +179,9 @@ function forwardCallResponse(frame) {
     frame.writeId(reqFrame.oldId);
 
     reqFrame.sourceConnection.writeFrame(frame);
+
+    LazyFrame.free(frame);
+    LazyFrame.free(reqFrame);
 };
 
 NaiveRelay.prototype.handleUnknownFrame =

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -25,7 +25,6 @@ function NaiveRelay(opts) {
 
     self.requestCount = 0;
     self.successCount = 0;
-    self.incomingCount = 0;
 
     function onSocket(socket) {
         self.onSocket(socket, 'in');
@@ -38,8 +37,8 @@ NaiveRelay.prototype.printRPS = function printRPS() {
     setTimeout(printTheRPS, 1000);
 
     function printTheRPS() {
-        var rate = self.incomingCount;
-        self.incomingCount = 0;
+        var rate = self.successCount;
+        self.successCount = 0;
 
         console.log('RPS[relay]:', rate);
 
@@ -107,7 +106,6 @@ NaiveRelay.prototype.handleFrame = function handleFrame(frame) {
 
         case 0x03:
             self.requestCount++;
-            self.incomingCount++;
             // console.log('pending requests', self.requestCount);
 
             self.forwardCallRequest(frame);

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -25,6 +25,7 @@ function NaiveRelay(opts) {
 
     self.requestCount = 0;
     self.successCount = 0;
+    self.incomingCount = 0;
 
     function onSocket(socket) {
         self.onSocket(socket, 'in');
@@ -37,8 +38,8 @@ NaiveRelay.prototype.printRPS = function printRPS() {
     setTimeout(printTheRPS, 1000);
 
     function printTheRPS() {
-        var rate = self.successCount;
-        self.successCount = 0;
+        var rate = self.incomingCount;
+        self.incomingCount = 0;
 
         console.log('RPS[relay]:', rate);
 
@@ -106,6 +107,7 @@ NaiveRelay.prototype.handleFrame = function handleFrame(frame) {
 
         case 0x03:
             self.requestCount++;
+            self.incomingCount++;
             // console.log('pending requests', self.requestCount);
 
             self.forwardCallRequest(frame);

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -1,0 +1,160 @@
+'use strict';
+
+var net = require('net');
+var console = require('console');
+
+var RelayConnection = require('./connection.js');
+
+module.exports = NaiveRelay;
+
+function NaiveRelay(opts) {
+    if (!(this instanceof NaiveRelay)) {
+        return new NaiveRelay(opts);
+    }
+
+    var self = this;
+
+    self.destinationPort = opts.destination;
+    self.server = net.createServer(onSocket);
+
+    self.outRequestMapping = Object.create(null);
+    self.destConn = null;
+    self.hostPort = null;
+
+    self.requestCount = 0;
+
+    function onSocket(socket) {
+        self.onSocket(socket, 'in');
+    }
+}
+
+NaiveRelay.prototype.onSocket = function onSocket(socket, direction) {
+    var self = this;
+
+    var conn = RelayConnection(socket, self, direction);
+    conn.readStart();
+
+    return conn;
+};
+
+NaiveRelay.prototype.listen = function listen(port) {
+    var self = this;
+
+    self.hostPort = '127.0.0.1:' + port;
+    self.server.listen(port);
+};
+
+NaiveRelay.prototype.chooseConn = function chooseConn(frame) {
+    var self = this;
+
+    if (self.destConn) {
+        return self.destConn;
+    }
+
+    var socket = net.createConnection(self.destinationPort);
+    self.destConn = self.onSocket(socket, 'out');
+    return self.destConn;
+};
+
+NaiveRelay.prototype.handleFrame = function handleFrame(frame) {
+    var self = this;
+
+    var frameType = frame.readFrameType();
+
+    // console.error('got frame type', {
+    //     type: frameType
+    // });
+
+    switch (frameType) {
+        case 0x01:
+            self.handleInitRequest(frame);
+            break;
+
+        case 0x02:
+            self.handleInitResponse(frame);
+            break;
+
+        case 0x03:
+            self.requestCount++;
+            // console.log('pending requests', self.requestCount);
+
+            self.forwardCallRequest(frame);
+            break;
+
+        case 0x04:
+            self.requestCount--;
+            // console.log('pending requests', self.requestCount);
+
+            self.forwardCallResponse(frame);
+            break;
+
+        default:
+            self.handleUnknownFrame(frame);
+            break;
+    }
+};
+
+NaiveRelay.prototype.handleInitRequest =
+function handleInitRequest(frame) {
+    var conn = frame.sourceConnection;
+
+    conn.handleInitRequest(frame);
+};
+
+NaiveRelay.prototype.handleInitResponse =
+function handleInitResponse(frame) {
+    var conn = frame.sourceConnection;
+
+    conn.handleInitResponse(frame);
+};
+
+NaiveRelay.prototype.forwardCallRequest =
+function forwardCallRequest(frame) {
+    var self = this;
+
+    // Read the id before we mutate it.
+    frame.readId();
+
+    var destConn = self.chooseConn(frame);
+
+    var outId = destConn.allocateId();
+    frame.writeId(outId);
+
+    var frameKey = destConn.guid + String(outId);
+    self.outRequestMapping[frameKey] = frame;
+
+    destConn.writeFrame(frame);
+};
+
+NaiveRelay.prototype.forwardCallResponse =
+function forwardCallResponse(frame) {
+    var self = this;
+
+    var frameId = frame.readId();
+
+    var frameKey = frame.sourceConnection.guid + String(frameId);
+    var reqFrame = self.outRequestMapping[frameKey];
+    delete self.outRequestMapping[frameKey];
+
+    if (!reqFrame) {
+        console.error('unknown frame', {
+            frameId: frame.oldId
+        });
+        return;
+    }
+
+    // console.log('forwardCallResponse', {
+    //     id: reqFrame.oldId
+    // });
+
+    frame.writeId(reqFrame.oldId);
+
+    reqFrame.sourceConnection.writeFrame(frame);
+};
+
+NaiveRelay.prototype.handleUnknownFrame =
+function handleUnknownFrame(frame) {
+    /* eslint no-console: 0*/
+    console.error('unknown frame', frame);
+    console.error('buf as string', frame.frameBuffer.toString());
+};

--- a/hyperbahn/naive-relay/relay.js
+++ b/hyperbahn/naive-relay/relay.js
@@ -2,6 +2,7 @@
 
 var net = require('net');
 var console = require('console');
+var setTimeout = require('timers').setTimeout;
 
 var RelayConnection = require('./connection.js');
 
@@ -22,11 +23,27 @@ function NaiveRelay(opts) {
     self.hostPort = null;
 
     self.requestCount = 0;
+    self.successCount = 0;
 
     function onSocket(socket) {
         self.onSocket(socket, 'in');
     }
 }
+
+NaiveRelay.prototype.printRPS = function printRPS() {
+    var self = this;
+
+    setTimeout(printTheRPS, 1000);
+
+    function printTheRPS() {
+        var rate = self.successCount;
+        self.successCount = 0;
+
+        console.log('RPS[relay]:', rate);
+
+        setTimeout(printTheRPS, 1000);
+    }
+};
 
 NaiveRelay.prototype.onSocket = function onSocket(socket, direction) {
     var self = this;
@@ -93,6 +110,7 @@ NaiveRelay.prototype.handleFrame = function handleFrame(frame) {
 
         case 0x04:
             self.requestCount--;
+            self.successCount++;
             // console.log('pending requests', self.requestCount);
 
             self.forwardCallResponse(frame);

--- a/hyperbahn/naive-relay/worker.js
+++ b/hyperbahn/naive-relay/worker.js
@@ -8,32 +8,28 @@
 
     This program is bounded by a single TCP socket
 
-    node naive-relay.js --relays [hps] --port [num]
+    node naive-relay.js [port] [host] [hps]
 */
 
-var parseArgs = require('minimist');
 var assert = require('assert');
-var process = require('process');
-var myLocalIp = require('my-local-ip');
 
 var NaiveRelay = require('../naive-relay/relay.js');
 
 if (require.main === module) {
-    var args = parseArgs(process.argv.slice(2));
+    var args = process.argv.slice(2);
     process.title = 'nodejs-benchmarks-naive_relay';
     main(args);
 }
 
 function main(argv) {
-    assert(argv.relays, '--relays required');
-    assert(argv.port, '--port required');
+    assert(argv[0], '--port required');
+    assert(argv[1], '--host required');
+    assert(argv[2], '--relays required');
 
     var relay = NaiveRelay({
-        relays: argv.relays
+        relays: argv[2]
     });
-    relay.listen(argv.port, argv.host || myLocalIp());
+    relay.listen(argv[0], argv[1]);
 
-    if (argv.printRPS) {
-        relay.printRPS();
-    }
+    relay.printRPS();
 }


### PR DESCRIPTION
This is a from scratch tchannel relay to find out where the performance ceiling for node is.

I've used @prashantv benchmark runner to determine the QPS per core and found this could do about 20-22k req/s compared to go's 35-37k req/s.

The semantics of this relay are to take a list of destinations from the command line and round robin call requests for all services to those destinations. The only action it does on forwarding is rewriting of ids.

We may want to re-use some of the tricks here in mainline hyperbahn like the FrameParser.

cc @kriskowal @jcorbin @rf 

P.S: There is no value in merging this. Just wanted to share the performance experiment.
