### PR TITLE
go: Support for latest Apache Thrift (1.0.0-dev)

### DIFF
--- a/golang/thrift/thrift-gen/names.go
+++ b/golang/thrift/thrift-gen/names.go
@@ -65,12 +65,12 @@ func goName(name string) string {
 		name += "_a1"
 	}
 
-	name = camelCase(name)
+	name = camelCase(name, false /* publicName */)
 	return name
 }
 
 // camelCase takes a name with underscores such as my_arg and returns camelCase (e.g. myArg).
-func camelCase(name string) string {
+func camelCase(name string, publicName bool) string {
 	parts := strings.Split(name, "_")
 	for i := 1; i < len(parts); i++ {
 		name := parts[i]
@@ -102,16 +102,14 @@ func avoidThriftClash(name string) string {
 // goPublicName returns a go identifier that is exported.
 func goPublicName(name string) string {
 	// Public names cannot clash with goKeywords as they are all lowercase.
-	name = camelCase(name)
+	name = camelCase(name, false /* publicName */)
 	name = strings.ToUpper(name[0:1]) + name[1:]
 	return name
 }
 
 // goPublicFieldName returns the name of the field as used in a struct.
 func goPublicFieldName(name string) string {
-	name = camcelCase(name)
-	name = strings.ToUpper(name[0:1]) + name[1:]
-	return avoidThriftClash(name)
+	return avoidThriftClash(goPublicName(name))
 }
 
 var thriftToGo = map[string]string{

--- a/golang/thrift/thrift-gen/names.go
+++ b/golang/thrift/thrift-gen/names.go
@@ -109,7 +109,7 @@ func goPublicName(name string) string {
 
 // goPublicFieldName returns the name of the field as used in a struct.
 func goPublicFieldName(name string) string {
-	name = goName(name)
+	name = camcelCase(name)
 	name = strings.ToUpper(name[0:1]) + name[1:]
 	return avoidThriftClash(name)
 }

--- a/golang/thrift/thrift-gen/test_files/test1.thrift
+++ b/golang/thrift/thrift-gen/test_files/test1.thrift
@@ -5,7 +5,21 @@ struct FakeStruct {
 }
 
 service Fake {
-  void fAkE(1: string LoL_http_TEST_Name, 2: i32 func, 3: i32 pkg, 4: i64 user_id, 5: i64 id, 6: FakeStruct fakeStruct)
+  // Test initialisms in the method name (as well as name clashes).
+  void id_get()
+  void id()
+  void get_id()
+  void get_Id()
+  void get_ID()
+
+  // Test initialisms in parameter names.
+  void initialisms_in_args1(1: string LoL_http_TEST_Name)
+  void initialisms_in_args2(1: string user_id)
+  void initialisms_in_args3(1: string id)
+
+
+  // Test casing for method names
+  void fAkE(1: i32 func, 2: i32 pkg, 3: FakeStruct fakeStruct)
 
   void MyArgs()
   void MyResult()

--- a/golang/thrift/thrift-gen/test_files/test1.thrift
+++ b/golang/thrift/thrift-gen/test_files/test1.thrift
@@ -5,7 +5,7 @@ struct FakeStruct {
 }
 
 service Fake {
-  void fAkE(1: string LoL_http_TEST_Name, 2: i32 func, 3: i32 package, 4: i64 user_id, 5: i64 id, 6: FakeStruct fakeStruct)
+  void fAkE(1: string LoL_http_TEST_Name, 2: i32 func, 3: i32 pkg, 4: i64 user_id, 5: i64 id, 6: FakeStruct fakeStruct)
 
   void MyArgs()
   void MyResult()

--- a/golang/thrift/thrift-gen/wrap.go
+++ b/golang/thrift/thrift-gen/wrap.go
@@ -101,7 +101,7 @@ func (l byMethodName) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
 func (s *Service) Methods() []*Method {
 	var methods []*Method
 	for _, m := range s.Service.Methods {
-		methods = append(methods, &Method{m, s.state})
+		methods = append(methods, &Method{m, s, s.state})
 	}
 	sort.Sort(byMethodName(methods))
 	return methods
@@ -111,7 +111,8 @@ func (s *Service) Methods() []*Method {
 type Method struct {
 	*parser.Method
 
-	state *State
+	service *Service
+	state   *State
 }
 
 // ThriftName returns the thrift identifier for this function.
@@ -157,14 +158,18 @@ func (m *Method) HasExceptions() bool {
 	return len(m.Method.Exceptions) > 0
 }
 
+func (m *Method) argResPrefix() string {
+	return goPublicName(m.service.Name) + m.Name()
+}
+
 // ArgsType returns the Go name for the struct used to encode the method's arguments.
 func (m *Method) ArgsType() string {
-	return m.Name() + "Args"
+	return m.argResPrefix() + "Args"
 }
 
 // ResultType returns the Go name for the struct used to encode the method's result.
 func (m *Method) ResultType() string {
-	return m.Name() + "Result"
+	return m.argResPrefix() + "Result"
 }
 
 // ArgList returns the argument list for the function.


### PR DESCRIPTION
This change adds supported for code generated by the latest versions of Apache Thrift. The changes required are:
 - Prefix arg/res structs with service name as well as method name
 - Public field names are no longer suffixed when the field name clashes with a Go keyword.
 - Thrift compiler now fixes common initialisms (e.g. `Id` becomes `ID`)

The requires some bug fixes in the Apache Thrift compiler:
 - Proper initialism handling (https://github.com/apache/thrift/pull/625)
 - Use typedef type in lists instead of the underlying (or true) type: (https://github.com/prashantv/thrift/tree/list_fix)