### PR TITLE
prefer outgoing connections for hyperbahn service channels

### DIFF
--- a/node/hyperbahn/service_proxy.js
+++ b/node/hyperbahn/service_proxy.js
@@ -225,6 +225,10 @@ function createServiceChannel(serviceName) {
         options.requestDefaults = self.serviceReqDefaults[serviceName];
     }
 
+    if (mode === 'exit') {
+        options.preferConnectionDirection = 'out';
+    }
+
     var svcchan = self.channel.makeSubChannel(options);
     svcchan.serviceProxyMode = mode; // duck: punched
 

--- a/node/peer_score_strategies.js
+++ b/node/peer_score_strategies.js
@@ -64,9 +64,6 @@ PreferOutgoing.prototype.getScore = function getScore() {
     self.lastTier = tier;
     switch (tier) {
         case PreferOutgoing.ONLY_INCOMING:
-            if (!self.peer.channel.destroyed) {
-                self.peer.connectTo();
-            }
             /* falls through */
         case PreferOutgoing.UNCONNECTED:
             /* falls through */

--- a/node/test/peer_strategies.js
+++ b/node/test/peer_strategies.js
@@ -207,7 +207,7 @@ allocCluster.test('prefer incoming selects the incoming peer when outgoing is pr
     }
 });
 
-allocCluster.test('prefer outgoing creates new conn even if incoming', {
+allocCluster.test('prefer outgoing should not create new connections', {
     numPeers: 2,
     preferConnectionDirection: 'out'
 }, function t(cluster, assert) {
@@ -253,11 +253,71 @@ allocCluster.test('prefer outgoing creates new conn even if incoming', {
     function onResponse2(err, res, arg2, arg3) {
         var steveCount = countConnections(steve);
         var bobCount = countConnections(bob);
-        assert.ok(bobCount.inCount >= 1, 'bob should have incoming connections');
-        assert.ok(bobCount.outCount >= 1, 'bob should have outgoing connections');
-        assert.ok(steveCount.outCount >= 1, 'steve should have outgoing connections');
-        assert.ok(steveCount.inCount >= 1, 'steve should have incoming connections');
+        assert.equals(bobCount.inCount, 0, 'bob should not have incoming connections');
+        assert.equals(bobCount.outCount, 1, 'bob should have 1 outgoing connection');
+        assert.equals(steveCount.outCount, 0, 'steve should not have outgoing connections');
+        assert.equals(steveCount.inCount, 1, 'steve should have 1 incoming connection');
         assert.end();
+    }
+});
+
+allocCluster.test('prefer outgoing selects the outgoing peer when incoming is present' , {
+    numPeers: 3,
+    skipEmptyCheck: true,
+    preferConnectionDirection: 'out'
+}, function t(cluster, assert) {
+    var bob = cluster.channels[0];
+    var steve = cluster.channels[1];
+    var steve2 = cluster.channels[2];
+
+    setupEcho(bob, 'bob');
+    setupEcho(steve, 'steve', update);
+    setupEcho(steve2, 'steve');
+    var subBob = bob.makeSubChannel({
+        serviceName: 'steve',
+        peers: [steve.hostPort, steve2.hostPort],
+        requestDefaults: {
+            headers: {
+                as: 'raw',
+                cn: 'wat'
+            }
+        }
+    });
+
+    var ready = CountedReadySignal(2);
+    bob.waitForIdentified({
+        host: steve.hostPort
+    }, ready.signal);
+
+    steve2.waitForIdentified({
+        host: bob.hostPort
+    }, ready.signal);
+
+    ready(onReady);
+
+    var steveRequested = false;
+    function update() {
+        steveRequested = true;
+    }
+
+    function onReady(err, res, arg2, arg3) {
+        var bobCount = countConnections(bob);
+        var steveCount = countConnections(steve);
+        var steve2Count = countConnections(steve2);
+        assert.equals(bobCount.inCount, 1, 'bob should have 1 incoming connection');
+        assert.equals(bobCount.outCount, 1, 'bob should have 1 outgoing connection');
+        assert.equals(steveCount.outCount, 0, 'steve should not have outgoing connections');
+        assert.equals(steveCount.inCount, 1, 'steve should have 1 incoming connection');
+        assert.equals(steve2Count.outCount, 1, 'steve2 should have 1 outgoing connections');
+        assert.equals(steve2Count.inCount, 0, 'steve2 should not have incoming connections');
+
+        subBob.request({
+            serviceName: 'steve',
+            hasNoParent: true
+        }).send('echo', 'a', 'b', function onResponse() {
+            assert.ok(steveRequested, 'the request from bob should go to steve');
+            assert.end();
+        });
     }
 });
 


### PR DESCRIPTION
r @Raynos @kriskowal @anson627 
cc @jcorbin 

PreferOutgoing.getScore should not create new outgoing connections; otherwise, it gets into race condition that ends up creating multiple out connections. That's why we observed 4x connection increase instead of 2x in Ringpop. On the other hand, it is not necessary anymore.