### PR TITLE
go: Improve Close to avoid races after timeout

### DIFF
--- a/golang/close_test.go
+++ b/golang/close_test.go
@@ -260,6 +260,7 @@ func TestCloseSemantics(t *testing.T) {
 	// Once the incoming connection is drained, outgoing calls should fail.
 	s1C <- struct{}{}
 	<-call2
+	runtime.Gosched()
 	assert.Equal(t, ChannelInboundClosed, s1.State())
 	require.Error(t, call(s1, s2),
 		"closed channel with no pending incoming calls should not allow outgoing calls")
@@ -267,6 +268,7 @@ func TestCloseSemantics(t *testing.T) {
 	// Now the channel should be completely closed as there are no pending connections.
 	s2C <- struct{}{}
 	<-call1
+	runtime.Gosched()
 	assert.Equal(t, ChannelClosed, s1.State())
 
 	// Close s2 so we don't leave any goroutines running.

--- a/golang/inbound.go
+++ b/golang/inbound.go
@@ -175,7 +175,6 @@ func (c *Connection) dispatchInbound(_ uint32, _ uint32, call *InboundCall) {
 	}
 	if h == nil {
 		c.log.Errorf("Could not find handler for %s:%s", call.ServiceName(), call.Operation())
-		call.mex.shutdown()
 		call.Response().SendSystemError(
 			NewSystemError(ErrCodeBadRequest, "no handler for service %q and operation %q", call.ServiceName(), call.Operation()))
 		return


### PR DESCRIPTION
Fix race conditions caused by timeouts.
Make inbound timeout handling be thread-safe
Update timeout/close tests to be more reliable