### PR TITLE
go: Making a call with no peers should return an error

### DIFF
--- a/golang/channel.go
+++ b/golang/channel.go
@@ -153,15 +153,7 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		handlers:          &handlerMap{},
 		subChannels:       &subChannelMap{},
 	}
-
-	traceReporter := opts.TraceReporter
-	if opts.TraceReporterFactory != nil {
-		traceReporter = opts.TraceReporterFactory(ch)
-	}
-	if traceReporter == nil {
-		traceReporter = NullReporter
-	}
-	ch.traceReporter = traceReporter
+	ch.peers = newPeerList(ch)
 
 	ch.mutable.peerInfo = LocalPeerInfo{
 		PeerInfo: PeerInfo{
@@ -171,8 +163,18 @@ func NewChannel(serviceName string, opts *ChannelOptions) (*Channel, error) {
 		ServiceName: serviceName,
 	}
 	ch.mutable.state = ChannelClient
-	ch.peers = newPeerList(ch)
 	ch.createCommonStats()
+
+	// TraceReporter may use the channel, so we must initialize it once the channel is ready.
+	traceReporter := opts.TraceReporter
+	if opts.TraceReporterFactory != nil {
+		traceReporter = opts.TraceReporterFactory(ch)
+	}
+	if traceReporter == nil {
+		traceReporter = NullReporter
+	}
+	ch.traceReporter = traceReporter
+
 	return ch, nil
 }
 

--- a/golang/peer.go
+++ b/golang/peer.go
@@ -32,6 +32,9 @@ var (
 	// ErrInvalidConnectionState indicates that the connection is not in a valid state.
 	ErrInvalidConnectionState = errors.New("connection is in an invalid state")
 
+	// ErrNoPeers indicates that there are no peers.
+	ErrNoPeers = errors.New("no peers available")
+
 	peerRng = NewRand(time.Now().UnixNano())
 )
 
@@ -71,18 +74,18 @@ func randPeer(peers []*Peer) *Peer {
 }
 
 // Get returns a peer from the peer list, or nil if none can be found.
-func (l *PeerList) Get() *Peer {
+func (l *PeerList) Get() (*Peer, error) {
 	l.mut.RLock()
 
 	if len(l.peers) == 0 {
 		l.mut.RUnlock()
-		return nil
+		return nil, ErrNoPeers
 	}
 
 	peer := randPeer(l.peers)
 	l.mut.RUnlock()
 
-	return peer
+	return peer, nil
 }
 
 // GetOrAdd returns a peer for the given hostPort, creating one if it doesn't yet exist.

--- a/golang/peer_test.go
+++ b/golang/peer_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel/golang/testutils"
+)
+
+func TestGetPeerNoPeer(t *testing.T) {
+	ch, err := testutils.NewClient(nil)
+	require.NoError(t, err, "NewClient failed")
+
+	peer, err := ch.Peers().Get()
+	assert.Error(t, err, "Empty peer list should return error")
+	assert.Nil(t, peer, "should not return peer")
+}
+
+func TestGetPeerSinglePeer(t *testing.T) {
+	ch, err := testutils.NewClient(nil)
+	require.NoError(t, err, "NewClient failed")
+
+	ch.Peers().Add("1.1.1.1:1234")
+
+	peer, err := ch.Peers().Get()
+	assert.NoError(t, err, "peer list should return contained element")
+	assert.Equal(t, "1.1.1.1:1234", peer.HostPort(), "returned peer mismatch")
+}

--- a/golang/subchannel.go
+++ b/golang/subchannel.go
@@ -69,7 +69,12 @@ func (c *SubChannel) BeginCall(ctx context.Context, operationName string, callOp
 		callOptions = defaultCallOptions
 	}
 
-	return c.peers.Get().BeginCall(ctx, c.ServiceName(), operationName, callOptions)
+	peer, err := c.peers.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return peer.BeginCall(ctx, c.ServiceName(), operationName, callOptions)
 }
 
 // Peers returns the PeerList for this subchannel.

--- a/golang/thrift/client.go
+++ b/golang/thrift/client.go
@@ -55,7 +55,11 @@ func (c *client) Call(ctx Context, thriftService, methodName string, req, resp t
 	if c.opts.HostPort != "" {
 		peer = c.sc.Peers().GetOrAdd(c.opts.HostPort)
 	} else {
-		peer = c.sc.Peers().Get()
+		var err error
+		peer, err = c.sc.Peers().Get()
+		if err != nil {
+			return false, err
+		}
 	}
 	call, err := peer.BeginCall(ctx, c.serviceName, thriftService+"::"+methodName, &tchannel.CallOptions{Format: tchannel.Thrift})
 	if err != nil {


### PR DESCRIPTION
Also fixes a bug where TraceReporter tried to use peers before it was set on the channel.