### PR TITLE
Move switches over codeNames into errors module

### DIFF
--- a/node/as/http.js
+++ b/node/as/http.js
@@ -254,32 +254,9 @@ TChannelHTTP.prototype.forwardToTChannel = function forwardToTChannel(tchannel, 
 TChannelHTTP.prototype._sendHTTPError = function _sendHTTPError(hres, error) {
     hres.setHeader('Content-Type', 'text/plain');
     var codeName = errors.classify(error);
-    switch (codeName) {
-        case 'Cancelled':
-            hres.writeHead(500, 'TChannel Cancelled');
-            break;
-        case 'Unhealthy':
-        case 'Declined':
-            hres.writeHead(503, 'Service Unavailable');
-            break;
-        case 'Timeout':
-            hres.writeHead(504, 'Gateway Timeout');
-            break;
-        case 'BadRequest':
-            hres.writeHead(400, 'Bad Request');
-            break;
-        case 'Busy':
-            hres.writeHead(429, 'Too Many Requests');
-            break;
-        case 'ProtocolError':
-            hres.writeHead(500, 'TChannel Protocol Error');
-            break;
-        case 'NetworkError':
-            hres.writeHead(500, 'TChannel Network Error');
-            break;
-        default:
-            hres.writeHead(500, 'Internal Server Error');
-    }
+    var httpInfo = errors.toHTTPCode(codeName);
+
+    hres.writeHead(httpInfo.statusCode, httpInfo.statusMessage);
     hres.end(error.message);
 };
 

--- a/node/errors.js
+++ b/node/errors.js
@@ -788,3 +788,37 @@ module.exports.shouldRetry = function shouldRetry(codeName, retryFlags) {
             return null;
     }
 };
+
+function HTTPInfo(statusCode, statusMessage) {
+    this.statusCode = statusCode;
+    this.statusMessage = statusMessage;
+}
+
+module.exports.toHTTPCode = function toHTTPCode(codeName) {
+    switch (codeName) {
+        case 'Cancelled':
+            return new HTTPInfo(500, 'TChannel Cancelled');
+
+        case 'Unhealthy':
+        case 'Declined':
+            return new HTTPInfo(503, 'Service Unavailable');
+
+        case 'Timeout':
+            return new HTTPInfo(504, 'Gateway Timeout');
+
+        case 'BadRequest':
+            return new HTTPInfo(400, 'Bad Request');
+
+        case 'Busy':
+            return new HTTPInfo(429, 'Too Many Requests');
+
+        case 'ProtocolError':
+            return new HTTPInfo(500, 'TChannel Protocol Error');
+
+        case 'NetworkError':
+            return new HTTPInfo(500, 'TChannel Network Error');
+
+        default:
+            return new HTTPInfo(500, 'Internal Server Error');
+    }
+};

--- a/node/errors.js
+++ b/node/errors.js
@@ -822,3 +822,27 @@ module.exports.toHTTPCode = function toHTTPCode(codeName) {
             return new HTTPInfo(500, 'Internal Server Error');
     }
 };
+
+module.exports.logLevel = function errorLogLevel(err, codeName) {
+    switch (codeName) {
+        case 'ProtocolError':
+        case 'UnexpectedError':
+            if (err.isErrorFrame) {
+                return 'warn';
+            }
+            return 'error';
+
+        case 'Busy':
+        case 'Cancelled':
+        case 'Declined':
+        case 'NetworkError':
+            return 'warn';
+
+        case 'BadRequest':
+        case 'Timeout':
+            return 'info';
+
+        default:
+            return 'error';
+    }
+};

--- a/node/relay_handler.js
+++ b/node/relay_handler.js
@@ -284,7 +284,7 @@ RelayRequest.prototype.logError = function relayRequestLogError(err, codeName) {
 };
 
 function logError(logger, err, codeName, extendLogInfo) {
-    var level = errorLogLevel(err, codeName);
+    var level = errors.logLevel(err, codeName);
 
     var logOptions = extendLogInfo({
         error: err,
@@ -303,30 +303,6 @@ function logError(logger, err, codeName, extendLogInfo) {
         logger.warn('error while forwarding', logOptions);
     } else if (level === 'info') {
         logger.info('expected error while forwarding', logOptions);
-    }
-}
-
-function errorLogLevel(err, codeName) {
-    switch (codeName) {
-        case 'ProtocolError':
-        case 'UnexpectedError':
-            if (err.isErrorFrame) {
-                return 'warn';
-            }
-            return 'error';
-
-        case 'NetworkError':
-        case 'Cancelled':
-        case 'Declined':
-        case 'Busy':
-            return 'warn';
-
-        case 'BadRequest':
-        case 'Timeout':
-            return 'info';
-
-        default:
-            return 'error';
     }
 }
 


### PR DESCRIPTION
Having the switch statements in the errors module makes
it easier to understand the semantics of each type of 
error frame in one place.

r: @jcorbin @anson627 @rf