### PR TITLE
go: Simplify trace tests and verify buildZipkinSpan

### DIFF
--- a/golang/trace/zipkin_tracereporter.go
+++ b/golang/trace/zipkin_tracereporter.go
@@ -135,8 +135,8 @@ func buildZipkinAnnotations(anns []tc.Annotation) []*tcollector.Annotation {
 	zipkinAnns := make([]*tcollector.Annotation, len(anns))
 	for i, ann := range anns {
 		zipkinAnns[i] = &tcollector.Annotation{
-			Timestamp: (float64)(ann.Timestamp.UnixNano() / 1e6),
-			Value:     (string)(ann.Key),
+			Timestamp: float64(ann.Timestamp.UnixNano() / 1e6),
+			Value:     string(ann.Key),
 		}
 	}
 	return zipkinAnns


### PR DESCRIPTION
Seeing trace reports that don't seem to make sense, so I added tests to verify that `buildZipkinSpan` is creating timestamps correctly.

No functional changes in this change.