### PR TITLE
Add java namespace to meta.thrift

### DIFF
--- a/idl/github.com/uber/tchannel/meta.thrift
+++ b/idl/github.com/uber/tchannel/meta.thrift
@@ -1,3 +1,5 @@
+namespace java com.uber.tchannel.meta
+
 // The HealthState provides additional information when the
 // health endpoint returns !ok.
 enum HealthState {


### PR DESCRIPTION
## Problem

The classes generated for this file in Java by thrift compiler are currently put in default package, making them unusable from any other Java package.

This also means that any other thrift files that `include` this one, but declare a `java namespace` will have their thrift compilation successful, error will only be surfaced by Java compiler when those thrift files are used in Java project making chain of updates very costly.

One example of a workaround is in [separate copy of this file](https://github.com/uber/tchannel-java/blob/771a42174896f6f6ca7fbb6e37a2c227cda3f3b5/tchannel-core/src/main/thrift/meta.thrift) in Java tchannel library.

## Backwards compatibility concerns

I don't expect this diff breaking anything because the generated files could only be referenced from default package and that is not a widely spread practice in Java to begin with. 
However, repos that commit generated files in the artifacts will have a lot of their code regenerated.