### PR TITLE
go: thrift-gen should not delete gen-go folder

### DIFF
--- a/golang/thrift/thrift-gen/generate.go
+++ b/golang/thrift/thrift-gen/generate.go
@@ -77,11 +77,6 @@ func runThrift(inFile string, thriftImport string) (string, error) {
 		return "", fmt.Errorf("failed to delete directory %s: %v", genDir, err)
 	}
 
-	// Create the directory.
-	if err := os.Mkdir(genDir, 0777); err != nil {
-		return "", fmt.Errorf("failed to create directory %s: %v", genDir, err)
-	}
-
 	// Generate the Apache Thrift generated code.
 	if err := execThrift("-r", "--gen", "go:thrift_import="+thriftImport, "-o", dir, inFile); err != nil {
 		return "", fmt.Errorf("Thrift compile failed: %v", err)

--- a/golang/thrift/thrift-gen/generate.go
+++ b/golang/thrift/thrift-gen/generate.go
@@ -72,8 +72,8 @@ func runThrift(inFile string, thriftImport string) (string, error) {
 	genDir := filepath.Join(dir, "gen-go")
 	outDir := filepath.Join(genDir, baseName)
 
-	// Delete any existing generated code.
-	if err := execCmd("rm", "-rf", genDir); err != nil {
+	// Delete any existing generated code for this Thrift file.
+	if err := execCmd("rm", "-rf", outDir); err != nil {
 		return "", fmt.Errorf("failed to delete directory %s: %v", genDir, err)
 	}
 

--- a/golang/thrift/thrift-gen/main.go
+++ b/golang/thrift/thrift-gen/main.go
@@ -103,6 +103,10 @@ func parseTemplate() *template.Template {
 }
 
 func generateCode(outputFile string, tmpl *template.Template, pkg string, parsed *parser.Thrift) error {
+	if outputFile == "" {
+		return fmt.Errorf("must speciy an output file")
+	}
+
 	wrappedServices, err := wrapServices(parsed)
 	if err != nil {
 		log.Fatalf("Service parsing error: %v", err)


### PR DESCRIPTION
Since there may be existing generated code for another .thrift file in gen-go, keep the folder around.