### PR TITLE
document background messages

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -770,6 +770,10 @@ TTLs are not sent back with the response. It is up to the calling service to
 track the time spent with dependent requests and validate the incoming deadline
 before dispatching every new dependent request.
 
+An RPC message may be marked as backgrounded in the rpc library. For backgrounded
+messages we do not decrement or propagate the TTL. The TTL for all outgoing
+backgrounded messages is the specified timeout when the message is sent.
+
 ## Checksums
 
 Checksums are optional in order to ease implementations in different languages


### PR DESCRIPTION
In the TTL documentation we talk about decrementing and
propagating the TTL.

This feature is currently unimplemented in all languages
and even if implemented might have suprising behaviour
for anyone trying to make background / async requests.

It should be possible for you to implement a low latency
handler that returns an immediate response and then makes
a background request.

I've updated the protocol document to mention background
requests and how they do not have TTL propagation.

r: @jcorbin @prashantv @blampe
