### PR TITLE
Remove init timeout connection noise

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -583,7 +583,7 @@ InitOperation.prototype.onTimeout = function onTimeout(now) {
     var self = this;
 
     // noop if identify succeeded
-    if (self.connection.remoteName) {
+    if (self.connection.remoteName || self.connection.closing) {
         return;
     }
 


### PR DESCRIPTION
Any given connection that is closed before it finishes
the init req/res handshake lies about it timing out.

This log should only happen if it actually timed out.

r: @jcorbin @kriskowal @shannili