### PR TITLE
Take busy frames into account for peer selection

### DIFF
--- a/node/peer.js
+++ b/node/peer.js
@@ -432,6 +432,8 @@ TChannelPeer.prototype.countPending = function countPending(direction) {
         } else {
             pending += connPending.out;
         }
+
+        pending += connPending.busy;
     }
 
     return pending;


### PR DESCRIPTION
This will penalize a peer that has busy frames by
giving him more pending counts and selecting him less.

Once that peer stops returning busy frames or the
tombstones time out we will start selecting him again.

This allows Hyperbahn to route requests around a busy
worker (same with xlate) without having to have retries
on.

In the long term this will make less requests fail
when you have 100 exit nodes and 4 of them are busy.

r: @jcorbin @kriskowal @rf

cc @anson627