### PR TITLE
Add arguments to health endpoint to determine source

### DIFF
--- a/idl/github.com/uber/tchannel/meta.thrift
+++ b/idl/github.com/uber/tchannel/meta.thrift
@@ -1,6 +1,23 @@
+enum State {
+    REFUSING = 0,
+    ACCEPTING = 1,
+    STOPPING = 2,
+    STOPPED = 3,
+}
+
+enum RequestType {
+    LEGACY = 0,
+    TRAFFIC = 1,
+}
+
+struct HealthRequest {
+    1: optional RequestType type
+}
+
 struct HealthStatus {
     1: required bool ok
     2: optional string message
+    3: optional State state
 }
 
 typedef string filename
@@ -22,7 +39,7 @@ struct VersionInfo {
 }
 
 service Meta {
-    HealthStatus health()
+    HealthStatus health(1: HealthRequest hr)
     ThriftIDLs thriftIDL()
     VersionInfo versionInfo()
 }

--- a/idl/github.com/uber/tchannel/meta.thrift
+++ b/idl/github.com/uber/tchannel/meta.thrift
@@ -1,23 +1,34 @@
-enum State {
+// The HealthState provides additional information when the
+// health endpoint returns !ok.
+enum HealthState {
     REFUSING = 0,
     ACCEPTING = 1,
     STOPPING = 2,
     STOPPED = 3,
 }
 
-enum RequestType {
-    LEGACY = 0,
+// The HealthRequestType is the type of health check, as a process may want to
+// return that it's running, but not ready for traffic.
+enum HealthRequestType {
+    // PROCESS indicates that the health check is for checking that
+    // the process is up. Handlers should always return "ok".
+    PROCESS = 0,
+
+    // TRAFFIC indicates that the health check is for checking whether
+    // the process wants to receive traffic. The process may want to reject
+    // traffic due to warmup, or before shutdown to avoid in-flight requests
+    // when the process exits.
     TRAFFIC = 1,
 }
 
 struct HealthRequest {
-    1: optional RequestType type
+    1: optional HealthRequestType type
 }
 
 struct HealthStatus {
     1: required bool ok
     2: optional string message
-    3: optional State state
+    3: optional HealthState state
 }
 
 typedef string filename

--- a/idl/github.com/uber/tchannel/meta.thrift
+++ b/idl/github.com/uber/tchannel/meta.thrift
@@ -50,7 +50,9 @@ struct VersionInfo {
 }
 
 service Meta {
+    // All arguments are optional. The default is a PROCESS health request.
     HealthStatus health(1: HealthRequest hr)
+
     ThriftIDLs thriftIDL()
     VersionInfo versionInfo()
 }


### PR DESCRIPTION
This matches the health endpoint we've defined internally in YARPC.

This change is backwards compatible since we're adding new optional
fields to the request and response.