### PR TITLE
document rd transport header

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -634,6 +634,7 @@ valid or not in a call req or res.  Following sections will elaborate on details
 | `se`  | Y   | N   | Speculative Execution
 | `fd`  | Y   | Y   | Failure Domain
 | `sk`  | Y   | N   | Shard key
+| `xs`  | Y   | N   | Cross scope request
 
 ### Transport Header `as` -- Arg Scheme
 
@@ -726,6 +727,18 @@ tchannel instance.
 For example you may want to keep some in memory state, i.e. cache, aggregation.
 You can use read the `sk` and forward the call request to a specific process
 that has ownership for the shard key.
+
+### Transport Header `xs` -- Cross scope request
+
+The cross scope request header when set determines whether this request
+should be routed to the cross scope service.
+
+A scope is a prefix on the service name like `.us-east-1.prod.`.
+
+This header should be set for requests when you don't know which scope
+they belong to and the cross scope service should be able to decide
+where the requests should be routed to (i.e. which datacenter) and
+is responsible for routing it.
 
 ### A note on `host:port` header values
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -634,7 +634,7 @@ valid or not in a call req or res.  Following sections will elaborate on details
 | `se`  | Y   | N   | Speculative Execution
 | `fd`  | Y   | Y   | Failure Domain
 | `sk`  | Y   | N   | Shard key
-| `cr`  | Y   | N   | Custom Routing
+| `rd`  | Y   | N   | Routing Delegate 
 
 ### Transport Header `as` -- Arg Scheme
 
@@ -728,14 +728,14 @@ For example you may want to keep some in memory state, i.e. cache, aggregation.
 You can use read the `sk` and forward the call request to a specific process
 that has ownership for the shard key.
 
-### Transport Header `cr` -- Custom routing
+### Transport Header `rd` -- Routing Delegate
 
-The custom routing request header must be set to a valid service name.
+The Routing Delegate request header must be set to a valid service name.
 
-When the custom routing header is set we will route to the service name
-in the `cr` header instead of the service name in the call request.
+When the Routing Delegate header is set we will route to the service name
+in the `rd` header instead of the service name in the call request.
 
-It is expected that the service in the `cr` header is capable of
+It is expected that the service in the `rd` header is capable of
 routing the request to the correct end destination.
 
 ### A note on `host:port` header values

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -634,7 +634,7 @@ valid or not in a call req or res.  Following sections will elaborate on details
 | `se`  | Y   | N   | Speculative Execution
 | `fd`  | Y   | Y   | Failure Domain
 | `sk`  | Y   | N   | Shard key
-| `xs`  | Y   | N   | Cross scope request
+| `cr`  | Y   | N   | Custom Routing
 
 ### Transport Header `as` -- Arg Scheme
 
@@ -728,17 +728,15 @@ For example you may want to keep some in memory state, i.e. cache, aggregation.
 You can use read the `sk` and forward the call request to a specific process
 that has ownership for the shard key.
 
-### Transport Header `xs` -- Cross scope request
+### Transport Header `cr` -- Custom routing
 
-The cross scope request header when set determines whether this request
-should be routed to the cross scope service.
+The custom routing request header must be set to a valid service name.
 
-A scope is a prefix on the service name like `.us-east-1.prod.`.
+When the custom routing header is set we will route to the service name
+in the `cr` header instead of the service name in the call request.
 
-This header should be set for requests when you don't know which scope
-they belong to and the cross scope service should be able to decide
-where the requests should be routed to (i.e. which datacenter) and
-is responsible for routing it.
+It is expected that the service in the `cr` header is capable of
+routing the request to the correct end destination.
 
 ### A note on `host:port` header values
 


### PR DESCRIPTION
The `xs` header will be used to route to the cross datacenter service and resolve this request to the write datacenter so we can send requests to the write master.

cc @jcorbin @mranney @blampe 