### PR TITLE
go: Fixes for thrift-gen compatibility with thrift generated code

### DIFF
--- a/golang/thrift/thrift-gen/names.go
+++ b/golang/thrift/thrift-gen/names.go
@@ -91,7 +91,9 @@ func camcelCase(name string) string {
 }
 
 func avoidThriftClash(name string) string {
-	if strings.HasSuffix(name, "Result") || strings.HasSuffix(name, "Args") {
+	if strings.HasSuffix(name, "Result") ||
+		strings.HasSuffix(name, "Args") ||
+		strings.HasPrefix(name, "New") {
 		return name + "_"
 	}
 	return name

--- a/golang/thrift/thrift-gen/test_files/gokeywords.thrift
+++ b/golang/thrift/thrift-gen/test_files/gokeywords.thrift
@@ -9,6 +9,7 @@ struct Result {
   2: required i32 func
   3: required i32 chan
   4: required i32 result
+  5: required i64 newRole
 }
 
 service func {

--- a/golang/thrift/thrift-gen/test_files/typedefs.thrift
+++ b/golang/thrift/thrift-gen/test_files/typedefs.thrift
@@ -13,11 +13,17 @@ struct S {
 
 typedef S ST
 
+enum Operator
+{
+  ADD = 1,
+  SUBTRACT = 2
+}
+
 service Test {
   Y M1(1: X arg1, 2: i arg2)
   X M2(1: Y arg1)
   Z M3(1: X arg1)
-  S M4(1: S arg1)
+  S M4(1: S arg1, 2: Operator op)
 
   // Thrift compiler is broken on this case.
   // ST M5(1: ST arg1, 2: S arg2)

--- a/golang/thrift/thrift-gen/typestate.go
+++ b/golang/thrift/thrift-gen/typestate.go
@@ -30,7 +30,18 @@ type State struct {
 
 // NewState parses the type information for a parsed Thrift file and returns the state.
 func NewState(v *parser.Thrift) *State {
-	return &State{v.Typedefs}
+	typedefs := make(map[string]*parser.Type)
+	for k, v := range v.Typedefs {
+		typedefs[k] = v
+	}
+
+	// Enums are typedefs to an int64.
+	i64Type := &parser.Type{Name: "i64"}
+	for k := range v.Enums {
+		typedefs[k] = i64Type
+	}
+
+	return &State{typedefs}
 }
 
 func (s *State) isBasicType(thriftType string) bool {


### PR DESCRIPTION
Support enum types and match the name for fields name New*