### PR TITLE
go: hyperbahn.Client Advertise should fail on ephemeral channels.

### DIFF
--- a/golang/hyperbahn/advertise.go
+++ b/golang/hyperbahn/advertise.go
@@ -72,6 +72,9 @@ func (c *Client) advertiseLoop() {
 
 	for {
 		timeSleep(sleepFor)
+		if c.IsClosed() {
+			return
+		}
 
 		if err := c.sendAdvertise(); err != nil {
 			consecutiveFailures++

--- a/golang/hyperbahn/advertise_test.go
+++ b/golang/hyperbahn/advertise_test.go
@@ -47,6 +47,24 @@ func TestAdvertiseFailed(t *testing.T) {
 	})
 }
 
+func TestNotListeningChannel(t *testing.T) {
+	withSetup(t, func(hypCh *tchannel.Channel, hyperbahnHostPort string) {
+		adHandler := func(ctx json.Context, req *AdRequest) (*AdResponse, error) {
+			return &AdResponse{1}, nil
+		}
+		json.Register(hypCh, json.Handlers{"ad": adHandler}, nil)
+
+		ch, err := testutils.NewClient(nil)
+		require.NoError(t, err, "testutils NewClient failed")
+
+		client, err := NewClient(ch, configFor(hyperbahnHostPort), nil)
+		assert.NoError(t, err, "hyperbahn NewClient failed")
+		defer client.Close()
+
+		assert.Equal(t, errEphemeralPeer, client.Advertise(), "Advertise without Listen should fail")
+	})
+}
+
 type retryTest struct {
 	// channel used to control the response to an 'ad' call.
 	respCh chan int

--- a/golang/hyperbahn/advertise_test.go
+++ b/golang/hyperbahn/advertise_test.go
@@ -118,8 +118,8 @@ func runRetryTest(t *testing.T, f func(r *retryTest)) {
 	withSetup(t, func(serverCh *tchannel.Channel, hostPort string) {
 		json.Register(serverCh, json.Handlers{"ad": r.adHandler}, nil)
 
-		clientCh, err := tchannel.NewChannel("my-client", nil)
-		require.NoError(t, err)
+		clientCh, err := testutils.NewServer(&testutils.ChannelOpts{ServiceName: "my-client"})
+		require.NoError(t, err, "NewServer failed")
 		defer clientCh.Close()
 
 		r.ch = clientCh

--- a/golang/hyperbahn/advertise_test.go
+++ b/golang/hyperbahn/advertise_test.go
@@ -42,6 +42,7 @@ func TestAdvertiseFailed(t *testing.T) {
 
 		client, err := NewClient(clientCh, configFor(hostPort), nil)
 		require.NoError(t, err, "NewClient")
+		defer client.Close()
 		assert.Error(t, client.Advertise(), "Advertise without handler should fail")
 	})
 }
@@ -109,6 +110,7 @@ func runRetryTest(t *testing.T, f func(r *retryTest)) {
 			FailStrategy: FailStrategyIgnore,
 		})
 		require.NoError(t, err, "NewClient")
+		defer r.client.Close()
 		f(r)
 		r.mock.AssertExpectations(t)
 	})

--- a/golang/hyperbahn/call.go
+++ b/golang/hyperbahn/call.go
@@ -21,9 +21,13 @@
 package hyperbahn
 
 import (
+	"errors"
+
 	"github.com/uber/tchannel/golang"
 	"github.com/uber/tchannel/golang/json"
 )
+
+var errEphemeralPeer = errors.New("cannot advertise on channel that has not called ListenAndServe")
 
 // The following parameters define the request/response for the Hyperbahn 'ad' call.
 type service struct {
@@ -55,6 +59,11 @@ func (c *Client) createRequest() *AdRequest {
 }
 
 func (c *Client) sendAdvertise() error {
+	// Cannot advertise from an ephemeral peer.
+	if c.tchan.PeerInfo().IsEphemeral() {
+		return errEphemeralPeer
+	}
+
 	ctx, cancel := json.NewContext(c.opts.Timeout)
 	defer cancel()
 


### PR DESCRIPTION
Calling Advertise on a channel that is not listening now causes an error - since advertising a host:port of 0.0.0.0:0 does not mean anything.

Also adds support for Closing hyperbahn clients so tests do not interfere with each other.

cc: @junchaowu 