### PR TITLE
Hyperbahn unadvertise should not return error when it succeeds

### DIFF
--- a/node/hyperbahn-client.js
+++ b/node/hyperbahn-client.js
@@ -380,10 +380,8 @@ function unadvertise(opts) {
     timers.clearTimeout(self._advertisementTimer);
     timers.clearTimeout(self.advertisementTimeoutTimer);
     self.latestAdvertisementResult = null;
-    self.state = States.UNADVERTISED;
-    self.emit('unadvertised');
     function unadvertiseInternalCb(error, result) {
-        if (error) {
+        if (error && error.type !== 'tchannel.connection.reset') {
             self.logger.warn('HyperbahnClient: unadvertisement failure', {
                 error: error,
                 serviceName: self.serviceName,
@@ -391,6 +389,8 @@ function unadvertise(opts) {
             });
             return;
         }
+        self.state = States.UNADVERTISED;
+        self.emit('unadvertised');
     }
 };
 


### PR DESCRIPTION
Most of time remote socket closes immediately after unadvertise request is made, and shows up as a reset error, which actually means success.

@ShanniLi @Raynos @jcorbin 