### PR TITLE
go: Only report traces if Tracing is enabled in the span

### DIFF
--- a/golang/tracereporter.go
+++ b/golang/tracereporter.go
@@ -104,7 +104,9 @@ func (as *Annotations) AddAnnotation(key AnnotationKey) {
 	as.annotations = append(as.annotations, NewAnnotation(key))
 }
 
-// Report reports the annotations to the given trace reporter.
+// Report reports the annotations to the given trace reporter, if tracing is enabled in the span.
 func (as *Annotations) Report(span Span, targetEndpoint TargetEndpoint, reporter TraceReporter) {
-	reporter.Report(span, as.annotations, as.binaryAnnotations, targetEndpoint)
+	if span.TracingEnabled() {
+		reporter.Report(span, as.annotations, as.binaryAnnotations, targetEndpoint)
+	}
 }

--- a/golang/tracereporter.go
+++ b/golang/tracereporter.go
@@ -69,6 +69,14 @@ type TraceReporter interface {
 	Report(span Span, annotations []Annotation, binaryAnnotations []BinaryAnnotation, targetEndpoint TargetEndpoint)
 }
 
+// TraceReporterFunc allows using a function as a TraceReporter.
+type TraceReporterFunc func(span Span, annotations []Annotation, binaryAnnotations []BinaryAnnotation, targetEndpoint TargetEndpoint)
+
+// Report calls the underlying function.
+func (f TraceReporterFunc) Report(span Span, annotations []Annotation, binaryAnnotations []BinaryAnnotation, targetEndpoint TargetEndpoint) {
+	f(span, annotations, binaryAnnotations, targetEndpoint)
+}
+
 // NullReporter is the default TraceReporter which does not do anything.
 var NullReporter TraceReporter = nullReporter{}
 

--- a/golang/tracereporter_test.go
+++ b/golang/tracereporter_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestZipkinTraceReporterFactoryOverTraceReporter(t *testing.T) {
+func TestTraceReporterFactory(t *testing.T) {
 	var gotChannel *Channel
 	testTraceReporterFactory := func(ch *Channel) TraceReporter {
 		gotChannel = ch

--- a/golang/utils_for_test.go
+++ b/golang/utils_for_test.go
@@ -45,6 +45,11 @@ func GetConnections(ch *Channel) []*Connection {
 	return connections
 }
 
+// NewSpan returns a Span for testing.
+func NewSpan(traceID uint64, parentID uint64, spanID uint64) Span {
+	return Span{traceID: traceID, parentID: parentID, spanID: spanID, flags: defaultTracingFlags}
+}
+
 // GetTimeNow returns the variable pointing to time.Now for stubbing.
 func GetTimeNow() *func() time.Time {
 	return &timeNow


### PR DESCRIPTION
Adds unit tests for TraceReporting and ensures spans are only reported if tracing is enabled in the span.