### PR TITLE
peer selection should favor least outgoing reqs

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -390,7 +390,7 @@ TChannelPeer.prototype.makeOutConnection = function makeOutConnection(socket) {
     return conn;
 };
 
-TChannelPeer.prototype.pendingWeightedRandom = function pendingWeightedRandom(direction) {
+TChannelPeer.prototype.pendingWeightedRandom = function pendingWeightedRandom() {
     // Returns a score in the range from 0 to 1, where it is preferable to use
     // a peer with a higher score over one with a lower score.
     // This range is divided among an infinite set of subranges corresponding
@@ -414,24 +414,20 @@ TChannelPeer.prototype.pendingWeightedRandom = function pendingWeightedRandom(di
     //
     // This remains true with this algorithm, within each equivalence class.
     var self = this;
-    var pending = self.pendingIdentified + self.countPending(direction);
+    var pending = self.pendingIdentified + self.countPending();
     var max = Math.pow(0.5, pending);
     var min = max / 2;
     var diff = max - min;
     return min + diff * self.random();
 };
 
-TChannelPeer.prototype.countPending = function countPending(direction) {
+TChannelPeer.prototype.countPending = function countPending() {
     var self = this;
     var pending = 0;
     for (var index = 0; index < self.connections.length; index++) {
         var connPending = self.connections[index].ops.getPending();
 
-        if (direction === 'in') {
-            pending += connPending.in;
-        } else {
-            pending += connPending.out;
-        }
+        pending += connPending.out;
     }
 
     return pending;

--- a/node/peer_score_strategies.js
+++ b/node/peer_score_strategies.js
@@ -59,7 +59,7 @@ PreferOutgoing.prototype.getScore = function getScore() {
     // space:
     //   [0.1, 0.4)  peers with no identified outgoing connection
     //   [0.4, 1.0)  identified outgoing connections
-    var random = self.peer.pendingWeightedRandom('out');
+    var random = self.peer.pendingWeightedRandom();
     var tier = self.getTier();
     self.lastTier = tier;
     switch (tier) {
@@ -105,7 +105,7 @@ NoPreference.prototype.getScore = function getScore() {
     // space:
     //   [0.1, 0.4)  peers with no identified connection
     //   [0.4, 1.0)  identified connections
-    var random = self.peer.pendingWeightedRandom('out');
+    var random = self.peer.pendingWeightedRandom();
     var tier = self.getTier();
     self.lastTier = tier;
     switch (tier) {
@@ -153,7 +153,7 @@ PreferIncoming.prototype.getScore = function getScore() {
     // space:
     //   [0.1, 0.4)  peers with no identified outgoing connection
     //   [0.4, 1.0)  identified outgoing connections
-    var random = self.peer.pendingWeightedRandom('in');
+    var random = self.peer.pendingWeightedRandom();
     var tier = self.getTier();
     self.lastTier = tier;
     switch (tier) {


### PR DESCRIPTION
We had a bug in PreferIncoming where we "generalized" the direction
too much.

We should always favor a peer with least outgoing because we want to
measure and pick the peer with the lowest P99 latency which we are doing
by least pending requests (i.e. more pending requests === bigger latency)

r: @jcorbin @kriskowal

cc @shannili