### PR TITLE
log socket-closed errors

### DIFF
--- a/node/connection.js
+++ b/node/connection.js
@@ -560,7 +560,6 @@ TChannelConnection.prototype.resetAll = function resetAll(err) {
         self.logger.warn('resetting connection', logInfo);
         self.errorEvent.emit(self, err);
     } else if (
-        err.type !== 'tchannel.socket-closed' &&
         err.type !== 'tchannel.socket-local-closed'
     ) {
         logInfo.error = extend(err);


### PR DESCRIPTION
If we do not log these errors then various tests or production
systems will just be silent on socket failures.

We need to know about the other end closing the socket to
reason about why our code hangs or production systems fail.

r: @jcorbin @kriskowal @rf