### PR TITLE
lightweight code errors POC

### DIFF
--- a/node/in_request.js
+++ b/node/in_request.js
@@ -25,6 +25,7 @@ var inherits = require('util').inherits;
 
 var errors = require('./errors');
 var States = require('./reqres_states');
+var LiteError = require('./lib/lite_error');
 
 var emptyBuffer = Buffer(0);
 
@@ -145,8 +146,13 @@ TChannelInRequest.prototype.handleFrame = function handleFrame(parts, isLast) {
 TChannelInRequest.prototype.emitError = function emitError(err) {
     var self = this;
 
-    self.err = err;
-    self.errorEvent.emit(self, err);
+    if (LiteError.isLiteError(err)) {
+        self.err = err.toError();
+    } else {
+        self.err = err;
+    }
+
+    self.errorEvent.emit(self, self.err);
 };
 
 TChannelInRequest.prototype.emitFinish = function emitFinish() {

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -28,15 +28,6 @@ function LiteError(options) {
     if (!(this instanceof LiteError)) {
         return new LiteError(options);
     }
-
-    var self = this;
-    if (options) {
-        var i;
-        var keys = Object.keys(options);
-        for (i = 0; i < keys.length; i++) {
-            self[keys[i]] = options[keys[i]];
-        }
-    }
 }
 
 LiteError.prototype.toError = function toError() {

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var TypedError = require('error/typed');
+
+module.exports = LiteError;
+
+function LiteError(options) {
+    if (!(this instanceof LiteError)) {
+        return new LiteError(options);
+    }
+
+    var self = this;
+    if (options) {
+        var i;
+        var keys = Object.keys(options);
+        for (i = 0; i < keys.length; i++) {
+            self[keys[i]] = options[keys[i]];
+        }
+    }
+}
+
+LiteError.prototype.toError = function toError() {
+    var copy = LiteError(this);
+    delete copy.fullType;
+    return TypedError(copy)();
+};
+
+LiteError.isLiteError = function isLiteError(err) {
+    return err.constructor.name === 'LiteError' ||
+        err.constructor.super_.name === 'LiteError';
+};
+
+LiteError.isError = function isError(err) {
+    return Object.prototype.toString.call(err) === '[object Error]' ||
+        LiteError.isLiteError(err);
+};

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -25,16 +25,33 @@ var extend = require('xtend');
 
 module.exports = LiteError;
 
-function LiteError(options) {
+function LiteError() {
     if (!(this instanceof LiteError)) {
-        return new LiteError(options);
+        return new LiteError();
     }
 }
 
 LiteError.prototype.toError = function toError() {
-    var copy = extend(this);
-    delete copy.fullType;
-    return TypedError(copy)();
+    var result = new Error();
+    Object.defineProperty(result, 'type', {
+        value: this.type,
+        enumerable: true,
+        writable: true,
+        configurable: true
+    });
+
+    var key;
+    for (key in this) {
+        if (this.hasOwnProperty(key)) {
+            result[key] = this[key];
+        }
+    }
+
+    if (!result.fullType) {
+        result.fullType = result.type;
+    }
+
+    return result;
 };
 
 LiteError.isLiteError = function isLiteError(err) {

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -20,9 +20,6 @@
 
 'use strict';
 
-var TypedError = require('error/typed');
-var extend = require('xtend');
-
 module.exports = LiteError;
 
 function LiteError() {

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -21,6 +21,7 @@
 'use strict';
 
 var TypedError = require('error/typed');
+var extend = require('xtend');
 
 module.exports = LiteError;
 
@@ -31,7 +32,7 @@ function LiteError(options) {
 }
 
 LiteError.prototype.toError = function toError() {
-    var copy = LiteError(this);
+    var copy = extend(this);
     delete copy.fullType;
     return TypedError(copy)();
 };

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -37,11 +37,10 @@ LiteError.prototype.toError = function toError() {
         configurable: true
     });
 
-    var key;
-    for (key in this) {
-        if (this.hasOwnProperty(key)) {
-            result[key] = this[key];
-        }
+    var keys = Object.keys(this);
+    var i;
+    for (i = 0; i < keys.length; i++) {
+        result[keys[i]] = this[keys[i]];
     }
 
     if (!result.fullType) {

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -52,15 +52,13 @@ LiteError.prototype.toError = function toError() {
 };
 
 LiteError.isLiteError = function isLiteError(err) {
-    if (err) {
-        if (err.constructor) {
-            if (err.constructor.name === 'LiteError') {
-                return true;
-            }
+    if (err && err.constructor) {
+        if (err.constructor.name === 'LiteError') {
+            return true;
+        }
 
-            if (err.constructor.super_ && err.constructor.super_.name === 'LiteError') {
-                return true;
-            }
+        if (err.constructor.super_ && err.constructor.super_.name === 'LiteError') {
+            return true;
         }
     }
     return false;

--- a/node/lib/lite_error.js
+++ b/node/lib/lite_error.js
@@ -46,8 +46,18 @@ LiteError.prototype.toError = function toError() {
 };
 
 LiteError.isLiteError = function isLiteError(err) {
-    return err.constructor.name === 'LiteError' ||
-        err.constructor.super_.name === 'LiteError';
+    if (err) {
+        if (err.constructor) {
+            if (err.constructor.name === 'LiteError') {
+                return true;
+            }
+
+            if (err.constructor.super_ && err.constructor.super_.name === 'LiteError') {
+                return true;
+            }
+        }
+    }
+    return false;
 };
 
 LiteError.isError = function isError(err) {

--- a/node/request.js
+++ b/node/request.js
@@ -25,10 +25,12 @@ module.exports = TChannelRequest;
 var assert = require('assert');
 var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
+var TypedError = require('error/typed');
 
 var TChannelOutRequest = require('./out_request.js');
 var RetryFlags = require('./retry-flags.js');
 var errors = require('./errors');
+var LiteError = require('./lib/lite_error');
 
 function TChannelRequest(options) {
     /*eslint max-statements: [2, 40]*/
@@ -91,7 +93,13 @@ TChannelRequest.prototype.emitError = function emitError(err) {
     TChannelOutRequest.prototype.emitLatency.call(self);
 
     self.channel.services.onRequestError(self);
-    self.errorEvent.emit(self, err);
+
+    if (LiteError.isLiteError(err)) {
+        var realError = err.toError();
+        self.errorEvent.emit(self, realError);
+    } else {
+        self.errorEvent.emit(self, err);
+    }
 };
 
 TChannelRequest.prototype.emitResponse = function emitResponse(res) {

--- a/node/request.js
+++ b/node/request.js
@@ -25,7 +25,6 @@ module.exports = TChannelRequest;
 var assert = require('assert');
 var EventEmitter = require('./lib/event_emitter');
 var inherits = require('util').inherits;
-var TypedError = require('error/typed');
 
 var TChannelOutRequest = require('./out_request.js');
 var RetryFlags = require('./retry-flags.js');

--- a/node/self_out_response.js
+++ b/node/self_out_response.js
@@ -84,10 +84,7 @@ SelfStreamingOutResponse.prototype._sendError =
 function passError(codeString, message) {
     var self = this;
     var code = v2.ErrorResponse.Codes[codeString];
-    var err = v2.ErrorResponse.CodeErrors[code]({
-        originalId: self.id,
-        message: message
-    });
+    var err = new v2.ErrorResponse.CodeErrors[code](self.id, message);
     if (!self.closing) self.conn.ops.lastTimeoutTime = 0;
     process.nextTick(emitError);
 

--- a/node/test/busy.js
+++ b/node/test/busy.js
@@ -23,7 +23,6 @@
 var Buffer = require('buffer').Buffer;
 var allocCluster = require('./lib/alloc-cluster.js');
 var TChannel = require('../channel.js');
-var LiteError = require('../lib/lite_error');
 
 allocCluster.test('request().send() to a server', 2, function t(cluster, assert) {
     var two = cluster.channels[1];
@@ -87,7 +86,7 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
     }
 
     function onResp2(err, res, arg2, arg3) {
-        assert.ok(LiteError.isError(err), 'got an error');
+        assert.ok(isError(err), 'got an error');
 
         assert.equals(err.type, 'tchannel.busy');
         assert.ok(err.isErrorFrame, 'err isErrorFrame');
@@ -99,3 +98,7 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
         assert.end();
     }
 });
+
+function isError(err) {
+    return Object.prototype.toString.call(err) === '[object Error]';
+}

--- a/node/test/busy.js
+++ b/node/test/busy.js
@@ -23,6 +23,7 @@
 var Buffer = require('buffer').Buffer;
 var allocCluster = require('./lib/alloc-cluster.js');
 var TChannel = require('../channel.js');
+var LiteError = require('../lib/lite_error');
 
 allocCluster.test('request().send() to a server', 2, function t(cluster, assert) {
     var two = cluster.channels[1];
@@ -86,7 +87,7 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
     }
 
     function onResp2(err, res, arg2, arg3) {
-        assert.ok(isError(err), 'got an error');
+        assert.ok(LiteError.isError(err), 'got an error');
 
         assert.equals(err.type, 'tchannel.busy');
         assert.ok(err.isErrorFrame, 'err isErrorFrame');
@@ -98,7 +99,3 @@ allocCluster.test('request().send() to a server', 2, function t(cluster, assert)
         assert.end();
     }
 });
-
-function isError(err) {
-    return Object.prototype.toString.call(err) === '[object Error]';
-}

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -68,6 +68,7 @@ CodeNames[Codes.Unhealthy] = 'unhealthy';
 
 var CodeErrors = Object.create(null);
 CodeErrors[Codes.Timeout] = function TChannelTimeoutError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.timeout';
     this.message = message || 'TChannel timeout';
     this.isErrorFrame = true;
@@ -75,11 +76,11 @@ CodeErrors[Codes.Timeout] = function TChannelTimeoutError(originalId, message) {
     this.errorCode = Codes.Timeout;
     this.originalId = originalId;
     this.name = 'TchannelTimeoutError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.Timeout], LiteError);
 
 CodeErrors[Codes.Cancelled] = function TChannelCancelledError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.cancelled';
     this.message = message || 'TChannel cancelled';
     this.isErrorFrame = true;
@@ -87,11 +88,11 @@ CodeErrors[Codes.Cancelled] = function TChannelCancelledError(originalId, messag
     this.errorCode = Codes.Cancelled;
     this.originalId = originalId;
     this.name = 'TchannelCancelledError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.Cancelled], LiteError);
 
 CodeErrors[Codes.Busy] = function TChannelBusyError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.busy';
     this.message = message || 'TChannel busy';
     this.isErrorFrame = true;
@@ -99,11 +100,11 @@ CodeErrors[Codes.Busy] = function TChannelBusyError(originalId, message) {
     this.errorCode = Codes.Busy;
     this.originalId = originalId;
     this.name = 'TchannelBusyError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.Busy], LiteError);
 
 CodeErrors[Codes.Declined] = function TChannelDeclinedError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.declined';
     this.message = message || 'TChannel declined';
     this.isErrorFrame = true;
@@ -111,11 +112,11 @@ CodeErrors[Codes.Declined] = function TChannelDeclinedError(originalId, message)
     this.errorCode = Codes.Declined;
     this.originalId = originalId;
     this.name = 'TchannelDeclinedError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.Declined], LiteError);
 
 CodeErrors[Codes.UnexpectedError] = function TChannelUnexpectedError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.unexpected';
     this.message = message || 'TChannel unexpected error';
     this.isErrorFrame = true;
@@ -123,11 +124,11 @@ CodeErrors[Codes.UnexpectedError] = function TChannelUnexpectedError(originalId,
     this.errorCode = Codes.UnexpectedError;
     this.originalId = originalId;
     this.name = 'TchannelUnexpectedError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.UnexpectedError], LiteError);
 
 CodeErrors[Codes.BadRequest] = function TChannelBadRequestError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.bad-request';
     this.message = message || 'TChannel bad request';
     this.isErrorFrame = true;
@@ -135,11 +136,11 @@ CodeErrors[Codes.BadRequest] = function TChannelBadRequestError(originalId, mess
     this.errorCode = Codes.BadRequest;
     this.originalId = originalId;
     this.name = 'TchannelBadRequestError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.BadRequest], LiteError);
 
 CodeErrors[Codes.NetworkError] = function TChannelNetworkError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.network';
     this.message = message || 'TChannel network error';
     this.isErrorFrame = true;
@@ -147,11 +148,11 @@ CodeErrors[Codes.NetworkError] = function TChannelNetworkError(originalId, messa
     this.errorCode = Codes.NetworkError;
     this.originalId = originalId;
     this.name = 'TchannelNetworkError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.NetworkError], LiteError);
 
 CodeErrors[Codes.ProtocolError] = function TChannelProtocolError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.protocol';
     this.message = message || 'TChannel protocol error';
     this.isErrorFrame = true;
@@ -159,11 +160,11 @@ CodeErrors[Codes.ProtocolError] = function TChannelProtocolError(originalId, mes
     this.errorCode = Codes.ProtocolError;
     this.originalId = originalId;
     this.name = 'TchannelProtocolError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.ProtocolError], LiteError);
 
 CodeErrors[Codes.Unhealthy] = function TChannelUnhealthyError(originalId, message) {
+    LiteError.call(this);
     this.type = this.fullType = 'tchannel.unhealthy';
     this.message = message || 'TChannel unhealthy';
     this.isErrorFrame = true;
@@ -171,7 +172,6 @@ CodeErrors[Codes.Unhealthy] = function TChannelUnhealthyError(originalId, messag
     this.errorCode = Codes.Unhealthy;
     this.originalId = originalId;
     this.name = 'TchannelUnhealthyError';
-    LiteError.call(this);
 };
 util.inherits(CodeErrors[Codes.Unhealthy], LiteError);
 

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -23,10 +23,12 @@
 var bufrw = require('bufrw');
 var WriteResult = bufrw.WriteResult;
 var ReadResult = bufrw.ReadResult;
-var TypedError = require('error/typed');
+//var TypedError = require('error/typed');
 var Tracing = require('./tracing');
+var util = require('util');
 
 var errors = require('../errors');
+var LiteError = require('../lib/lite_error');
 
 // TODO: enforce message ID of this frame is Frame.NullId when
 // errorBody.code.ProtocolError = ErrorResponse.Codes.ProtocolError
@@ -67,77 +69,112 @@ CodeNames[Codes.Unhealthy] = 'unhealthy';
 
 var CodeErrors = Object.create(null);
 CodeErrors[Codes.Timeout] = function TChannelTimeoutError(originalId, message) {
-    this.type = 'tchannel.timeout';
+    this.type = this.fullType = 'tchannel.timeout';
     this.message = message || 'TChannel timeout';
     this.isErrorFrame = true;
     this.codeName = 'Timeout';
     this.errorCode = Codes.Timeout;
     this.originalId = originalId;
+    this.name = 'TchannelTimeoutError';
+    LiteError.call(this);
 };
+util.inherits(CodeErrors[Codes.Timeout], LiteError);
+
 CodeErrors[Codes.Cancelled] = function TChannelCancelledError(originalId, message) {
-    this.type = 'tchannel.cancelled',
-    this.message = message || 'TChannel cancelled',
-    this.isErrorFrame = true,
-    this.codeName = 'Cancelled',
-    this.errorCode = Codes.Cancelled,
+    this.type = this.fullType = 'tchannel.cancelled';
+    this.message = message || 'TChannel cancelled';
+    this.isErrorFrame = true;
+    this.codeName = 'Cancelled';
+    this.errorCode = Codes.Cancelled;
     this.originalId = originalId;
-}
+    this.name = 'TchannelCancelledError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.Cancelled], LiteError);
+
 CodeErrors[Codes.Busy] = function TChannelBusyError(originalId, message) {
-    this.type = 'tchannel.busy';
+    this.type = this.fullType = 'tchannel.busy';
     this.message = message || 'TChannel busy';
     this.isErrorFrame = true;
     this.codeName = 'Busy';
     this.errorCode = Codes.Busy;
     this.originalId = originalId;
-}
+    this.name = 'TchannelBusyError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.Busy], LiteError);
+
 CodeErrors[Codes.Declined] = function TChannelDeclinedError(originalId, message) {
-    this.type = 'tchannel.declined';
+    this.type = this.fullType = 'tchannel.declined';
     this.message = message || 'TChannel declined';
     this.isErrorFrame = true;
     this.codeName = 'Declined';
     this.errorCode = Codes.Declined;
     this.originalId = originalId;
-}
+    this.name = 'TchannelDeclinedError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.Declined], LiteError);
+
 CodeErrors[Codes.UnexpectedError] = function TChannelUnexpectedError(originalId, message) {
-    this.type = 'tchannel.unexpected';
+    this.type = this.fullType = 'tchannel.unexpected';
     this.message = message || 'TChannel unexpected error';
     this.isErrorFrame = true;
     this.codeName = 'UnexpectedError';
     this.errorCode = Codes.UnexpectedError;
     this.originalId = originalId;
-}
+    this.name = 'TchannelUnexpectedError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.UnexpectedError], LiteError);
+
 CodeErrors[Codes.BadRequest] = function TChannelBadRequestError(originalId, message) {
-    this.type = 'tchannel.bad-request';
+    this.type = this.fullType = 'tchannel.bad-request';
     this.message = message || 'TChannel bad request';
     this.isErrorFrame = true;
     this.codeName = 'BadRequest';
     this.errorCode = Codes.BadRequest;
     this.originalId = originalId;
-}
+    this.name = 'TchannelBadRequestError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.BadRequest], LiteError);
+
 CodeErrors[Codes.NetworkError] = function TChannelNetworkError(originalId, message) {
-    this.type = 'tchannel.network';
+    this.type = this.fullType = 'tchannel.network';
     this.message = message || 'TChannel network error';
     this.isErrorFrame = true;
     this.codeName = 'NetworkError';
     this.errorCode = Codes.NetworkError;
     this.originalId = originalId;
-}
+    this.name = 'TchannelNetworkError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.NetworkError], LiteError);
+
 CodeErrors[Codes.ProtocolError] = function TChannelProtocolError(originalId, message) {
-    this.type = 'tchannel.protocol';
+    this.type = this.fullType = 'tchannel.protocol';
     this.message = message || 'TChannel protocol error';
     this.isErrorFrame = true;
     this.codeName = 'ProtocolError';
     this.errorCode = Codes.ProtocolError;
     this.originalId = originalId;
-}
+    this.name = 'TchannelProtocolError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.ProtocolError], LiteError);
+
 CodeErrors[Codes.Unhealthy] = function TChannelUnhealthyError(originalId, message) {
-    this.type = 'tchannel.unhealthy';
+    this.type = this.fullType = 'tchannel.unhealthy';
     this.message = message || 'TChannel unhealthy';
     this.isErrorFrame = true;
     this.codeName = 'Unhealthy';
     this.errorCode = Codes.Unhealthy;
     this.originalId = originalId;
-}
+    this.name = 'TchannelUnhealthyError';
+    LiteError.call(this);
+};
+util.inherits(CodeErrors[Codes.Unhealthy], LiteError);
 
 ErrorResponse.Codes = Codes;
 ErrorResponse.CodeNames = CodeNames;

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -70,108 +70,108 @@ var CodeErrors = Object.create(null);
 CodeErrors[Codes.Timeout] = function TChannelTimeoutError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.timeout';
-    this.message = message || 'TChannel timeout';
     this.isErrorFrame = true;
     this.codeName = 'Timeout';
     this.errorCode = Codes.Timeout;
-    this.originalId = originalId;
     this.name = 'TchannelTimeoutError';
+    this.message = message || 'TChannel timeout';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.Timeout], LiteError);
 
 CodeErrors[Codes.Cancelled] = function TChannelCancelledError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.cancelled';
-    this.message = message || 'TChannel cancelled';
     this.isErrorFrame = true;
     this.codeName = 'Cancelled';
     this.errorCode = Codes.Cancelled;
-    this.originalId = originalId;
     this.name = 'TchannelCancelledError';
+    this.message = message || 'TChannel cancelled';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.Cancelled], LiteError);
 
 CodeErrors[Codes.Busy] = function TChannelBusyError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.busy';
-    this.message = message || 'TChannel busy';
     this.isErrorFrame = true;
     this.codeName = 'Busy';
     this.errorCode = Codes.Busy;
-    this.originalId = originalId;
     this.name = 'TchannelBusyError';
+    this.message = message || 'TChannel busy';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.Busy], LiteError);
 
 CodeErrors[Codes.Declined] = function TChannelDeclinedError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.declined';
-    this.message = message || 'TChannel declined';
     this.isErrorFrame = true;
     this.codeName = 'Declined';
     this.errorCode = Codes.Declined;
-    this.originalId = originalId;
     this.name = 'TchannelDeclinedError';
+    this.message = message || 'TChannel declined';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.Declined], LiteError);
 
 CodeErrors[Codes.UnexpectedError] = function TChannelUnexpectedError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.unexpected';
-    this.message = message || 'TChannel unexpected error';
     this.isErrorFrame = true;
     this.codeName = 'UnexpectedError';
     this.errorCode = Codes.UnexpectedError;
-    this.originalId = originalId;
     this.name = 'TchannelUnexpectedError';
+    this.message = message || 'TChannel unexpected error';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.UnexpectedError], LiteError);
 
 CodeErrors[Codes.BadRequest] = function TChannelBadRequestError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.bad-request';
-    this.message = message || 'TChannel bad request';
     this.isErrorFrame = true;
     this.codeName = 'BadRequest';
     this.errorCode = Codes.BadRequest;
-    this.originalId = originalId;
     this.name = 'TchannelBadRequestError';
+    this.message = message || 'TChannel bad request';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.BadRequest], LiteError);
 
 CodeErrors[Codes.NetworkError] = function TChannelNetworkError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.network';
-    this.message = message || 'TChannel network error';
     this.isErrorFrame = true;
     this.codeName = 'NetworkError';
     this.errorCode = Codes.NetworkError;
-    this.originalId = originalId;
     this.name = 'TchannelNetworkError';
+    this.message = message || 'TChannel network error';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.NetworkError], LiteError);
 
 CodeErrors[Codes.ProtocolError] = function TChannelProtocolError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.protocol';
-    this.message = message || 'TChannel protocol error';
     this.isErrorFrame = true;
     this.codeName = 'ProtocolError';
     this.errorCode = Codes.ProtocolError;
-    this.originalId = originalId;
     this.name = 'TchannelProtocolError';
+    this.message = message || 'TChannel protocol error';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.ProtocolError], LiteError);
 
 CodeErrors[Codes.Unhealthy] = function TChannelUnhealthyError(originalId, message) {
     LiteError.call(this);
     this.type = this.fullType = 'tchannel.unhealthy';
-    this.message = message || 'TChannel unhealthy';
     this.isErrorFrame = true;
     this.codeName = 'Unhealthy';
     this.errorCode = Codes.Unhealthy;
-    this.originalId = originalId;
     this.name = 'TchannelUnhealthyError';
+    this.message = message || 'TChannel unhealthy';
+    this.originalId = originalId;
 };
 util.inherits(CodeErrors[Codes.Unhealthy], LiteError);
 

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -65,8 +65,31 @@ CodeNames[Codes.NetworkError] = 'network error';
 CodeNames[Codes.ProtocolError] = 'protocol error';
 CodeNames[Codes.Unhealthy] = 'unhealthy';
 
+function CodeError(type, message, isErrorFrame, codeName, errorCode, originalId) {
+    var self = this;
+    self.type = type;
+    self.message = message;
+    self.isErrorFrame = isErrorFrame;
+    self.codeName = codeName;
+    self.errorCode = errorCode;
+    self.originalId = originalId;
+}
+
+function partiallyApplyCodeError(options1) {
+    return function makeError(options2) {
+        return new CodeError(
+            options1.type || options2.type,
+            options1.message || options2.message,
+            options1.isErrorFrame || options2.isErrorFrame,
+            options1.codeName || options2.codeName,
+            options1.errorCode || options2.errorCode,
+            options1.originalId || options2.originalId
+        );
+    }
+}
+
 var CodeErrors = Object.create(null);
-CodeErrors[Codes.Timeout] = TypedError({
+CodeErrors[Codes.Timeout] = partiallyApplyCodeError({
     type: 'tchannel.timeout',
     message: 'TChannel timeout',
     isErrorFrame: true,
@@ -74,7 +97,7 @@ CodeErrors[Codes.Timeout] = TypedError({
     errorCode: Codes.Timeout,
     originalId: null
 });
-CodeErrors[Codes.Cancelled] = TypedError({
+CodeErrors[Codes.Cancelled] = partiallyApplyCodeError({
     type: 'tchannel.cancelled',
     message: 'TChannel cancelled',
     isErrorFrame: true,
@@ -82,7 +105,7 @@ CodeErrors[Codes.Cancelled] = TypedError({
     errorCode: Codes.Cancelled,
     originalId: null
 });
-CodeErrors[Codes.Busy] = TypedError({
+CodeErrors[Codes.Busy] = partiallyApplyCodeError({
     type: 'tchannel.busy',
     message: 'TChannel busy',
     isErrorFrame: true,
@@ -90,7 +113,7 @@ CodeErrors[Codes.Busy] = TypedError({
     errorCode: Codes.Busy,
     originalId: null
 });
-CodeErrors[Codes.Declined] = TypedError({
+CodeErrors[Codes.Declined] = partiallyApplyCodeError({
     type: 'tchannel.declined',
     message: 'TChannel declined',
     isErrorFrame: true,
@@ -98,7 +121,7 @@ CodeErrors[Codes.Declined] = TypedError({
     errorCode: Codes.Declined,
     originalId: null
 });
-CodeErrors[Codes.UnexpectedError] = TypedError({
+CodeErrors[Codes.UnexpectedError] = partiallyApplyCodeError({
     type: 'tchannel.unexpected',
     message: 'TChannel unexpected error',
     isErrorFrame: true,
@@ -106,7 +129,7 @@ CodeErrors[Codes.UnexpectedError] = TypedError({
     errorCode: Codes.UnexpectedError,
     originalId: null
 });
-CodeErrors[Codes.BadRequest] = TypedError({
+CodeErrors[Codes.BadRequest] = partiallyApplyCodeError({
     type: 'tchannel.bad-request',
     message: 'TChannel bad request',
     isErrorFrame: true,
@@ -114,7 +137,7 @@ CodeErrors[Codes.BadRequest] = TypedError({
     errorCode: Codes.BadRequest,
     originalId: null
 });
-CodeErrors[Codes.NetworkError] = TypedError({
+CodeErrors[Codes.NetworkError] = partiallyApplyCodeError({
     type: 'tchannel.network',
     message: 'TChannel network error',
     isErrorFrame: true,
@@ -122,7 +145,7 @@ CodeErrors[Codes.NetworkError] = TypedError({
     errorCode: Codes.NetworkError,
     originalId: null
 });
-CodeErrors[Codes.ProtocolError] = TypedError({
+CodeErrors[Codes.ProtocolError] = partiallyApplyCodeError({
     type: 'tchannel.protocol',
     message: 'TChannel protocol error',
     isErrorFrame: true,
@@ -130,7 +153,7 @@ CodeErrors[Codes.ProtocolError] = TypedError({
     errorCode: Codes.ProtocolError,
     originalId: null
 });
-CodeErrors[Codes.Unhealthy] = TypedError({
+CodeErrors[Codes.Unhealthy] = partiallyApplyCodeError({
     type: 'tchannel.unhealthy',
     message: 'TChannel unhealthy',
     isErrorFrame: true,

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -23,7 +23,6 @@
 var bufrw = require('bufrw');
 var WriteResult = bufrw.WriteResult;
 var ReadResult = bufrw.ReadResult;
-//var TypedError = require('error/typed');
 var Tracing = require('./tracing');
 var util = require('util');
 

--- a/node/v2/error_response.js
+++ b/node/v2/error_response.js
@@ -65,102 +65,79 @@ CodeNames[Codes.NetworkError] = 'network error';
 CodeNames[Codes.ProtocolError] = 'protocol error';
 CodeNames[Codes.Unhealthy] = 'unhealthy';
 
-function CodeError(type, message, isErrorFrame, codeName, errorCode, originalId) {
-    var self = this;
-    self.type = type;
-    self.message = message;
-    self.isErrorFrame = isErrorFrame;
-    self.codeName = codeName;
-    self.errorCode = errorCode;
-    self.originalId = originalId;
-}
-
-function partiallyApplyCodeError(options1) {
-    return function makeError(options2) {
-        return new CodeError(
-            options1.type || options2.type,
-            options1.message || options2.message,
-            options1.isErrorFrame || options2.isErrorFrame,
-            options1.codeName || options2.codeName,
-            options1.errorCode || options2.errorCode,
-            options1.originalId || options2.originalId
-        );
-    }
-}
-
 var CodeErrors = Object.create(null);
-CodeErrors[Codes.Timeout] = partiallyApplyCodeError({
-    type: 'tchannel.timeout',
-    message: 'TChannel timeout',
-    isErrorFrame: true,
-    codeName: 'Timeout',
-    errorCode: Codes.Timeout,
-    originalId: null
-});
-CodeErrors[Codes.Cancelled] = partiallyApplyCodeError({
-    type: 'tchannel.cancelled',
-    message: 'TChannel cancelled',
-    isErrorFrame: true,
-    codeName: 'Cancelled',
-    errorCode: Codes.Cancelled,
-    originalId: null
-});
-CodeErrors[Codes.Busy] = partiallyApplyCodeError({
-    type: 'tchannel.busy',
-    message: 'TChannel busy',
-    isErrorFrame: true,
-    codeName: 'Busy',
-    errorCode: Codes.Busy,
-    originalId: null
-});
-CodeErrors[Codes.Declined] = partiallyApplyCodeError({
-    type: 'tchannel.declined',
-    message: 'TChannel declined',
-    isErrorFrame: true,
-    codeName: 'Declined',
-    errorCode: Codes.Declined,
-    originalId: null
-});
-CodeErrors[Codes.UnexpectedError] = partiallyApplyCodeError({
-    type: 'tchannel.unexpected',
-    message: 'TChannel unexpected error',
-    isErrorFrame: true,
-    codeName: 'UnexpectedError',
-    errorCode: Codes.UnexpectedError,
-    originalId: null
-});
-CodeErrors[Codes.BadRequest] = partiallyApplyCodeError({
-    type: 'tchannel.bad-request',
-    message: 'TChannel bad request',
-    isErrorFrame: true,
-    codeName: 'BadRequest',
-    errorCode: Codes.BadRequest,
-    originalId: null
-});
-CodeErrors[Codes.NetworkError] = partiallyApplyCodeError({
-    type: 'tchannel.network',
-    message: 'TChannel network error',
-    isErrorFrame: true,
-    codeName: 'NetworkError',
-    errorCode: Codes.NetworkError,
-    originalId: null
-});
-CodeErrors[Codes.ProtocolError] = partiallyApplyCodeError({
-    type: 'tchannel.protocol',
-    message: 'TChannel protocol error',
-    isErrorFrame: true,
-    codeName: 'ProtocolError',
-    errorCode: Codes.ProtocolError,
-    originalId: null
-});
-CodeErrors[Codes.Unhealthy] = partiallyApplyCodeError({
-    type: 'tchannel.unhealthy',
-    message: 'TChannel unhealthy',
-    isErrorFrame: true,
-    codeName: 'Unhealthy',
-    errorCode: Codes.Unhealthy,
-    originalId: null
-});
+CodeErrors[Codes.Timeout] = function TChannelTimeoutError(originalId, message) {
+    this.type = 'tchannel.timeout';
+    this.message = message || 'TChannel timeout';
+    this.isErrorFrame = true;
+    this.codeName = 'Timeout';
+    this.errorCode = Codes.Timeout;
+    this.originalId = originalId;
+};
+CodeErrors[Codes.Cancelled] = function TChannelCancelledError(originalId, message) {
+    this.type = 'tchannel.cancelled',
+    this.message = message || 'TChannel cancelled',
+    this.isErrorFrame = true,
+    this.codeName = 'Cancelled',
+    this.errorCode = Codes.Cancelled,
+    this.originalId = originalId;
+}
+CodeErrors[Codes.Busy] = function TChannelBusyError(originalId, message) {
+    this.type = 'tchannel.busy';
+    this.message = message || 'TChannel busy';
+    this.isErrorFrame = true;
+    this.codeName = 'Busy';
+    this.errorCode = Codes.Busy;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.Declined] = function TChannelDeclinedError(originalId, message) {
+    this.type = 'tchannel.declined';
+    this.message = message || 'TChannel declined';
+    this.isErrorFrame = true;
+    this.codeName = 'Declined';
+    this.errorCode = Codes.Declined;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.UnexpectedError] = function TChannelUnexpectedError(originalId, message) {
+    this.type = 'tchannel.unexpected';
+    this.message = message || 'TChannel unexpected error';
+    this.isErrorFrame = true;
+    this.codeName = 'UnexpectedError';
+    this.errorCode = Codes.UnexpectedError;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.BadRequest] = function TChannelBadRequestError(originalId, message) {
+    this.type = 'tchannel.bad-request';
+    this.message = message || 'TChannel bad request';
+    this.isErrorFrame = true;
+    this.codeName = 'BadRequest';
+    this.errorCode = Codes.BadRequest;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.NetworkError] = function TChannelNetworkError(originalId, message) {
+    this.type = 'tchannel.network';
+    this.message = message || 'TChannel network error';
+    this.isErrorFrame = true;
+    this.codeName = 'NetworkError';
+    this.errorCode = Codes.NetworkError;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.ProtocolError] = function TChannelProtocolError(originalId, message) {
+    this.type = 'tchannel.protocol';
+    this.message = message || 'TChannel protocol error';
+    this.isErrorFrame = true;
+    this.codeName = 'ProtocolError';
+    this.errorCode = Codes.ProtocolError;
+    this.originalId = originalId;
+}
+CodeErrors[Codes.Unhealthy] = function TChannelUnhealthyError(originalId, message) {
+    this.type = 'tchannel.unhealthy';
+    this.message = message || 'TChannel unhealthy';
+    this.isErrorFrame = true;
+    this.codeName = 'Unhealthy';
+    this.errorCode = Codes.Unhealthy;
+    this.originalId = originalId;
+}
 
 ErrorResponse.Codes = Codes;
 ErrorResponse.CodeNames = CodeNames;

--- a/node/v2/handler.js
+++ b/node/v2/handler.js
@@ -495,10 +495,7 @@ TChannelV2Handler.prototype.handleError = function handleError(errFrame, callbac
     var id = errFrame.id;
     var code = errFrame.body.code;
     var message = String(errFrame.body.message);
-    var err = v2.ErrorResponse.CodeErrors[code]({
-        originalId: id,
-        message: message
-    });
+    var err = new v2.ErrorResponse.CodeErrors[code](id, message);
 
     delete self.streamingReq[id];
     delete self.streamingRes[id];


### PR DESCRIPTION
By avoiding the pit of despair that is v8's Error objects, we can eliminate the 15% of the process or so we spend creating these objects by using a lightweight container class. Arguably, stack traces aren't necessary here.

before:
```
1:      SET 4KiB, 10000/0 min/max/avg/p95:  852/4506/2585.58/3779.10   7238ms total,  2763.19 ops/sec
1:      SET 4KiB, 10000/0 min/max/avg/p95:  881/4373/2658.98/4036.20   7260ms total,  2754.82 ops/sec
1:      SET 4KiB, 10000/0 min/max/avg/p95:  655/4438/2662.27/3855.65   7217ms total,  2771.23 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  628/4482/2248.48/3562.50   6118ms total,  3269.04 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  628/4080/2357.28/3738.55   6087ms total,  3285.69 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  689/4894/2442.56/3894.10   6334ms total,  3157.56 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1789/5460/3375.80/5231.55   7626ms total,  2622.61 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1658/5809/3494.39/5613.70   7784ms total,  2569.37 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1655/6978/4041.88/6666.85   8966ms total,  2230.65 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1430/5415/3422.20/4720.40   6320ms total,  3164.56 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1172/5391/2866.71/4797.00   6257ms total,  3196.42 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1670/6135/3153.97/5514.10   6561ms total,  3048.32 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95: 1011/5140/3759.07/4948.55  10402ms total,  1922.71 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95: 1319/5496/3914.08/5205.55  10728ms total,  1864.28 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95: 1199/5471/3639.33/5101.30  10074ms total,  1985.31 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95:  637/4293/2425.64/4017.00   6353ms total,  3148.12 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95: 1082/4054/2287.95/3746.10   6215ms total,  3218.02 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95:  692/4383/2366.44/3606.10   6542ms total,  3057.17 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 3106/9059/6129.85/8764.75  12186ms total,  1641.23 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 3014/9196/5897.33/8722.30  12347ms total,  1619.83 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 2633/8174/5211.64/7738.55  11013ms total,  1816.04 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1811/4470/3147.27/4137.30   6016ms total,  3324.47 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1654/27002/16802.13/25903.10  28112ms total,   711.44 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1819/4525/3244.00/4139.65   6458ms total,  3096.93 ops/sec
```
[flame](https://people.uberinternal.com/~rf/lightweight-code-errors/flame-before.svg)

after:
```
1:      SET 4KiB, 10000/0 min/max/avg/p95:  774/3602/2271.58/3075.75   6263ms total,  3193.36 ops/sec
1:      SET 4KiB, 10000/0 min/max/avg/p95:  743/3621/2138.66/3230.10   5954ms total,  3359.09 ops/sec
1:      SET 4KiB, 10000/0 min/max/avg/p95:  717/3529/2185.37/3217.65   6022ms total,  3321.16 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  445/3396/1821.72/2664.00   4749ms total,  4211.41 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  542/3115/1813.47/2568.20   4805ms total,  4162.33 ops/sec
1:      GET 4KiB, 10000/0 min/max/avg/p95:  458/3958/2018.70/3611.55   4952ms total,  4038.77 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1340/4181/2734.49/3928.00   6088ms total,  3285.15 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1397/4521/2924.58/4375.00   6238ms total,  3206.16 ops/sec
1:      SET 4KiB, 20000/0 min/max/avg/p95: 1739/4629/3037.95/4489.55   6544ms total,  3056.23 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1079/4720/2477.85/4390.55   5348ms total,  3739.72 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1056/5314/2853.16/4862.65   5457ms total,  3665.02 ops/sec
1:      GET 4KiB, 20000/0 min/max/avg/p95: 1328/4469/2963.96/4220.55   5186ms total,  3856.54 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95:  986/7145/3774.42/6210.75  10517ms total,  1901.68 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95: 1186/5949/3741.59/5413.95   9951ms total,  2009.85 ops/sec
1:     SET 16KiB, 10000/0 min/max/avg/p95: 1073/4793/3053.61/4398.10   8593ms total,  2327.48 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95:  291/2904/1756.49/2513.00   4832ms total,  4139.07 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95:  806/3372/1852.70/2855.40   4793ms total,  4172.75 ops/sec
1:     GET 16KiB, 10000/0 min/max/avg/p95:  555/4133/2162.79/3268.65   5621ms total,  3558.09 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 2918/6519/4579.50/6299.55   9716ms total,  2058.46 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 2667/6947/4606.71/6832.75  10059ms total,  1988.27 ops/sec
1:     SET 16KiB, 20000/0 min/max/avg/p95: 2769/7175/4767.64/6800.95  10148ms total,  1970.83 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1245/3976/2588.52/3275.10   5040ms total,  3968.25 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1536/4362/2852.55/4136.10   5132ms total,  3897.12 ops/sec
1:     GET 16KiB, 20000/0 min/max/avg/p95: 1358/4604/2672.56/4181.95   5961ms total,  3355.14 ops/sec
```
[flame](https://people.uberinternal.com/~rf/lightweight-code-errors/flame-after.svg)