### PR TITLE
Fix hostports tests to work with hyperbahn

### DIFF
--- a/hyperbahn/test/hyperbahn-client.js
+++ b/hyperbahn/test/hyperbahn-client.js
@@ -31,7 +31,7 @@ require('./hyperbahn-client/egress-nodes.js');
 require('./hyperbahn-client/forward.js')(TestCluster);
 require('./hyperbahn-client/advertise.js')(TestCluster);
 require('./hyperbahn-client/unadvertise.js')(TestCluster);
-// require('./hyperbahn-client/hostports.js')(TestCluster);
+require('./hyperbahn-client/hostports.js')(TestCluster);
 require('./hyperbahn-client/forward-retry.js')(TestCluster);
 
 require('./hyperbahn-client/hyperbahn-down.js')(TestCluster);

--- a/hyperbahn/test/hyperbahn-client/advertise.js
+++ b/hyperbahn/test/hyperbahn-client/advertise.js
@@ -29,7 +29,7 @@ var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {

--- a/hyperbahn/test/hyperbahn-client/forward-retry.js
+++ b/hyperbahn/test/hyperbahn-client/forward-retry.js
@@ -28,7 +28,7 @@ var TChannelJSON = require('tchannel/as/json');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {

--- a/hyperbahn/test/hyperbahn-client/forward.js
+++ b/hyperbahn/test/hyperbahn-client/forward.js
@@ -28,7 +28,7 @@ var TChannelJSON = require('tchannel/as/json');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {

--- a/hyperbahn/test/hyperbahn-client/hostports.js
+++ b/hyperbahn/test/hyperbahn-client/hostports.js
@@ -50,11 +50,7 @@ function runTests(HyperbahnCluster) {
         size: 15
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.subChannels.hyperbahn ||
-            bob.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var bobSub = bob.channel.subChannels.hyperbahn;
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -88,11 +84,7 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
         var steve = cluster.remotes.steve;
-        var steveSub = steve.channel.subChannels.hyperbahn || 
-            steve.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var steveSub = steve.channel.subChannels.hyperbahn;
         var request = steveSub.request({
             headers: {
                 cn: 'test'
@@ -142,11 +134,7 @@ function runTests(HyperbahnCluster) {
         size: 5
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.subChannels.hyperbahn ||
-            bob.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var bobSub = bob.channel.subChannels.hyperbahn;
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -179,11 +167,7 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.subChannels.hyperbahn ||
-            bob.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var bobSub = bob.channel.subChannels.hyperbahn;
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -224,11 +208,7 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.subChannels.hyperbahn ||
-            bob.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var bobSub = bob.channel.subChannels.hyperbahn;
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -268,11 +248,7 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.subChannels.hyperbahn ||
-            bob.channel.makeSubChannel({
-                serviceName: 'hyperbahn',
-                peers: cluster.hostPortList
-            });
+        var bobSub = bob.channel.subChannels.hyperbahn;
         var request = bobSub.request({
             headers: {
                 cn: 'test'

--- a/hyperbahn/test/hyperbahn-client/hostports.js
+++ b/hyperbahn/test/hyperbahn-client/hostports.js
@@ -27,13 +27,13 @@ var path = require('path');
 var TChannelAsThrift = require('tchannel/as/thrift');
 var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 
-var source = fs.readFileSync(path.join(__dirname, '../../hyperbahn/hyperbahn.thrift'), 'utf8');
+var source = fs.readFileSync(path.join(__dirname, '../../hyperbahn.thrift'), 'utf8');
 var thrift = new TChannelAsThrift({source: source});
 
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function covertHost(host) {

--- a/hyperbahn/test/hyperbahn-client/hostports.js
+++ b/hyperbahn/test/hyperbahn-client/hostports.js
@@ -50,10 +50,11 @@ function runTests(HyperbahnCluster) {
         size: 15
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var bobSub = bob.channel.subChannels.hyperbahn ||
+            bob.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -87,10 +88,11 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
         var steve = cluster.remotes.steve;
-        var steveSub = steve.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var steveSub = steve.channel.subChannels.hyperbahn || 
+            steve.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = steveSub.request({
             headers: {
                 cn: 'test'
@@ -140,10 +142,11 @@ function runTests(HyperbahnCluster) {
         size: 5
     }, function t(cluster, assert) {
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var bobSub = bob.channel.subChannels.hyperbahn ||
+            bob.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -176,10 +179,11 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var bobSub = bob.channel.subChannels.hyperbahn ||
+            bob.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -207,6 +211,7 @@ function runTests(HyperbahnCluster) {
                 'error message should be a parsing failure');
 
             var items = cluster.logger.items();
+            console.log('items', items);
             assert.ok(items.length > 0 && items[0].msg === 'Got unexpected invalid thrift for arg3',
                 'Do not miss the error log');
 
@@ -219,10 +224,11 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var bobSub = bob.channel.subChannels.hyperbahn ||
+            bob.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = bobSub.request({
             headers: {
                 cn: 'test'
@@ -262,10 +268,11 @@ function runTests(HyperbahnCluster) {
     }, function t(cluster, assert) {
         cluster.logger.whitelist('warn', 'Got unexpected invalid thrift for arg3');
         var bob = cluster.remotes.bob;
-        var bobSub = bob.channel.makeSubChannel({
-            serviceName: 'hyperbahn',
-            peers: cluster.hostPortList
-        });
+        var bobSub = bob.channel.subChannels.hyperbahn ||
+            bob.channel.makeSubChannel({
+                serviceName: 'hyperbahn',
+                peers: cluster.hostPortList
+            });
         var request = bobSub.request({
             headers: {
                 cn: 'test'

--- a/hyperbahn/test/hyperbahn-client/hostports.js
+++ b/hyperbahn/test/hyperbahn-client/hostports.js
@@ -195,7 +195,6 @@ function runTests(HyperbahnCluster) {
                 'error message should be a parsing failure');
 
             var items = cluster.logger.items();
-            console.log('items', items);
             assert.ok(items.length > 0 && items[0].msg === 'Got unexpected invalid thrift for arg3',
                 'Do not miss the error log');
 

--- a/hyperbahn/test/hyperbahn-client/hyperbahn-down.js
+++ b/hyperbahn/test/hyperbahn-client/hyperbahn-down.js
@@ -27,7 +27,7 @@ var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {

--- a/hyperbahn/test/hyperbahn-client/hyperbahn-times-out.js
+++ b/hyperbahn/test/hyperbahn-client/hyperbahn-times-out.js
@@ -27,7 +27,7 @@ var HyperbahnClient = require('tchannel/hyperbahn/index.js');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {

--- a/hyperbahn/test/hyperbahn-client/rate-limiter.js
+++ b/hyperbahn/test/hyperbahn-client/rate-limiter.js
@@ -28,7 +28,7 @@ var setTimeout = require('timers').setTimeout;
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function send(opts, done) {

--- a/hyperbahn/test/hyperbahn-client/unadvertise.js
+++ b/hyperbahn/test/hyperbahn-client/unadvertise.js
@@ -30,7 +30,7 @@ var TChannelJSON = require('tchannel/as/json');
 module.exports = runTests;
 
 if (require.main === module) {
-    runTests(require('../lib/hyperbahn-cluster.js'));
+    runTests(require('../lib/test-cluster.js'));
 }
 
 function runTests(HyperbahnCluster) {


### PR DESCRIPTION
The hyperbahn cluster is slightly different. This gets the
tests to pass from Hyperbahn itself

r: @jcorbin @rf @shannili