### PR TITLE
Go service extends

### DIFF
--- a/golang/thrift/thrift-gen/test_files/service_extend.thrift
+++ b/golang/thrift/thrift-gen/test_files/service_extend.thrift
@@ -5,3 +5,7 @@ service S1 {
 service S2 extends S1 {
   void M2()
 }
+
+service S3 extends S2 {
+  void M3()
+}

--- a/golang/thrift/thrift-gen/test_files/service_extend.thrift
+++ b/golang/thrift/thrift-gen/test_files/service_extend.thrift
@@ -1,0 +1,7 @@
+service S1 {
+  void M1()
+}
+
+service S2 extends S1 {
+  void M2()
+}


### PR DESCRIPTION
Rather than copying methods, which fails to compile due to the wrong
Arg/Res struct name being used, embed the underlying service structs.

cc @cbradfield
